### PR TITLE
Add logics of dealing with ids uniquely both for source and target in _directed_graph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ line-length = 100
 [tool.ruff.lint]
 extend-ignore = [
     "C416",
+    "COM812",
     "DTZ001",
     "DTZ007",
     "FBT001",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -172,6 +172,18 @@ class TestGraphStructures(BaseGraphTest):
             if keep_geom:
                 assert "original_geometry" in dual_nodes.columns
 
+    def test_validate_nx_populates_pos_from_xy(self, sample_crs: str) -> None:
+        """validate_nx should auto-create pos from x/y when missing."""
+        G = nx.Graph()
+        G.add_node(1, x=0.0, y=0.0)
+        G.add_node(2, x=1.0, y=1.0)
+        G.add_edge(1, 2)
+        G.graph = {"crs": sample_crs, "is_hetero": False}
+
+        utils.GeoDataProcessor().validate_nx(G)
+        assert "pos" in G.nodes[1]
+        assert "pos" in G.nodes[2]
+
     @pytest.mark.parametrize(
         ("segments_fixture", "expect_empty", "multigraph"),
         [


### PR DESCRIPTION
## Description

Refactors `_directed_graph` to separately deal with node ids for source and target `gdf`.

**Refactoring node and edge identifier handling:**

* All relevant functions (`_prepare_nodes`, `_add_edges`, etc.) now support generic node IDs (`Any` type) instead of requiring integers. This allows for more flexible graph construction, especially when merging graphs from different sources. [[1]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1324-R1324) [[2]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1347-R1354) [[3]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1541-R1543) [[4]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1581-R1581) [[5]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1604-R1604)
* In `_directed_graph`, node IDs from different layers are disambiguated using tuple-based namespacing (e.g., `('src', id)` and `('dst', id)`), ensuring collision-free composition of graphs. Relabeling maps and provenance attributes are attached to enable proper reconstruction and tracking of original indices and node types. [[1]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1778-R1817) [[2]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R1827-R1855)

**Edge and geometry creation improvements:**

* The mapping from edge endpoints to indices is now more robust, with explicit error handling for missing endpoints. Geometry attributes are created using the updated edge lists and mappings, supporting the new identifier scheme. [[1]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1649-R1658) [[2]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1662-R1668)

**Testing and configuration:**

* A new test (`test_validate_nx_populates_pos_from_xy`) is added to verify that node positions (`pos`) are auto-created from `x` and `y` attributes when missing, improving graph validation reliability.
* The lint configuration is updated to extend ignored rules, improving code style consistency.

## Related Issues

[`[BUG] knn_graph with target_gdf misconnects when source/target indices overlap (node ID collisions) #30`](https://github.com/c2g-dev/city2graph/issues/30)

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
