### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests and Upload Coverage
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/c2g-dev/city2graph/security/code-scanning/2](https://github.com/c2g-dev/city2graph/security/code-scanning/2)

The best way to fix this is to add an explicit `permissions` block at the level of the workflow (above `jobs:`), setting permissions to the minimum required. For most testing and code coverage jobs that do not push changes or create PRs/issues, `contents: read` is sufficient. If the Codecov action requires additional permissions (e.g., to post PR comments), you may need to add `pull-requests: write`, but from the shown configuration, only coverage upload is performed, so `contents: read` suffices as a minimal starting point. You should edit `.github/workflows/test.yml`, inserting the block after the workflow name but before the `on:` block. No new imports, methods, or variable definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
