### PR TITLE
Add rustworkx support

### DIFF
--- a/docs/source/api/utils.rst
+++ b/docs/source/api/utils.rst
@@ -23,3 +23,7 @@ Utils
 .. autofunction:: create_tessellation
 
 .. autofunction:: create_isochrone
+
+.. autofunction:: nx_to_rx
+
+.. autofunction:: rx_to_nx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -201,6 +201,7 @@ intersphinx_mapping = {
 
     # Graph libraries
     "networkx": ("https://networkx.org/documentation/stable/", None),
+    "rustworkx": ("https://www.rustworkx.org/", None),
 
     # Deep learning and PyTorch ecosystem
     "torch": ("https://pytorch.org/docs/stable/", None),

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -95,6 +95,7 @@ city2graph requires the following packages:
 * libpysal
 * momepy
 * overturemaps
+* rustworkx
 
 For graph neural network functionality, you'll also need:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "libpysal >=4.12.1",
     "momepy",
     "overturemaps >=0.17.0",
+    "rustworkx >=0.17.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -424,6 +424,7 @@ dependencies = [
     { name = "networkx" },
     { name = "osmnx" },
     { name = "overturemaps" },
+    { name = "rustworkx" },
     { name = "shapely" },
 ]
 
@@ -506,6 +507,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=2.8" },
     { name = "osmnx", specifier = ">=2.0.3" },
     { name = "overturemaps", specifier = ">=0.17.0" },
+    { name = "rustworkx", specifier = ">=0.17.1" },
     { name = "shapely", specifier = ">=2.1.0" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cu118') or (sys_platform == 'win32' and extra == 'cu118')", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cu118", conflict = { package = "city2graph", extra = "cu118" } },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cu124') or (sys_platform == 'win32' and extra == 'cu124')", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cu124", conflict = { package = "city2graph", extra = "cu124" } },
@@ -3913,6 +3915,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/24/e3e72d265121e00b063aef3e3501e5b2473cf1b23511d56e529531acf01e/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:94c44ee01fd21c9058f124d2d4f0c9dc7634bec93cd4b38eefc385dabe71acbf", size = 560003, upload-time = "2025-08-27T12:16:08.06Z" },
     { url = "https://files.pythonhosted.org/packages/26/ca/f5a344c534214cc2d41118c0699fffbdc2c1bc7046f2a2b9609765ab9c92/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:df8b74962e35c9249425d90144e721eed198e6555a0e22a563d29fe4486b51f6", size = 590482, upload-time = "2025-08-27T12:16:10.137Z" },
     { url = "https://files.pythonhosted.org/packages/ce/08/4349bdd5c64d9d193c360aa9db89adeee6f6682ab8825dca0a3f535f434f/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:dc23e6820e3b40847e2f4a7726462ba0cf53089512abe9ee16318c366494c17a", size = 556523, upload-time = "2025-08-27T12:16:12.188Z" },
+]
+
+[[package]]
+name = "rustworkx"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/b0/66d96f02120f79eeed86b5c5be04029b6821155f31ed4907a4e9f1460671/rustworkx-0.17.1.tar.gz", hash = "sha256:59ea01b4e603daffa4e8827316c1641eef18ae9032f0b1b14aa0181687e3108e", size = 399407, upload-time = "2025-09-15T16:29:46.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/24/8972ed631fa05fdec05a7bb7f1fc0f8e78ee761ab37e8a93d1ed396ba060/rustworkx-0.17.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c08fb8db041db052da404839b064ebfb47dcce04ba9a3e2eb79d0c65ab011da4", size = 2257491, upload-time = "2025-08-13T01:43:31.466Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/7b6bbae5e0487ee42072dc6a46edf5db9731a0701ed648db22121fb7490c/rustworkx-0.17.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4ef8e327dadf6500edd76fedb83f6d888b9266c58bcdbffd5a40c33835c9dd26", size = 2040175, upload-time = "2025-08-13T01:43:33.762Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ea/c17fb9428c8f0dcc605596f9561627a5b9ef629d356204ee5088cfcf52c6/rustworkx-0.17.1-cp39-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b809e0aa2927c68574b196f993233e269980918101b0dd235289c4f3ddb2115", size = 2324771, upload-time = "2025-08-13T01:43:35.553Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/40/ec8b3b8b0f8c0b768690c454b8dcc2781b4f2c767f9f1215539c7909e35b/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7e82c46a92fb0fd478b7372e15ca524c287485fdecaed37b8bb68f4df2720f2", size = 2068584, upload-time = "2025-08-13T01:43:37.261Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/22/713b900d320d06ce8677e71bba0ec5df0037f1d83270bff5db3b271c10d7/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42170075d8a7319e89ff63062c2f1d1116ced37b6f044f3bf36d10b60a107aa4", size = 2380949, upload-time = "2025-08-13T01:52:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4b/54be84b3b41a19caf0718a2b6bb280dde98c8626c809c969f16aad17458f/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65cba97fa95470239e2d65eb4db1613f78e4396af9f790ff771b0e5476bfd887", size = 2562069, upload-time = "2025-08-13T02:09:27.222Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/281bb21d091ab4e36cf377088366d55d0875fa2347b3189c580ec62b44c7/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:246cc252053f89e36209535b9c58755960197e6ae08d48d3973760141c62ac95", size = 2221186, upload-time = "2025-08-13T01:43:38.598Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2d/30a941a21b81e9db50c4c3ef8a64c5ee1c8eea3a90506ca0326ce39d021f/rustworkx-0.17.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c10d25e9f0e87d6a273d1ea390b636b4fb3fede2094bf0cb3fe565d696a91b48", size = 2123510, upload-time = "2025-08-13T01:43:40.288Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ef/c9199e4b6336ee5a9f1979c11b5779c5cf9ab6f8386e0b9a96c8ffba7009/rustworkx-0.17.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:48784a673cf8d04f3cd246fa6b53fd1ccc4d83304503463bd561c153517bccc1", size = 2302783, upload-time = "2025-08-13T01:43:42.073Z" },
+    { url = "https://files.pythonhosted.org/packages/30/3d/a49ab633e99fca4ccbb9c9f4bd41904186c175ebc25c530435529f71c480/rustworkx-0.17.1-cp39-abi3-win32.whl", hash = "sha256:5dbc567833ff0a8ad4580a4fe4bde92c186d36b4c45fca755fb1792e4fafe9b5", size = 1931541, upload-time = "2025-08-13T01:43:43.415Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/cee878c1879b91ab8dc7d564535d011307839a2fea79d2a650413edf53be/rustworkx-0.17.1-cp39-abi3-win_amd64.whl", hash = "sha256:d0a48fb62adabd549f9f02927c3a159b51bf654c7388a12fc16d45452d5703ea", size = 2055049, upload-time = "2025-08-13T01:43:44.926Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Added conversion support into rustworkx objects.

**Graph Conversion Utilities:**

* Added `nx_to_rx` and `rx_to_nx` functions in `city2graph/utils.py` to enable bidirectional conversion between NetworkX and rustworkx graphs, preserving node, edge, and graph attributes, and supporting multi-graphs and directed graphs. [[1]](diffhunk://#diff-dfeb28fcd09751d4e337bde358990829b6aa0d1950067713c72297bc72b449e7R32-R33) [[2]](diffhunk://#diff-dfeb28fcd09751d4e337bde358990829b6aa0d1950067713c72297bc72b449e7R3036-R3189)
* Updated the docstring for the `gdf_to_nx` function to clarify the expected type for the `edges` parameter.

**Testing:**

* Introduced a new test class `TestRustworkxConversions` in `tests/test_utils.py` to verify roundtrip conversion between NetworkX and rustworkx, and to test edge cases such as raw payloads and non-dict edge data.

**Documentation:**

* Added references to the new conversion functions in the API documentation (`docs/source/api/utils.rst`) and included rustworkx in the intersphinx mapping (`docs/source/conf.py`). [[1]](diffhunk://#diff-34f2b4668b8c23c60110ea447cfef0686cbd10f1810c0b65548a44fef00cf4f4R26-R29) [[2]](diffhunk://#diff-008dcb3426febd767787b1521f1fe33086313b927ea37eaab86df5fa88a51698R204)
* Updated the installation instructions to list rustworkx as a required dependency.

**Dependencies:**

* Added `rustworkx >=0.17.1` as a required dependency in `pyproject.toml`.

**Imports:**

* Updated imports in `city2graph/utils.py` and `tests/test_utils.py` to include rustworkx. [[1]](diffhunk://#diff-dfeb28fcd09751d4e337bde358990829b6aa0d1950067713c72297bc72b449e7R20) [[2]](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33R9-R15)

These changes ensure seamless interoperability between NetworkX and rustworkx graphs within the codebase and provide thorough documentation and testing for the new functionality.

## Related Issues

#48 

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
