### PR TITLE
Add `add_metapaths_by_weights`

### DIFF
--- a/docs/source/api/graph.rst
+++ b/docs/source/api/graph.rst
@@ -20,4 +20,4 @@ Graph
 
 .. autofunction:: add_metapaths
 
-.. autofunction:: filter_edges_by_weight
+.. autofunction:: add_metapaths_by_weight

--- a/docs/source/api/graph.rst
+++ b/docs/source/api/graph.rst
@@ -19,3 +19,5 @@ Graph
 .. autofunction:: validate_pyg
 
 .. autofunction:: add_metapaths
+
+.. autofunction:: filter_edges_by_weight

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "momepy",
     "overturemaps >=0.17.0",
     "rustworkx >=0.17.1",
+    "scipy >=1.10.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -5,6 +5,7 @@ repeated patterns via parametrization, while preserving coverage.
 """
 
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import cast
 
 import geopandas as gpd
@@ -657,8 +658,14 @@ class TestODMatrixToGraph:
     def test_adjacency_wrong_type_raises(self, od_zones_gdf: gpd.GeoDataFrame) -> None:
         """Passing an unsupported type for adjacency matrix raises TypeError."""
         bad = [[0, 1, 0], [0, 0, 0], [0, 0, 0]]  # list, not DataFrame/ndarray
+        bad_input: Any = bad
         try:
-            od_matrix_to_graph(bad, od_zones_gdf, zone_id_col="zone_id", matrix_type="adjacency")  # type: ignore[arg-type]
+            od_matrix_to_graph(
+                bad_input,
+                od_zones_gdf,
+                zone_id_col="zone_id",
+                matrix_type="adjacency",
+            )
         except TypeError:
             pass
         else:

--- a/uv.lock
+++ b/uv.lock
@@ -425,6 +425,7 @@ dependencies = [
     { name = "osmnx" },
     { name = "overturemaps" },
     { name = "rustworkx" },
+    { name = "scipy" },
     { name = "shapely" },
 ]
 
@@ -508,6 +509,7 @@ requires-dist = [
     { name = "osmnx", specifier = ">=2.0.3" },
     { name = "overturemaps", specifier = ">=0.17.0" },
     { name = "rustworkx", specifier = ">=0.17.1" },
+    { name = "scipy", specifier = ">=1.10.0" },
     { name = "shapely", specifier = ">=2.1.0" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cu118') or (sys_platform == 'win32' and extra == 'cu118')", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cu118", conflict = { package = "city2graph", extra = "cu118" } },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cu124') or (sys_platform == 'win32' and extra == 'cu124')", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cu124", conflict = { package = "city2graph", extra = "cu124" } },


### PR DESCRIPTION
## Description

Add a new feature for weighted metapath generation in graphs, adds comprehensive tests for this functionality, and makes a minor dependency update. The main focus is the addition of the `add_metapaths_by_weight` function, which enables connecting nodes based on weighted edge paths and thresholding, along with extensive tests to ensure its correctness and flexibility.

**Weighted Metapath Generation:**
* Added the `add_metapaths_by_weight` function to the codebase and documented it in the API reference. [[1]](diffhunk://#diff-0b10a4ca82e92505c5628ba226dd6ac339a75f4b7fa52bedbe2e6eaa94f2634aR22-R23) [[2]](diffhunk://#diff-e9352f44736d5b9e922852f07917f4d93bb6d4ca2e6d9743abf20194a5c414d5R51)

**Testing and Validation:**
* Introduced a comprehensive test suite for `add_metapaths_by_weight`, including fixtures for sample weighted graphs, tests for thresholding, custom edge types, edge filtering, NetworkX I/O, and handling of missing endpoints. [[1]](diffhunk://#diff-e9352f44736d5b9e922852f07917f4d93bb6d4ca2e6d9743abf20194a5c414d5R704-R795) [[2]](diffhunk://#diff-e9352f44736d5b9e922852f07917f4d93bb6d4ca2e6d9743abf20194a5c414d5R1259-R1392)

**Dependency Management:**
* Added `scipy >=1.10.0` to the project dependencies, likely to support new weighted graph operations.

**General Test Improvements:**
* Improved type safety in mobility tests by introducing a typed variable for intentionally incorrect input. [[1]](diffhunk://#diff-bdb1a43e27ea3d6e560d7542056f06f76cfad7102a79901aef7af01bef31a564R8) [[2]](diffhunk://#diff-bdb1a43e27ea3d6e560d7542056f06f76cfad7102a79901aef7af01bef31a564R661-R668)

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
