### PR TITLE
Fix docstrings of functions

### DIFF
--- a/city2graph/graph.py
+++ b/city2graph/graph.py
@@ -2065,8 +2065,8 @@ def validate_pyg(data: Data | HeteroData) -> GraphMetadata:
 
     Examples
     --------
-    >>> data = create_homogeneous_graph(nodes_gdf)
-    >>> metadata = _validate_pyg_data(data)
+    >>> data = gdf_to_pyg(nodes_gdf, edges_gdf)
+    >>> metadata = validate_pyg(data)
     """
     # Check PyTorch availability first
     if not TORCH_AVAILABLE:
@@ -2147,8 +2147,8 @@ def _validate_hetero_structure(data: HeteroData, metadata: GraphMetadata) -> Non
 
     Examples
     --------
-    >>> data = create_heterogeneous_graph(nodes_dict)
-    >>> metadata = data._metadata
+    >>> data = gdf_to_pyg(nodes_dict, edges_dict)
+    >>> metadata = data.graph_metadata
     >>> _validate_hetero_structure(data, metadata)
     """
     # Check that node types in metadata match actual node types in data
@@ -2224,8 +2224,8 @@ def _validate_homo_structure(data: Data, metadata: GraphMetadata) -> None:
 
     Examples
     --------
-    >>> data = create_homogeneous_graph(nodes_gdf)
-    >>> metadata = data._metadata
+    >>> data = gdf_to_pyg(nodes_gdf, edges_gdf)
+    >>> metadata = data.graph_metadata
     >>> _validate_homo_structure(data, metadata)
     """
     # Validate that metadata has the expected structure for homogeneous graphs
@@ -2355,8 +2355,8 @@ def add_metapaths_by_weight(
     edge_types: list[tuple[str, str, str]] | None = None,
     endpoint_type: str | None = None,
     directed: bool = False,
-    as_nx: bool = False,
     multigraph: bool = False,
+    as_nx: bool = False,
 ) -> (
     nx.Graph
     | nx.MultiGraph
@@ -2393,10 +2393,10 @@ def add_metapaths_by_weight(
         is not a tuple.
     directed : bool, default False
         If True, creates a directed graph for traversal.
-    as_nx : bool, default False
-        If True, returns a NetworkX graph.
     multigraph : bool, default False
         If True, returns a MultiGraph (only relevant if as_nx=True).
+    as_nx : bool, default False
+        If True, returns a NetworkX graph.
 
     Returns
     -------
@@ -3012,8 +3012,8 @@ def add_metapaths(
     edge_attr_agg: str | object | None = "sum",
     directed: bool = False,
     trace_path: bool = False,
-    as_nx: bool = False,
     multigraph: bool = False,
+    as_nx: bool = False,
     **_: object,
 ) -> (
     nx.Graph
@@ -3050,10 +3050,10 @@ def add_metapaths(
     trace_path : bool, optional
         When ``True``, attempt to create traced geometries. Currently ignored but
         retained for API compatibility.
-    as_nx : bool, optional
-        Return the result as a NetworkX graph when ``True``.
     multigraph : bool, optional
         When returning NetworkX data, build a ``networkx.MultiGraph`` if ``True``.
+    as_nx : bool, optional
+        Return the result as a NetworkX graph when ``True``.
     **_ : object
         Ignored placeholder for future keyword extensions.
 

--- a/city2graph/graph.py
+++ b/city2graph/graph.py
@@ -1706,16 +1706,13 @@ def pyg_to_gdf(
 
     Returns
     -------
-    tuple
-        **For HeteroData input:** Returns a tuple containing:
-            - First element: dict[str, geopandas.GeoDataFrame] mapping node type names to
-              GeoDataFrames
-            - Second element: dict[tuple[str, str, str], geopandas.GeoDataFrame] mapping
-              edge types to GeoDataFrames
-
+    tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]]
         **For Data input:** Returns a tuple containing:
-            - First element: geopandas.GeoDataFrame containing nodes
-            - Second element: geopandas.GeoDataFrame containing edges (or None if no edges)
+            - First element: GeoDataFrame containing nodes
+            - Second element: GeoDataFrame containing edges (or None if no edges)
+        **For HeteroData input:** Returns a tuple containing:
+            - First element: dict mapping node type names to GeoDataFrames
+            - Second element: dict mapping edge types to GeoDataFrames
 
     See Also
     --------
@@ -1774,7 +1771,7 @@ def pyg_to_nx(data: Data | HeteroData, keep_geom: bool = True) -> nx.Graph:
     Returns
     -------
     networkx.Graph
-        NetworkX graph with node and edge attributes from the PyG object.
+        The converted NetworkX graph with node and edge attributes.
         For heterogeneous graphs, node and edge types are stored as attributes.
 
     Raises
@@ -3059,14 +3056,15 @@ def add_metapaths(
 
     Returns
     -------
-    tuple[dict[str, GeoDataFrame], dict[tuple[str, str, str], GeoDataFrame]] | networkx.Graph | networkx.MultiGraph
-        Updated heterogeneous dictionaries or a NetworkX graph with metapath
-        edges appended.
+    tuple[dict[str, geopandas.GeoDataFrame], dict[tuple[str, str, str], geopandas.GeoDataFrame]] | networkx.Graph | networkx.MultiGraph
+        The graph with metapath-derived edges.
+        If as_nx is False (default), returns a tuple of node and edge GeoDataFrames.
+        If as_nx is True, returns a NetworkX graph (Graph or MultiGraph).
 
     Notes
     -----
     Legacy scaffolding for path-tracing geometries has been removed because it
-    was never executed. The ``trace_path`` argument is preserved for API
+    was never executed. The trace_path argument is preserved for API
     compatibility but remains a no-op while straight-line geometries are
     generated for all metapath edges.
     """

--- a/city2graph/mobility.py
+++ b/city2graph/mobility.py
@@ -120,17 +120,15 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
 
     Returns
     -------
-    tuple of (geopandas.GeoDataFrame, geopandas.GeoDataFrame)
-        The nodes and edges GeoDataFrames. The nodes GeoDataFrame index is
-        aligned with the zone identifier (``zone_id_col`` when provided, else
-        the original ``zones_gdf.index``). The edges GeoDataFrame uses a
-        pandas MultiIndex on (source_id, target_id) and does not carry
-        separate 'source'/'target' columns, to comply with gdf_to_nx/gdf_to_pyg.
-    networkx.DiGraph
-        When ``as_nx=True``, a directed graph with node and edge attributes.
-    networkx.Graph
-        When ``as_nx=True`` and ``directed=False``, an undirected graph with
-        node and edge attributes.
+    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame] or networkx.Graph or networkx.DiGraph
+        The graph representation in the requested format:
+
+        *   When ``as_nx=False`` (default): Returns a tuple ``(nodes, edges)`` of
+            GeoDataFrames. The nodes GeoDataFrame index is aligned with the zone
+            identifier. The edges GeoDataFrame uses a pandas MultiIndex on
+            (source_id, target_id).
+        *   When ``as_nx=True``: Returns a NetworkX graph. A ``networkx.DiGraph``
+            is returned if ``directed=True``, otherwise a ``networkx.Graph``.
     """
     # --- Validation (Task 2) ------------------------------------------------
     _validate_zones_gdf(zones_gdf, zone_id_col)

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -120,9 +120,17 @@ def morphological_graph(
     Returns
     -------
     tuple[dict[str, geopandas.GeoDataFrame], dict[tuple[str, str, str], geopandas.GeoDataFrame]] | networkx.Graph
-        A tuple containing:
-        - nodes: Dictionary with keys "private" and "public" containing node GeoDataFrames
-        - edges: Dictionary with relationship type keys containing edge GeoDataFrames
+        If as_nx is False (default), returns a tuple (nodes, edges) where:
+
+        - nodes: Dictionary containing node GeoDataFrames with keys:
+            - "private": Tessellation cells (private spaces)
+            - "public": Street segments (public spaces)
+
+        - edges: Dictionary containing edge GeoDataFrames with keys:
+            - ("private", "touched_to", "private"): Adjacency between tessellation cells
+            - ("public", "connected_to", "public"): Connectivity between street segments
+            - ("private", "faced_to", "public"): Interface between tessellation cells and street segments
+
         If as_nx is True, returns a NetworkX graph.
 
     Raises
@@ -253,11 +261,13 @@ def private_to_private_graph(
 
     Returns
     -------
-    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame] | networkx.Graph
-        A tuple containing:
-        - Nodes of the private graph (the input private_gdf).
-        - Edges of the private graph (adjacency connections).
-        If as_nx is True, returns a NetworkX graph.
+    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame] or networkx.Graph
+        If as_nx is False (default), returns a tuple (nodes, edges) where:
+
+        - nodes is a geopandas.GeoDataFrame containing the private nodes.
+        - edges is a geopandas.GeoDataFrame containing the adjacency connections.
+
+        If as_nx is True, returns a networkx.Graph representing the private adjacency.
 
     Raises
     ------
@@ -396,11 +406,13 @@ def private_to_public_graph(
 
     Returns
     -------
-    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame] | networkx.Graph
-        A tuple containing:
-        - Nodes of the private and public graphs (the input private_gdf and public_gdf).
-        - Edges of the private-public graph (connections between private polygons and public geometries).
-        If as_nx is True, returns a NetworkX graph.
+    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame] or networkx.Graph
+        If as_nx is False (default), returns a tuple (nodes, edges) where:
+
+        - nodes is a geopandas.GeoDataFrame containing the combined private and public nodes.
+        - edges is a geopandas.GeoDataFrame containing the edges between private and public geometries.
+
+        If as_nx is True, returns a networkx.Graph representing the private-to-public connections.
 
     Raises
     ------
@@ -523,11 +535,13 @@ def public_to_public_graph(
 
     Returns
     -------
-    tuple[geopandas.GeoDataFrame, gpd.GeoDataFrame] | networkx.Graph
-        A tuple containing:
-        - Nodes of the public graph (the input public_gdf).
-        - Edges of the public graph (connectivity).
-        If as_nx is True, returns a NetworkX graph.
+    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame] or networkx.Graph
+        If as_nx is False (default), returns a tuple (nodes, edges) where:
+
+        - nodes is a geopandas.GeoDataFrame containing the public nodes.
+        - edges is a geopandas.GeoDataFrame containing the topological connections.
+
+        If as_nx is True, returns a networkx.Graph representing the public connectivity.
 
     Raises
     ------

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -1434,8 +1434,8 @@ def bridge_nodes(
               Distance metric ("euclidean", "manhattan", "network")
             - network_gdf : geopandas.GeoDataFrame, optional
               Network for "network" distance calculations
-                        - network_weight : str, optional
-                            Edge attribute used as shortest-path weight when ``distance_metric='network'``
+            - network_weight : str, optional
+                Edge attribute used as shortest-path weight when ``distance_metric='network'``
 
         For `proximity_method="fixed_radius"`:
             - radius : float, required
@@ -1444,8 +1444,8 @@ def bridge_nodes(
               Distance metric ("euclidean", "manhattan", "network")
             - network_gdf : geopandas.GeoDataFrame, optional
               Network for "network" distance calculations
-                        - network_weight : str, optional
-                            Edge attribute used as shortest-path weight when ``distance_metric='network'``
+            - network_weight : str, optional
+                Edge attribute used as shortest-path weight when ``distance_metric='network'``
 
     Returns
     -------

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -1383,10 +1383,10 @@ def bridge_nodes(
     nodes_dict: dict[str, gpd.GeoDataFrame],
     proximity_method: str = "knn",
     *,
-    multigraph: bool = False,
-    as_nx: bool = False,
     source_node_types: Iterable[str] | None = None,
     target_node_types: Iterable[str] | None = None,
+    multigraph: bool = False,
+    as_nx: bool = False,
     **kwargs: float | str | bool,
 ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]] | nx.Graph:
     r"""
@@ -1412,18 +1412,18 @@ def bridge_nodes(
         The method to use for generating proximity edges between layers. Options are:
         - "knn": k-nearest neighbors method
         - "fixed_radius": fixed-radius method
-    multigraph : bool, default False
-        If True, the resulting NetworkX graph will be a MultiGraph, allowing
-        multiple edges between the same pair of nodes from different proximity relationships.
-    as_nx : bool, default False
-        If True, returns a NetworkX graph object containing all nodes and
-        inter-layer edges. Otherwise, returns dictionaries of GeoDataFrames.
     source_node_types : Iterable[str], optional
         Node types from ``nodes_dict`` that should act as sources. When None, all
         node types are considered sources.
     target_node_types : Iterable[str], optional
         Node types from ``nodes_dict`` that should act as targets. When None, all
         node types are considered targets.
+    multigraph : bool, default False
+        If True, the resulting NetworkX graph will be a MultiGraph, allowing
+        multiple edges between the same pair of nodes from different proximity relationships.
+    as_nx : bool, default False
+        If True, returns a NetworkX graph object containing all nodes and
+        inter-layer edges. Otherwise, returns dictionaries of GeoDataFrames.
     **kwargs : Any
         Additional keyword arguments passed to the underlying proximity method:
 

--- a/city2graph/transportation.py
+++ b/city2graph/transportation.py
@@ -476,7 +476,7 @@ def load_gtfs(path: str | Path) -> dict[str, pd.DataFrame | gpd.GeoDataFrame]:
 
     Returns
     -------
-    dict[str, pd.DataFrame | gpd.GeoDataFrame]
+    dict[str, pandas.DataFrame or geopandas.GeoDataFrame]
         Keys are the original GTFS file names (without extension) and values
         are pandas or GeoPandas DataFrames ready for analysis.
 

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -2260,9 +2260,9 @@ def nx_to_gdf(
     edges : bool, default True
         If True, a GeoDataFrame for edges will be created and returned.
     set_missing_pos_from : tuple[str, ...] | None, default ("x", "y")
-            If provided (or None implies ("x", "y")) set missing node 'pos' from
-            the given attribute name(s). With two names use them as x/y; with one
-            name expect a 2-length coordinate.
+        If provided (or None implies ("x", "y")) set missing node 'pos' from
+        the given attribute name(s). With two names use them as x/y; with one
+        name expect a 2-length coordinate.
 
     Returns
     -------
@@ -2499,9 +2499,10 @@ def create_isochrone(
         'travel_time'). If None, the function will use the default edge attribute.
     cut_edge_types : list[tuple[str, str, str]] | None, default None
         List of edge types to remove from the graph before processing (e.g.,
-        [("highway", "motorway", "motorway")]).
+        [("bus_stop", "is_next_to", "bus_stop")]).
     method : str, default "concave_hull_knn"
         The method to generate the isochrone polygon. Options are:
+
         - "concave_hull_knn": Creates a concave hull (k-NN) around reachable nodes.
         - "concave_hull_alpha": Creates a concave hull (alpha shape) around reachable nodes.
         - "convex_hull": Creates a convex hull around reachable nodes.
@@ -2509,28 +2510,25 @@ def create_isochrone(
     **kwargs : Any
         Additional parameters for specific isochrone generation methods:
 
-        Method: "concave_hull_knn"
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        k : int, default 100
-            The number of nearest neighbors to consider.
+        For method="concave_hull_knn":
+            k : int, default 100
+                The number of nearest neighbors to consider.
 
-        Method: "concave_hull_alpha"
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        hull_ratio : float, default 0.3
-            The ratio for concave hull generation (0.0 to 1.0). Higher values mean tighter fit.
-        allow_holes : bool, default False
-            Whether to allow holes in the concave hull.
+        For method="concave_hull_alpha":
+            hull_ratio : float, default 0.3
+                The ratio for concave hull generation (0.0 to 1.0). Higher values mean tighter fit.
+            allow_holes : bool, default False
+                Whether to allow holes in the concave hull.
 
-        Method: "buffer"
-        ~~~~~~~~~~~~~~~~
-        buffer_distance : float, default 100
-            The distance to buffer reachable geometries.
-        cap_style : int, default 1
-            The cap style for buffering. 1=Round, 2=Flat, 3=Square.
-        join_style : int, default 1
-            The join style for buffering. 1=Round, 2=Mitre, 3=Bevel.
-        resolution : int, default 16
-            The resolution of the buffer (number of segments per quarter circle).
+        For method="buffer":
+            buffer_distance : float, default 100
+                The distance to buffer reachable geometries.
+            cap_style : int, default 1
+                The cap style for buffering. 1=Round, 2=Flat, 3=Square.
+            join_style : int, default 1
+                The join style for buffering. 1=Round, 2=Mitre, 3=Bevel.
+            resolution : int, default 16
+                The resolution of the buffer (number of segments per quarter circle).
 
     Returns
     -------
@@ -3677,10 +3675,9 @@ def validate_gdf(
 
     Returns
     -------
-    tuple[geopandas.GeoDataFrame | dict[str, geopandas.GeoDataFrame] | None,
-          geopandas.GeoDataFrame | dict[tuple[str, str, str], geopandas.GeoDataFrame] | None,
-          bool]
+    tuple
         A tuple containing:
+
         - validated nodes_gdf (same type as input)
         - validated edges_gdf (same type as input)
         - is_hetero: boolean indicating if this is a heterogeneous graph

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -3856,10 +3856,6 @@ def nx_to_rx(graph: nx.Graph | nx.MultiGraph) -> rx.PyGraph | rx.PyDiGraph:
 
     Examples
     --------
-    >>> import networkx as nx
-    >>> G = nx.Graph()
-    >>> G.add_node("a", color="red")
-    >>> G.add_edge("a", "b", weight=2)
     >>> rx_G = nx_to_rx(G)
     """
     is_directed = graph.is_directed()

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -1683,9 +1683,9 @@ def dual_graph(
     graph: tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph | nx.MultiGraph,
     edge_id_col: str | None = None,
     keep_original_geom: bool = False,
-    as_nx: bool = False,
     source_col: str | None = None,
     target_col: str | None = None,
+    as_nx: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph | nx.MultiGraph:
     """
     Convert a primal graph represented by nodes and edges GeoDataFrames to its dual graph.
@@ -1704,14 +1704,14 @@ def dual_graph(
     keep_original_geom : bool, default False
         If True, preserve the original geometry of the edges in a new column named
         'original_geometry' in the dual nodes GeoDataFrame.
-    as_nx : bool, default False
-        If True, return the dual graph as a NetworkX graph instead of GeoDataFrames.
     source_col : str, optional
         Name of the column or index level representing the source node ID in the edges GeoDataFrame.
         If provided, it overrides automatic detection.
     target_col : str, optional
         Name of the column or index level representing the target node ID in the edges GeoDataFrame.
         If provided, it overrides automatic detection.
+    as_nx : bool, default False
+        If True, return the dual graph as a NetworkX graph instead of GeoDataFrames.
 
     Returns
     -------

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -166,10 +166,26 @@ class NxConverter(BaseGraphConverter):
 
         Returns
         -------
-        tuple
-            A tuple containing the reconstructed GeoDataFrames. For homogeneous graphs,
-            it's `(nodes_gdf, edges_gdf)`. For heterogeneous graphs, it's
-            `(nodes_dict, edges_dict)`.
+        geopandas.GeoDataFrame or tuple
+            The reconstructed GeoDataFrames. The return type depends on the graph structure
+            (homogeneous vs heterogeneous) and the requested components (`nodes`, `edges`).
+
+            **Homogeneous Graphs:**
+
+            *   If ``nodes=True`` and ``edges=True``: Returns ``(nodes_gdf, edges_gdf)``
+                where both are :class:`geopandas.GeoDataFrame`.
+            *   If only ``nodes=True``: Returns ``nodes_gdf`` (:class:`geopandas.GeoDataFrame`).
+            *   If only ``edges=True``: Returns ``edges_gdf`` (:class:`geopandas.GeoDataFrame`).
+
+            **Heterogeneous Graphs:**
+
+            *   Returns ``(nodes_dict, edges_dict)`` where:
+
+                *   ``nodes_dict`` is ``dict[str, geopandas.GeoDataFrame]`` mapping node types to GeoDataFrames.
+                *   ``edges_dict`` is ``dict[tuple[str, str, str], geopandas.GeoDataFrame]`` mapping edge types to GeoDataFrames.
+
+            Note: For heterogeneous graphs, the return value is always a tuple of dictionaries,
+            even if only one component is requested (the other will be an empty dict).
 
         See Also
         --------
@@ -2267,13 +2283,25 @@ def nx_to_gdf(
     Returns
     -------
     geopandas.GeoDataFrame or tuple
-        The returned type depends on the graph type and input parameters:
-        - Homogeneous graph:
-            - `(nodes_gdf, edges_gdf)` if `nodes` and `edges` are True.
-            - `nodes_gdf` if only `nodes` is True.
-            - `edges_gdf` if only `edges` is True.
-        - Heterogeneous graph:
-            - `(nodes_dict, edges_dict)` where dicts map types to GeoDataFrames.
+        The reconstructed GeoDataFrames. The return type depends on the graph structure
+        (homogeneous vs heterogeneous) and the requested components (`nodes`, `edges`).
+
+        **Homogeneous Graphs:**
+
+        *   If nodes=True and edges=True: Returns (nodes_gdf, edges_gdf)
+            where both are geopandas.GeoDataFrame.
+        *   If only nodes=True: Returns nodes_gdf (geopandas.GeoDataFrame).
+        *   If only edges=True: Returns edges_gdf (geopandas.GeoDataFrame).
+
+        **Heterogeneous Graphs:**
+
+        *   Returns (nodes_dict, edges_dict) where:
+
+            *   nodes_dict is dict[str, geopandas.GeoDataFrame] mapping node types to GeoDataFrames.
+            *   edges_dict is dict[tuple[str, str, str], geopandas.GeoDataFrame] mapping edge types to GeoDataFrames.
+
+        Note: For heterogeneous graphs, the return value is always a tuple of dictionaries,
+        even if only one component is requested (the other will be an empty dict).
 
     Raises
     ------
@@ -3795,6 +3823,11 @@ def validate_nx(graph: nx.Graph | nx.MultiGraph) -> None:
     graph : networkx.Graph or networkx.MultiGraph
         The NetworkX graph to validate.
 
+    Returns
+    -------
+    None
+        This function does not return a value.
+
     Raises
     ------
     TypeError
@@ -3836,9 +3869,7 @@ def nx_to_rx(graph: nx.Graph | nx.MultiGraph) -> rx.PyGraph | rx.PyDiGraph:
 
     This function converts a NetworkX graph object into a rustworkx graph object,
     preserving node, edge, and graph attributes. It handles both directed and
-    undirected graphs, as well as multigraphs. The original NetworkX node IDs
-    are stored in the node payload under the key ``__nx_node_id__`` to ensure
-    reversibility.
+    undirected graphs, as well as multigraphs.
 
     Parameters
     ----------
@@ -3906,9 +3937,7 @@ def rx_to_nx(graph: rx.PyGraph | rx.PyDiGraph) -> nx.Graph | nx.MultiGraph:
     Convert a rustworkx graph to a NetworkX graph.
 
     This function converts a rustworkx graph object into a NetworkX graph object,
-    restoring node, edge, and graph attributes. It attempts to restore original
-    NetworkX node IDs if they were preserved during a previous conversion using
-    ``nx_to_rx`` (via the ``__nx_node_id__`` key).
+    restoring node, edge, and graph attributes.
 
     Parameters
     ----------
@@ -4090,6 +4119,11 @@ def plot_graph(  # noqa: PLR0913
         - **pd.Series**: Direct values for each geometry
 
         Other common options: etc.
+
+    Returns
+    -------
+    None
+        This function does not return a value.
 
     Raises
     ------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,13 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../.."))
 
+import pypandoc
+
+# Configure nbsphinx to use the pandoc binary from pypandoc
+nbsphinx_pandoc_path = pypandoc.get_pandoc_path()
+# Also add to PATH as fallback
+os.environ["PATH"] = os.path.dirname(nbsphinx_pandoc_path) + os.pathsep + os.environ["PATH"]
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ docs = [
     "sphinx-plotly-directive",
     "sphinx-sitemap",
     "toml",
-    "pandoc",
+    "pypandoc-binary",
     "overturemaps"
 ]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -490,8 +490,8 @@ docs = [
     { name = "nbsphinx" },
     { name = "numpydoc" },
     { name = "overturemaps" },
-    { name = "pandoc" },
     { name = "pydata-sphinx-theme" },
+    { name = "pypandoc-binary" },
     { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-plotly-directive" },
@@ -558,8 +558,8 @@ docs = [
     { name = "nbsphinx" },
     { name = "numpydoc" },
     { name = "overturemaps" },
-    { name = "pandoc" },
     { name = "pydata-sphinx-theme" },
+    { name = "pypandoc-binary" },
     { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-plotly-directive" },
@@ -3112,16 +3112,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pandoc"
-version = "2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "plumbum" },
-    { name = "ply" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/9a/e3186e760c57ee5f1c27ea5cea577a0ff9abfca51eefcb4d9a4cd39aff2e/pandoc-2.4.tar.gz", hash = "sha256:ecd1f8cbb7f4180c6b5db4a17a7c1a74df519995f5f186ef81ce72a9cbd0dd9a", size = 34635, upload-time = "2024-08-07T14:33:58.016Z" }
-
-[[package]]
 name = "pandocfilters"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3251,27 +3241,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "plumbum"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu118') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu124') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu126') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu128') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu130') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu118' and extra == 'extra-10-city2graph-cu124') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu118' and extra == 'extra-10-city2graph-cu126') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu118' and extra == 'extra-10-city2graph-cu128') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu118' and extra == 'extra-10-city2graph-cu130') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu124' and extra == 'extra-10-city2graph-cu126') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu124' and extra == 'extra-10-city2graph-cu128') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu124' and extra == 'extra-10-city2graph-cu130') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu126' and extra == 'extra-10-city2graph-cu128') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu126' and extra == 'extra-10-city2graph-cu130') or (platform_python_implementation == 'PyPy' and extra == 'extra-10-city2graph-cu128' and extra == 'extra-10-city2graph-cu130') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu118') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu124') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu126') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu128') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cpu' and extra == 'extra-10-city2graph-cu130') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu118' and extra == 'extra-10-city2graph-cu124') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu118' and extra == 'extra-10-city2graph-cu126') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu118' and extra == 'extra-10-city2graph-cu128') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu118' and extra == 'extra-10-city2graph-cu130') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu124' and extra == 'extra-10-city2graph-cu126') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu124' and extra == 'extra-10-city2graph-cu128') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu124' and extra == 'extra-10-city2graph-cu130') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu126' and extra == 'extra-10-city2graph-cu128') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu126' and extra == 'extra-10-city2graph-cu130') or (sys_platform != 'win32' and extra == 'extra-10-city2graph-cu128' and extra == 'extra-10-city2graph-cu130')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/5d/49ba324ad4ae5b1a4caefafbce7a1648540129344481f2ed4ef6bb68d451/plumbum-1.9.0.tar.gz", hash = "sha256:e640062b72642c3873bd5bdc3effed75ba4d3c70ef6b6a7b907357a84d909219", size = 319083, upload-time = "2024-10-05T05:59:27.059Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/9d/d03542c93bb3d448406731b80f39c3d5601282f778328c22c77d270f4ed4/plumbum-1.9.0-py3-none-any.whl", hash = "sha256:9fd0d3b0e8d86e4b581af36edf3f3bbe9d1ae15b45b8caab28de1bcb27aaa7f5", size = 127970, upload-time = "2024-10-05T05:59:25.102Z" },
-]
-
-[[package]]
-name = "ply"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]
@@ -3519,6 +3488,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/dd/c968c49a2e9b7c219eac0cc504241c21ef789f1f1b34d33780508cea9764/pyogrio-0.11.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:76150a3cd787c31628191c7abc6f8c796660125852fb65ae15dd7be1e9196816", size = 26433178, upload-time = "2025-08-02T20:18:58.274Z" },
     { url = "https://files.pythonhosted.org/packages/89/a9/79eca15094f7806a3adcf0bb976ab4346b0fb1bd87956c1933df44546c14/pyogrio-0.11.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e929452f6988c0365dd32ff2485d9488160a709fee28743abbbc18d663169ed0", size = 27616835, upload-time = "2025-08-02T20:19:01.112Z" },
     { url = "https://files.pythonhosted.org/packages/2b/f3/7722bc81e9eee39b528c1cbc6289a26d2d3b1b187491ed8493457d6a3a0e/pyogrio-0.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:d6d56862b89a05fccd7211171c88806b6ec9b5effb79bf807cce0a57c1f2a606", size = 19219088, upload-time = "2025-08-02T20:19:03.732Z" },
+]
+
+[[package]]
+name = "pypandoc-binary"
+version = "1.16.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e0/dcccafc2d8b343408abe1e4f84fa5f854eb29f2b59323a6d9fb95db333d1/pypandoc_binary-1.16.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:dc71533dcce1cb112994e44f95a21c042c02e4fd4b4815442d8cbf7fe0159a88", size = 25526445, upload-time = "2025-11-13T16:30:09.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8f/5f8e7d7febad6972b826537fdb4d78db2dbed8f40f141f58cf1bd95cca7e/pypandoc_binary-1.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a240d645963266be5d68c2b5a0fb9703dfa5bb5e6a8367e36060e2584236b457", size = 25526446, upload-time = "2025-11-13T16:30:12.627Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ae/904a96cd84ef568fa7a8a6a2a783265dda1542fd6ee489ef6fbaf32dfc04/pypandoc_binary-1.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d9d4e14bbf973578ba635d18730131f76d11cf6926e4be977b39fad0bf330a8", size = 36942728, upload-time = "2025-11-13T16:30:15.302Z" },
+    { url = "https://files.pythonhosted.org/packages/55/97/4c7e2543013ed6b8c1c7d7344ae5e3f0fa8df67c6712b90a7d2dc87669c0/pypandoc_binary-1.16.2-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6108d0661298f97def07695527b73f8499e7c425c8386ae0de2e8bf95d5799c", size = 34049538, upload-time = "2025-11-13T16:30:18.467Z" },
+    { url = "https://files.pythonhosted.org/packages/63/72/7ddda95c6ea454296c450191860ecb6f833534d605288fa120bfbfa97c1f/pypandoc_binary-1.16.2-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:a7e03052c7e526188e970aa782245e10be815a292c74b14d350d81c19fdeeafb", size = 36942720, upload-time = "2025-11-13T16:30:21.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fd/0dadb4c5ed01a98bfef1a3d63386686a43e19cf779181f5aea3e31bba800/pypandoc_binary-1.16.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:49a2bea5a79b20eca546b67d466f41d97cecf10e2efb366a7bef7cc3d4edef15", size = 34049518, upload-time = "2025-11-13T16:30:24.461Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a5/8065640aa3acefafe784ed9dc8338ea4516d40c60e151d727369f609eaa1/pypandoc_binary-1.16.2-py3-none-win_amd64.whl", hash = "sha256:9005c32c9d62152cbdd00e5e38579e17c0e708789ef554852367e24fb0cc6cf3", size = 40229130, upload-time = "2025-11-13T16:30:27.624Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Updated docstrings

### Docstring and Return Type Clarifications

* Standardized and clarified the descriptions of return types for functions that convert between different graph representations (e.g., PyG, NetworkX, GeoDataFrame), making them more explicit about the structure and types of returned values for both homogeneous and heterogeneous graphs. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1709-R1715) [[2]](diffhunk://#diff-dfeb28fcd09751d4e337bde358990829b6aa0d1950067713c72297bc72b449e7L169-R188) [[3]](diffhunk://#diff-dfeb28fcd09751d4e337bde358990829b6aa0d1950067713c72297bc72b449e7L2270-R2304) [[4]](diffhunk://#diff-4cca64beb7a79fbae3c1d5daa52946e47b3abf066f4283188c2c27e46054e24cL123-R131) [[5]](diffhunk://#diff-39b4719d8e73b6d94ddc0dff10c9fcb3b8a6b43a88d5fb3874069e91ab0ef4baL123-R133) [[6]](diffhunk://#diff-39b4719d8e73b6d94ddc0dff10c9fcb3b8a6b43a88d5fb3874069e91ab0ef4baL256-R270) [[7]](diffhunk://#diff-39b4719d8e73b6d94ddc0dff10c9fcb3b8a6b43a88d5fb3874069e91ab0ef4baL399-R415) [[8]](diffhunk://#diff-39b4719d8e73b6d94ddc0dff10c9fcb3b8a6b43a88d5fb3874069e91ab0ef4baL526-R544)
* Improved parameter and return documentation for functions that optionally return NetworkX graphs, ensuring that the conditions for different return types are clearly stated. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1777-R1774) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L3053-R3067) [[3]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L2396-R2396) [[4]](diffhunk://#diff-dfeb28fcd09751d4e337bde358990829b6aa0d1950067713c72297bc72b449e7L1707-R1730) [[5]](diffhunk://#diff-17dea7256e2c84ac224af6dbe93d9056fd0f2427b47dbf9daac5a842450e76b5L479-R479)

### Example and Usage Updates

* Updated and corrected example usages in docstrings to reflect current function names and typical workflows, replacing outdated or incorrect calls. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L2068-R2066) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L2150-R2148) [[3]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L2227-R2225)

### Parameter Order and API Consistency

* Reordered keyword arguments (e.g., `as_nx`, `multigraph`) in function signatures for consistency and to match documentation order, improving code readability. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L2358-R2356) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L3015-R3013) [[3]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L1386-R1389) [[4]](diffhunk://#diff-dfeb28fcd09751d4e337bde358990829b6aa0d1950067713c72297bc72b449e7L1686-R1704)

### Minor Documentation Improvements

* Updated specific parameter examples and added clarifying notes for special cases (e.g., explaining dictionary keys for heterogeneous graphs, updating example edge types in isochrone generation).

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
