### PR TITLE
Fixed docs workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,17 +1,53 @@
 name: Build and Deploy Documentation
+
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
+
 permissions:
   contents: write
   pages: write
   id-token: write
 
 jobs:
-  build_mkdocs:
+  # Job 1: CI Check (Runs on Pull Requests)
+  check_build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev
+
+      - name: Install dependencies
+        run: |
+          uv sync --group docs --extra cpu
+
+      - name: Check Build
+        run: |
+          # Build in strict mode to catch warnings/errors
+          uv run mkdocs build --strict
+
+  # Job 2: Manual Deployment (Runs on Workflow Dispatch)
+  deploy:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,25 +82,17 @@ jobs:
           VERSION=$(grep "version = " pyproject.toml | head -n 1 | cut -d '"' -f 2)
           uv run mike deploy --push --update-aliases $VERSION latest
 
-  deploy_mkdocs:
-    needs: build_mkdocs
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Checkout gh-pages
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
+          path: gh-pages-build
+          fetch-depth: 0
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: .
+          path: gh-pages-build
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Description

Fixed the workflow for document build and deploy.

**Workflow improvements:**

* The documentation workflow is now triggered on pull requests (opened, synchronized, or reopened) instead of only on pushes to `main`, allowing early detection of documentation build issues.
* Added a new `check_build` job that installs dependencies and runs `mkdocs build --strict` to catch warnings and errors during pull requests.

**Deployment process changes:**

* Deployment to GitHub Pages is now a separate `deploy` job that only runs on manual workflow dispatch, making deployments explicit and controlled.
* The deployment job was refactored to upload the documentation artifact from the correct path (`gh-pages-build`) and to fetch the full history for the `gh-pages` branch.

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
