### PR TITLE
Add `node_geom_col` and `set_point_nodes` in `contiguity graph` and `group_nodes`

### DIFF
--- a/city2graph/data.py
+++ b/city2graph/data.py
@@ -651,8 +651,9 @@ def _cluster_segment_endpoints(
     # Update segment geometries
     result_gdf = segments_gdf.copy()
     for idx, row in result_gdf.iterrows():
-        if isinstance(row.geometry, LineString) and len(row.geometry.coords) >= 2:
-            coords = list(row.geometry.coords)
+        row_geom = row.get("geometry")
+        if isinstance(row_geom, LineString) and len(row_geom.coords) >= 2:
+            coords = list(row_geom.coords)
             start_coord = coord_lookup.get((idx, "start"), coords[0])
             end_coord = coord_lookup.get((idx, "end"), coords[-1])
             result_gdf.loc[idx, "geometry"] = LineString([start_coord, *coords[1:-1], end_coord])

--- a/city2graph/data.py
+++ b/city2graph/data.py
@@ -578,7 +578,7 @@ def _create_segment_splits(segment: pd.Series, positions: list[float]) -> list[p
 
         if part_geom and not part_geom.is_empty:
             new_segment = segment.copy()
-            new_segment.geometry = part_geom
+            new_segment["geometry"] = part_geom
             new_segment["split_from"] = start_pct
             new_segment["split_to"] = end_pct
             new_segment["id"] = f"{original_id}_{i + 1}" if len(positions) > 2 else original_id

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -462,6 +462,8 @@ class GraphBuilder:
             for node_id, attrs, (x, y) in zip(self.node_ids, attrs_list, self.coords, strict=False)
         )
         self.G.graph["crs"] = self.gdf.crs
+        self.G.graph["node_geom_cols"] = list(self.gdf.select_dtypes(include=["geometry"]).columns)
+        self.G.graph["node_index_names"] = list(self.gdf.index.names)
 
         # Validate metric against CRS
         self.metric.validate(self.gdf.crs)
@@ -1775,7 +1777,7 @@ def contiguity_graph(
     if set_point_nodes:
         point_geom = node_geom if node_geom is not None else gdf.geometry.centroid
         nodes_gdf = gdf.copy()
-        nodes_gdf["original_geometry"] = gdf.geometry
+        nodes_gdf["original_geometry"] = gpd.GeoSeries(gdf.geometry, index=gdf.index, crs=gdf.crs)
         nodes_gdf["geometry"] = point_geom
         nodes_gdf = nodes_gdf.set_geometry("geometry")
 


### PR DESCRIPTION
## Description

This pull request introduces enhanced flexibility for controlling node geometries in proximity and contiguity graph construction functions within `city2graph/proximity.py`. The main improvements allow users to specify custom point geometries for polygon nodes (instead of always using centroids), and to optionally swap polygon geometries for points while preserving the original shapes.

The most important changes are:

**API Enhancements: Polygon Node Geometry Control**
- Added `node_geom_col` and `set_point_nodes` parameters to `group_nodes` and `contiguity_graph`, allowing users to specify a custom column of point geometries for nodes and to swap polygon geometries for points while preserving original geometries. [[1]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R1567-R1568) [[2]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R1603-R1608) [[3]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R1704-R1705) [[4]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R1751-R1757)
- Modified internal logic so that, when these options are used, node positions and edge computations use the provided point geometries rather than centroids. [[1]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560L437-R451) [[2]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R1655-R1687) [[3]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R1794-R1817)

**Edge Construction Logic**
- Updated `_edges_gdf_from_pairs` to accept custom polygon node positions for accurate edge geometry and weight calculation when node geometries are overridden. [[1]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R2216-R2217) [[2]](diffhunk://#diff-34ed582715caf354e50d86e387ab217f94060a18de0027513759988dc91b2560R2233-R2247)

**Graph Metadata**
- The graph now records which columns were used for node geometries and the index names in its metadata for better traceability.

**Testing and Validation**
- Added tests to cover custom node geometry columns, swapping to point nodes, preservation of original geometries, and error handling for missing columns in both `group_nodes` and `contiguity_graph`. [[1]](diffhunk://#diff-dcc82a8788c10ae841865d920aac07cff41bf7f2ceceea247f17a85e4ae56c20R328-R357) [[2]](diffhunk://#diff-dcc82a8788c10ae841865d920aac07cff41bf7f2ceceea247f17a85e4ae56c20R690-R754)

These changes provide more control and transparency over how spatial graphs are constructed, making the API more flexible for advanced spatial analysis workflows.

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
