### PR TITLE
Add support for extracting additional node/edge attributes during gra…

### DIFF
--- a/city2graph/base.py
+++ b/city2graph/base.py
@@ -283,6 +283,8 @@ class BaseGraphConverter(ABC):
         graph_data: Any,  # noqa: ANN401
         nodes: bool = True,
         edges: bool = True,
+        additional_node_cols: Any = None,  # noqa: ANN401
+        additional_edge_cols: Any = None,  # noqa: ANN401
     ) -> (
         tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]
         | tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]]
@@ -300,6 +302,10 @@ class BaseGraphConverter(ABC):
             Whether to reconstruct node GeoDataFrames.
         edges : bool, default True
             Whether to reconstruct edge GeoDataFrames.
+        additional_node_cols : Any, optional
+            Additional node attributes to extract.
+        additional_edge_cols : Any, optional
+            Additional edge attributes to extract.
 
         Returns
         -------
@@ -311,8 +317,22 @@ class BaseGraphConverter(ABC):
         metadata = self._extract_metadata(graph_data)
 
         if metadata.is_hetero:
-            return self._reconstruct_heterogeneous(graph_data, metadata, nodes, edges)
-        return self._reconstruct_homogeneous(graph_data, metadata, nodes, edges)
+            return self._reconstruct_heterogeneous(
+                graph_data,
+                metadata,
+                nodes,
+                edges,
+                additional_node_cols=additional_node_cols,
+                additional_edge_cols=additional_edge_cols,
+            )
+        return self._reconstruct_homogeneous(
+            graph_data,
+            metadata,
+            nodes,
+            edges,
+            additional_node_cols=additional_node_cols,
+            additional_edge_cols=additional_edge_cols,
+        )
 
     @abstractmethod
     def _convert_homogeneous(
@@ -375,6 +395,8 @@ class BaseGraphConverter(ABC):
         metadata: GraphMetadata,
         nodes: bool,
         edges: bool,
+        additional_node_cols: Any | None = None,  # noqa: ANN401
+        additional_edge_cols: Any | None = None,  # noqa: ANN401
     ) -> tuple[gpd.GeoDataFrame | None, gpd.GeoDataFrame | None] | gpd.GeoDataFrame:
         """
         Reconstruct homogeneous GeoDataFrames.
@@ -392,6 +414,10 @@ class BaseGraphConverter(ABC):
             Whether to reconstruct node GeoDataFrame.
         edges : bool
             Whether to reconstruct edge GeoDataFrame.
+        additional_node_cols : Any or None, optional
+            Additional node attributes to extract.
+        additional_edge_cols : Any or None, optional
+            Additional edge attributes to extract.
         """
 
     @abstractmethod
@@ -401,6 +427,8 @@ class BaseGraphConverter(ABC):
         metadata: GraphMetadata,
         nodes: bool,
         edges: bool,
+        additional_node_cols: Any | None = None,  # noqa: ANN401
+        additional_edge_cols: Any | None = None,  # noqa: ANN401
     ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]]:
         """
         Reconstruct heterogeneous GeoDataFrames.
@@ -418,6 +446,10 @@ class BaseGraphConverter(ABC):
             Whether to reconstruct node GeoDataFrames.
         edges : bool
             Whether to reconstruct edge GeoDataFrames.
+        additional_node_cols : Any or None, optional
+            Additional node attributes to extract.
+        additional_edge_cols : Any or None, optional
+            Additional edge attributes to extract.
         """
 
 

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -976,6 +976,8 @@ class NxConverter(BaseGraphConverter):
         metadata: "GraphMetadata",
         nodes: bool = True,
         edges: bool = True,
+        additional_node_cols: list[str] | None = None,  # noqa: ARG002
+        additional_edge_cols: list[str] | None = None,  # noqa: ARG002
     ) -> tuple[gpd.GeoDataFrame | None, gpd.GeoDataFrame | None] | gpd.GeoDataFrame:
         """
         Reconstruct homogeneous GeoDataFrames from a NetworkX graph.
@@ -994,6 +996,10 @@ class NxConverter(BaseGraphConverter):
             Whether to reconstruct the nodes GeoDataFrame.
         edges : bool, default True
             Whether to reconstruct the edges GeoDataFrame.
+        additional_node_cols : list[str] or None, optional
+            Additional columns to extract. Not used in this implementation.
+        additional_edge_cols : list[str] or None, optional
+            Additional columns to extract. Not used in this implementation.
 
         Returns
         -------
@@ -1021,6 +1027,8 @@ class NxConverter(BaseGraphConverter):
         metadata: "GraphMetadata",
         nodes: bool = True,
         edges: bool = True,
+        additional_node_cols: dict[str, list[str]] | None = None,  # noqa: ARG002
+        additional_edge_cols: dict[str, list[str]] | None = None,  # noqa: ARG002
     ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]]:
         """
         Reconstruct heterogeneous GeoDataFrames from a NetworkX graph.
@@ -1041,6 +1049,10 @@ class NxConverter(BaseGraphConverter):
             Whether to reconstruct the node GeoDataFrames.
         edges : bool, default True
             Whether to reconstruct the edge GeoDataFrames.
+        additional_node_cols : dict[str, list[str]] or None, optional
+            Additional columns to extract. Not used in this implementation.
+        additional_edge_cols : dict[str, list[str]] or None, optional
+            Additional columns to extract. Not used in this implementation.
 
         Returns
         -------


### PR DESCRIPTION
## Description

Adds support for extracting additional node and edge attributes when reconstructing GeoDataFrames from PyTorch Geometric data.

**API enhancements for extracting additional attributes:**

* Added `additional_node_cols` and `additional_edge_cols` parameters to the `reconstruct`, `_reconstruct_homogeneous`, and `_reconstruct_heterogeneous` methods in `city2graph/base.py` and `city2graph/graph.py`, allowing users to specify extra node and edge attributes to extract. [[1]](diffhunk://#diff-fd0cbe33eeec3fc604c687dfff1489c30c6ee948960f7d99b2e7ed36335578afR286-R287) [[2]](diffhunk://#diff-fd0cbe33eeec3fc604c687dfff1489c30c6ee948960f7d99b2e7ed36335578afR305-R308) [[3]](diffhunk://#diff-fd0cbe33eeec3fc604c687dfff1489c30c6ee948960f7d99b2e7ed36335578afL314-R335) [[4]](diffhunk://#diff-fd0cbe33eeec3fc604c687dfff1489c30c6ee948960f7d99b2e7ed36335578afR398-R399) [[5]](diffhunk://#diff-fd0cbe33eeec3fc604c687dfff1489c30c6ee948960f7d99b2e7ed36335578afR417-R420) [[6]](diffhunk://#diff-fd0cbe33eeec3fc604c687dfff1489c30c6ee948960f7d99b2e7ed36335578afR430-R431) [[7]](diffhunk://#diff-fd0cbe33eeec3fc604c687dfff1489c30c6ee948960f7d99b2e7ed36335578afR449-R452) [[8]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R184-R185) [[9]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R797) [[10]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R872) [[11]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R985) [[12]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R1335-R1336) [[13]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R1384-R1385)

* Updated the `pyg_to_gdf` function and method to accept and forward these new parameters, with detailed docstring explanations for both homogeneous and heterogeneous cases. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R1784-R1785) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R1813-R1821) [[3]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R204-R219)

**Implementation of additional attribute extraction:**

* Modified the feature extraction pipeline by updating `_extract_features` to accept an `additional_cols` argument and calling a new helper method, `_extract_additional_columns`, which extracts specified tensor attributes from the data object and adds them to the GeoDataFrame dictionary. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L811-R827) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R888-R889) [[3]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R1002-R1003) [[4]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R1059-R1106)

**Support for both homogeneous and heterogeneous graphs:**

* In `_reconstruct_homogeneous` and `_reconstruct_heterogeneous`, passed the appropriate additional columns to node and edge reconstruction methods, handling both list and dictionary input for heterogeneous graphs. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1291-R1374) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1331-R1439)

**Documentation and typing improvements:**

* Updated docstrings and type annotations throughout the affected methods to clarify the purpose and expected types of the new parameters. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R813-R814) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R1353-R1356) [[3]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81R1402-R1405)

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
