### PR TITLE
Fixed robots.txt

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://city2graph.net/sitemap.xml
+Sitemap: https://city2graph.net/latest/sitemap.xml


### PR DESCRIPTION
Changed the `Sitemap` directive in `robots.txt` to reference `https://city2graph.net/latest/sitemap.xml` instead of the previous location.