### PR TITLE
Fix edge_feature_cols in gdf_to_pyg and 

### DIFF
--- a/city2graph/base.py
+++ b/city2graph/base.py
@@ -100,7 +100,7 @@ class GraphMetadata:
         self.node_mappings: dict[str, dict[str, dict[str | int, int] | str | list[str | int]]] = {}
         self.node_feature_cols: dict[str, list[str]] | list[str] | None = None
         self.node_label_cols: dict[str, list[str]] | list[str] | None = None
-        self.edge_feature_cols: dict[str, list[str]] | list[str] | None = None
+        self.edge_feature_cols: dict[tuple[str, str, str], list[str]] | list[str] | None = None
         self.edge_index_values: (
             dict[tuple[str, str, str], list[list[str | int]]] | list[list[str | int]] | None
         ) = None

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -174,7 +174,10 @@ class TestGraphConversion:
                 sample_hetero_edges_dict,
                 node_feature_cols={"building": ["b_feat1"], "road": ["length"]},
                 node_label_cols={"building": ["b_label"]},
-                edge_feature_cols={"connects_to": ["conn_feat1"], "links_to": ["link_feat1"]},
+                edge_feature_cols={
+                    ("building", "connects_to", "road"): ["conn_feat1"],
+                    ("road", "links_to", "road"): ["link_feat1"],
+                },
             )
             assert data["building"].x.shape[1] == 1
             assert data["road"].x.shape[1] == 1
@@ -1050,11 +1053,10 @@ class TestOptionalTensorConversion:
         metadata.edge_types = [edge_type_1, edge_type_2]
         data.graph_metadata = metadata
 
-        # Test matching by full edge type tuple for e1
-        # and matching by relation string for e2
+        # Test matching by full edge type tuple for both
         _, edges_dict = pyg_to_gdf(
             data,
-            additional_edge_cols={edge_type_1: ["z"], "via": ["w"]},
+            additional_edge_cols={edge_type_1: ["z"], edge_type_2: ["w"]},
         )
         assert isinstance(edges_dict, dict)
         assert "z" in edges_dict[edge_type_1].columns


### PR DESCRIPTION
## Description

Updates how edge feature columns are specified and handled throughout the codebase to improve consistency and correctness for heterogeneous graphs. The main change is that edge feature columns are now always keyed by the full edge type tuple (`(src, relation, dst)`) instead of just the relation string.

**Edge feature column specification and usage:**

* Updated the type of `edge_feature_cols` in constructors and functions (e.g., `__init__` in `city2graph/base.py` and `city2graph/graph.py`, `gdf_to_pyg`, `_process_hetero_edges`, `_store_hetero_metadata`, etc.) to require dictionaries keyed by full edge type tuples for heterogeneous graphs. [[1]](diffhunk://#diff-fd0cbe33eeec3fc604c687dfff1489c30c6ee948960f7d99b2e7ed36335578afL103-R103) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L117-R117) [[3]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L555-R555) [[4]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L622-R624) [[5]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1648-R1650)
* Modified docstrings and comments to clarify that `edge_feature_cols` and related arguments should be keyed by edge type tuples, not relation strings, for heterogeneous graphs. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L570-R571) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L643-R646) [[3]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1685-R1689) [[4]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1817-R1822) [[5]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1899-R1901)

**Internal logic changes:**

* Changed logic in `_process_hetero_edges` and `_extract_features` to always look up feature columns by the full edge type tuple, ensuring correct feature extraction for all edge types. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L604-R606) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1046-R1053)

**Function argument consistency:**

* Updated function signatures for `pyg_to_gdf`, `pyg_to_nx`, and related functions to require `additional_edge_cols` dictionaries keyed by edge type tuples for heterogeneous graphs. [[1]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L185-R185) [[2]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1785-R1787) [[3]](diffhunk://#diff-a28f4903b08757960dda578eabafbe34ab1572b4c6131dfbdecfd961f7b72b81L1880-R1882)

**Test updates:**

* Modified tests to use full edge type tuples when specifying edge feature columns and additional edge columns, ensuring test coverage matches the new requirements. [[1]](diffhunk://#diff-e9352f44736d5b9e922852f07917f4d93bb6d4ca2e6d9743abf20194a5c414d5L177-R180) [[2]](diffhunk://#diff-e9352f44736d5b9e922852f07917f4d93bb6d4ca2e6d9743abf20194a5c414d5L1053-R1059)

## Related Issues

Is this pull request related to any existing issues? If so, please link them here. For example, `Fixes #123` or `Closes #456`.

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
