### PR TITLE
Fixed site url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: City2Graph
-site_url: https://city2graph.net/
+site_url: https://city2graph.net/latest/
 site_author: Yuta Sato
 site_description: Transform urban data into graphs for spatial analysis and Graph Neural Networks
 repo_url: https://github.com/c2g-dev/city2graph


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `mkdocs.yml` configuration file, changing the documentation site URL to point to the `/latest/` version.

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
