### PR TITLE
Fix site url

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,3 +1,8 @@
 User-agent: *
 Allow: /
+Sitemap: https://city2graph.net/stable/sitemap.xml
 Sitemap: https://city2graph.net/latest/sitemap.xml
+Sitemap: https://city2graph.net/v0.2.3/sitemap.xml
+Sitemap: https://city2graph.net/v0.2.2/sitemap.xml
+Sitemap: https://city2graph.net/v0.2.1/sitemap.xml
+Sitemap: https://city2graph.net/v0.2.0/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: City2Graph
-site_url: https://city2graph.net/
+site_url: https://city2graph.net/latest/
 site_author: Yuta Sato
 site_description: Transform urban data into graphs for spatial analysis and Graph Neural Networks
 repo_url: https://github.com/c2g-dev/city2graph


### PR DESCRIPTION
## Description

Website discoverability improvements:

* Added multiple sitemap entries for different documentation versions (`stable`, `v0.2.3`, `v0.2.2`, `v0.2.1`, `v0.2.0`) in `docs/robots.txt` to help search engines index all available versions.

Documentation configuration updates:

* Changed the `site_url` in `mkdocs.yml` from the root site to the `/latest/` documentation path, ensuring the latest docs are referenced as the main site.

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
