### PR TITLE
Fix kwargs in plot_graph

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2151,6 +2151,38 @@ class TestPlotting(BaseGraphTest):
         finally:
             plt.close(fig)
 
+    def test_plot_graph_homo_with_legend_kwargs_and_title(
+        self,
+        sample_nodes_gdf: gpd.GeoDataFrame,
+        sample_edges_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """Homogeneous plotting should support legend kwargs and title."""
+        if not utils.MATPLOTLIB_AVAILABLE:
+            pytest.skip("matplotlib not available")
+
+        nodes = sample_nodes_gdf.copy()
+        nodes["centrality_quantile"] = range(len(nodes))
+
+        edge_linewidth = pd.Series([1.0] * len(sample_edges_gdf), index=sample_edges_gdf.index)
+        fig, ax = plt.subplots(figsize=(5, 5))
+        try:
+            utils.plot_graph(
+                nodes=nodes,
+                edges=sample_edges_gdf,
+                node_color="centrality_quantile",
+                edge_color="#bbbbbb",
+                edge_linewidth=edge_linewidth,
+                legend=True,
+                legend_kwargs={"label": "Betweenness Centrality", "orientation": "horizontal"},
+                title="Central London Transit Network Betweenness Centrality of Stops",
+                ax=ax,
+            )
+            assert (
+                ax.get_title() == "Central London Transit Network Betweenness Centrality of Stops"
+            )
+        finally:
+            plt.close(fig)
+
     @pytest.mark.skipif(not MATPLOTLIB_AVAILABLE, reason="Matplotlib not available")
     def test_plot_empty_gdf(self, empty_gdf: gpd.GeoDataFrame) -> None:
         """Test _plot_gdf with empty GeoDataFrame (line 3246)."""


### PR DESCRIPTION
## Description

Fixed a plotting bug in `plot_graph` for homogeneous graphs when `legend=True`, `legend_kwargs`, and `title` are provided

### Problem
`plot_graph` was forwarding `legend`, `legend_kwargs`, and `title` directly into lower-level `GeoDataFrame.plot()` kwargs. In this path:
- `legend_kwargs` leaked into edge plotting and triggered:
  - `IndexError: index 1 is out of bounds for axis 0 with size 1`
- `title` was also incorrectly passed through instead of being applied on the axes.

### Root Cause
In `_plot_homo_graph` and style resolution, plot-control kwargs (`legend`, `legend_kwargs`, `title`) were not properly treated as city2graph-managed parameters. They were unintentionally propagated to GeoPandas/Matplotlib collection plotting calls.

### Changes
- Marked `legend`, `legend_kwargs`, and `title` as reserved c2g keys so they are excluded from generic style kwargs.
- Updated homogeneous plotting flow to:
  - strip `title`, `legend`, `legend_kwargs` before edge/node plotting,
  - apply legend settings only on node plotting,
  - map `legend_kwargs` to GeoPandas’ expected `legend_kwds`,
  - set title via `ax.set_title(...)` after plotting.
- Improved plot parameter handling for column-driven styling by resolving `pd.Series`/column refs to numpy arrays where needed for consistent plotting behavior.

### Validation
- Reproduced the originally reported failing snippet and confirmed it now runs successfully.

```
### Failed before

import geopandas as gpd
from shapely.geometry import Point, LineString
import matplotlib.pyplot as plt
import city2graph as c2g

nodes = gpd.GeoDataFrame(
    {"centrality_quantile": [1, 2]},
    geometry=[Point(0, 0), Point(1, 1)],
    crs="EPSG:4326",
)

edges = gpd.GeoDataFrame(
    {"frequency": [100, 200]},
    geometry=[LineString([(0, 0), (1, 1)]), LineString([(1, 1), (2, 2)])],
    crs="EPSG:4326",
)

fig, ax = plt.subplots(figsize=(5, 5))

c2g.plot_graph(
    nodes=nodes,
    edges=edges,
    node_color="centrality_quantile",
    edge_color="#bbbbbb",
    edge_linewidth=edges["frequency"] / 200,
    legend=True,
    legend_kwargs={"label": "Betweenness Centrality", "orientation": "horizontal"},
    title = "Central London Transit Network Betweenness Centrality of Stops",
    ax=ax,
)

plt.show()
```

<img width="557" height="432" alt="test_bug_with_legend" src="https://github.com/user-attachments/assets/c766628f-b060-4d78-a9c5-b17a034c813b" />

```
### Works
# Removing `legend=True`, `legend_kwargs`, and `title`  a makes the same call succeed.

import geopandas as gpd
from shapely.geometry import Point, LineString
import matplotlib.pyplot as plt
import city2graph as c2g

nodes = gpd.GeoDataFrame(
    {"centrality_quantile": [1, 2]},
    geometry=[Point(0, 0), Point(1, 1)],
    crs="EPSG:4326",
)

edges = gpd.GeoDataFrame(
    {"frequency": [100, 200]},
    geometry=[LineString([(0, 0), (1, 1)]), LineString([(1, 1), (2, 2)])],
    crs="EPSG:4326",
)

fig, ax = plt.subplots(figsize=(5, 5))

c2g.plot_graph(
    nodes=nodes,
    edges=edges,
    node_color="centrality_quantile",
    edge_color="#bbbbbb",
    edge_linewidth=edges["frequency"] / 200,
    # legend=True,
    # legend_kwargs={"label": "Betweenness Centrality", "orientation": "horizontal"},
    # title = "Central London Transit Network Betweenness Centrality of Stops"
    ax=ax,
)

plt.show()
```

<img width="404" height="405" alt="test_bug_without_legend" src="https://github.com/user-attachments/assets/e52f15ee-85d2-4715-b26d-e6bb3dcff181" />

- Added a regression test covering the homogeneous case with `node_color` column, `edge_linewidth` series, `legend=True`, `legend_kwargs`, and `title`.

## Related Issues

https://github.com/c2g-dev/city2graph/issues/121

## Checklist

- [x] I have read the [Contributing Guide](https://city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.