### PR TITLE
Fix ID typing in morphological_graph()

### DIFF
--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -18,6 +18,7 @@ The module specializes in three types of spatial relationships:
 import itertools
 import logging
 import math
+import typing
 import warnings
 
 # Third-party imports
@@ -1238,6 +1239,11 @@ def _add_building_info(
 
         # Remove the temporary 'index_right' column
         joined = joined.drop(columns=["index_right"])
+    else:
+        # Always allocate the "building_geometry" column even if sjoin yields 0 matches
+        joined["building_geometry"] = gpd.GeoSeries(
+            [None] * len(joined), index=joined.index, crs=buildings.crs
+        )
 
     return joined  # Return tessellation with added building geometry (if any)
 
@@ -1391,7 +1397,7 @@ def _filter_tessellation_by_network_distance(
 
 def _filter_nodes_by_path_length(
     graph: nx.Graph,
-    source_node_id: str,
+    source_node_id: typing.Hashable,
     max_distance: float,
     centroid_iloc_to_node_id: dict[int, str],
 ) -> list[int]:
@@ -1407,7 +1413,7 @@ def _filter_nodes_by_path_length(
     ----------
     graph : networkx.Graph
         The graph to perform the search on.
-    source_node_id : str
+    source_node_id : typing.Hashable
         The ID of the source node for the path length calculation.
     max_distance : float
         The maximum path length for a node to be included.
@@ -1591,7 +1597,7 @@ def _connect_centroids_to_centroids(
 def _find_closest_node_to_center(
     graph: nx.Graph,
     center_point_geom: Point,
-) -> str:
+) -> typing.Hashable:
     """
     Find the graph node ID closest to a geometric center point.
 
@@ -1622,8 +1628,8 @@ def _find_closest_node_to_center(
     # Query for the closest node to the center point
     _, idx = kdtree.query([center_point_geom.x, center_point_geom.y])
 
-    # Return the ID of the closest node
-    return str(node_ids[idx])
+    # Return the exact native ID of the closest node
+    return typing.cast("typing.Hashable", node_ids[int(idx)])
 
 
 # ============================================================================

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -4200,12 +4200,12 @@ def _resolve_plot_parameter(
         Resolved parameter value.
     """
     if param_value is None:
-        return default_value  # type: ignore[no-any-return]
+        return typing.cast("str | float | np.ndarray | pd.Series", default_value)
     if isinstance(param_value, pd.Series):
         return param_value.to_numpy()
     if isinstance(param_value, str) and param_value in gdf.columns:
-        return gdf[param_value].to_numpy()  # type: ignore[no-any-return]
-    return param_value
+        return typing.cast("str | float | np.ndarray | pd.Series", gdf[param_value].to_numpy())
+    return typing.cast("str | float | np.ndarray | pd.Series", param_value)
 
 
 def _get_color_for_type(i: int) -> str | tuple[float, float, float, float]:

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -544,7 +544,8 @@ class TestInputValidationAndErrors(TestMorphologyBase):
                 for msg in warning_messages
                 if "Source node for distance filtering not found" in msg
             ]
-            assert len(distance_warnings) > 0
+            # Since the str() cast bug is fixed, KDTree always returns a valid node ID
+            assert len(distance_warnings) == 0
 
         # Should still return valid (possibly empty) results
         self.validate_basic_output(nodes, edges, ["private", "public"])


### PR DESCRIPTION
## Description
This pull request primarily improves type safety and robustness in the `city2graph` codebase by updating function signatures, handling edge cases, and making type casting explicit. The changes ensure better compatibility with non-string node IDs and clarify the handling of return types, particularly in utility functions.

### Type safety and compatibility improvements

* Updated function signatures in `city2graph/morphology.py` (`_filter_nodes_by_path_length`, `_find_closest_node_to_center`) to use `typing.Hashable` instead of `str` for node IDs, making the code compatible with non-string node identifiers. [[1]](diffhunk://#diff-39b4719d8e73b6d94ddc0dff10c9fcb3b8a6b43a88d5fb3874069e91ab0ef4baL1394-R1400) [[2]](diffhunk://#diff-39b4719d8e73b6d94ddc0dff10c9fcb3b8a6b43a88d5fb3874069e91ab0ef4baL1410-R1416) [[3]](diffhunk://#diff-39b4719d8e73b6d94ddc0dff10c9fcb3b8a6b43a88d5fb3874069e91ab0ef4baL1594-R1600)
* Modified the return value of `_find_closest_node_to_center` to return the native node ID type using `typing.cast`, rather than always casting to `str`.

### Robustness and edge case handling

* Ensured that the `building_geometry` column is always allocated in the tessellation DataFrame, even if spatial join yields zero matches, preventing potential errors in downstream processing.

### Utility function improvements

* Added explicit type casting in `_resolve_plot_parameter` to clarify and enforce the return type, reducing ambiguity and suppressing type checker warnings.

### Test updates

* Updated the test for network distance edge cases to reflect the fixed bug: KDTree now always returns a valid node ID, so the test no longer expects warnings about missing source nodes.

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
