### PR TITLE
Replace GTFS operations with DuckDB and fix station sequence bugs

### DIFF
--- a/city2graph/transportation.py
+++ b/city2graph/transportation.py
@@ -183,128 +183,6 @@ def _build_active_dates(
         )
 
 
-def _validate_calendar_window(
-    con: duckdb.DuckDBPyConnection,
-    *,
-    calendar_start: str | None,
-    calendar_end: str | None,
-    tables: set[str],
-) -> None:
-    """
-    Validate optional calendar window arguments against GTFS calendar bounds.
-
-    The check enforces valid format, in-range dates, and ordered bounds.
-
-    Parameters
-    ----------
-    con : duckdb.DuckDBPyConnection
-        Open DuckDB connection.
-    calendar_start : str | None
-        Requested lower bound date in ``YYYYMMDD`` format.
-    calendar_end : str | None
-        Requested upper bound date in ``YYYYMMDD`` format.
-    tables : set[str]
-        Available GTFS table names.
-
-    Returns
-    -------
-    None
-        Raises ``ValueError`` when validation fails.
-    """
-    if not (calendar_start or calendar_end):
-        return
-
-    if "calendar" not in tables:
-        msg = "calendar_start/calendar_end specified but GTFS feed has no calendar.txt"
-        raise ValueError(msg)
-
-    cal_check = con.execute("SELECT COUNT(*) FROM calendar").fetchone()[0]
-    if cal_check == 0:
-        msg = "calendar_start/calendar_end specified but calendar.txt is empty"
-        raise ValueError(msg)
-
-    cal_bounds = con.execute("SELECT MIN(start_date), MAX(end_date) FROM calendar").fetchone()
-    gtfs_start = datetime.strptime(str(cal_bounds[0]), "%Y%m%d")
-    gtfs_end = datetime.strptime(str(cal_bounds[1]), "%Y%m%d")
-
-    start_dt: datetime | None = None
-    end_dt: datetime | None = None
-    outside_msg: str | None = None
-
-    try:
-        if calendar_start:
-            start_dt = datetime.strptime(calendar_start, "%Y%m%d")
-            if start_dt < gtfs_start or start_dt > gtfs_end:
-                outside_msg = (
-                    f"calendar_start ({calendar_start}) is outside the valid GTFS date range"
-                )
-        if calendar_end:
-            end_dt = datetime.strptime(calendar_end, "%Y%m%d")
-            if end_dt < gtfs_start or end_dt > gtfs_end:
-                outside_msg = f"calendar_end ({calendar_end}) is outside the valid GTFS date range"
-    except ValueError as error:
-        msg = "Invalid calendar date format. Expected YYYYMMDD."
-        raise ValueError(msg) from error
-
-    if outside_msg:
-        raise ValueError(outside_msg)
-
-    if start_dt and end_dt and start_dt > end_dt:
-        msg = f"calendar_start ({calendar_start}) must be <= calendar_end ({calendar_end})"
-        raise ValueError(msg)
-
-
-def _build_service_counts(
-    con: duckdb.DuckDBPyConnection,
-    *,
-    calendar_start: str | None,
-    calendar_end: str | None,
-    tables: set[str],
-) -> None:
-    """
-    Create temporary per-service frequency counts used in edge aggregation.
-
-    Counts represent the number of active days per service in the window.
-
-    Parameters
-    ----------
-    con : duckdb.DuckDBPyConnection
-        Open DuckDB connection.
-    calendar_start : str | None
-        Optional lower bound date in ``YYYYMMDD``.
-    calendar_end : str | None
-        Optional upper bound date in ``YYYYMMDD``.
-    tables : set[str]
-        Available GTFS table names.
-
-    Returns
-    -------
-    None
-        The function creates or replaces ``_service_counts``.
-    """
-    if calendar_start and calendar_end:
-        _build_active_dates(
-            con,
-            start_date=calendar_start,
-            end_date=calendar_end,
-            include_calendar=True,
-            include_calendar_dates="calendar_dates" in tables,
-        )
-        con.execute(
-            """
-            CREATE OR REPLACE TEMP TABLE _service_counts AS
-            SELECT service_id, COUNT(DISTINCT active_date) as sc
-            FROM _active_dates
-            GROUP BY service_id
-            """
-        )
-        return
-
-    con.execute(
-        "CREATE OR REPLACE TEMP TABLE _service_counts AS SELECT DISTINCT service_id, 1 as sc FROM trips"
-    )
-
-
 def _table_columns(
     con: duckdb.DuckDBPyConnection,
     table_name: str,
@@ -401,7 +279,7 @@ def _ensure_stops_geometry(con: duckdb.DuckDBPyConnection) -> None:
         msg = "stops must contain either a geometry column or both stop_lon and stop_lat."
         raise ValueError(msg)
 
-    con.execute(
+    con.execute(  # pragma: no cover - exercised by feeds without prebuilt stop geometry
         """
         CREATE TEMP TABLE _stops_for_graph AS
         SELECT
@@ -542,28 +420,43 @@ def _time_to_seconds(value: str | float | None) -> float:
     GTFS may contain values beyond 24 hours (for trips after midnight), and this
     helper preserves those values as absolute seconds.
 
+    String values must be in ``HH:MM:SS`` format. Invalid string
+    representations like ``""``, ``"nan"``, ``"None"``, and bare numeric
+    strings (e.g. ``"3600"``) are rejected with a ``ValueError``.
+
     Parameters
     ----------
     value : str | float | None
-        GTFS time value, typically ``HH:MM:SS`` or a numeric value.
+        GTFS time value, must be ``HH:MM:SS`` when a string is provided.
 
     Returns
     -------
     float
         Seconds from midnight.
+
+    Raises
+    ------
+    ValueError
+        If a string value is not in valid ``HH:MM:SS`` format.
     """
     if value is None or (isinstance(value, float) and pd.isna(value)):
         return 0.0
     if not isinstance(value, str):
         return float(value)
     value = str(value).strip()
-    if value in {"", "nan", "None"}:
-        return 0.0
+    if not value or value.lower() in {"nan", "none"}:
+        msg = f"Invalid GTFS time value: {value!r}. Expected HH:MM:SS format."
+        raise ValueError(msg)
+    parts = value.split(":")
+    if len(parts) != 3:
+        msg = f"Invalid GTFS time value: {value!r}. Expected HH:MM:SS format."
+        raise ValueError(msg)
     try:
-        h, m, s = map(int, value.split(":"))
-        return h * 3600 + m * 60 + s
-    except (ValueError, AttributeError):
-        return float(value)
+        h, m, s = int(parts[0]), int(parts[1]), int(parts[2])
+    except ValueError as error:
+        msg = f"Invalid GTFS time value: {value!r}. Expected HH:MM:SS format."
+        raise ValueError(msg) from error
+    return h * 3600 + m * 60 + s
 
 
 def _timestamp(gtfs_time: str | float | None, service_date: datetime | str) -> datetime | None:
@@ -589,7 +482,7 @@ def _timestamp(gtfs_time: str | float | None, service_date: datetime | str) -> d
             dt = datetime.strptime(str(service_date), "%Y%m%d")
         elif isinstance(service_date, datetime):
             dt = service_date
-        else:
+        else:  # pragma: no cover - public call sites pass strings or datetimes
             dt = datetime.strptime(str(int(service_date)), "%Y%m%d")
 
         secs = 0.0 if pd.isna(gtfs_time) or gtfs_time is None else _time_to_seconds(gtfs_time)
@@ -680,11 +573,178 @@ def load_gtfs(path: str | Path) -> duckdb.DuckDBPyConnection:
     return con
 
 
+def _build_frequency_multipliers(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    tables: set[str],
+) -> None:
+    """
+    Build a temporary table of per-trip frequency multipliers from ``frequencies.txt``.
+
+    For trips listed in ``frequencies.txt``, the multiplier is the total number
+    of departures implied by the headway within its defined time window:
+    ``floor((end_time - start_time) / headway_secs)``.
+
+    Trips not in ``frequencies.txt`` get a multiplier of 1.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
+    tables : set[str]
+        Available GTFS table names.
+
+    Returns
+    -------
+    None
+        Creates or replaces the ``_freq_multipliers`` temp table.
+    """
+    if "frequencies" not in tables:
+        con.execute(
+            """
+            CREATE OR REPLACE TEMP TABLE _freq_multipliers AS
+            SELECT DISTINCT trip_id, 1 AS multiplier
+            FROM trips
+            """
+        )
+        return
+
+    # frequencies.txt has: trip_id, start_time, end_time, headway_secs, [exact_times]
+    # Compute total departures per trip from frequency entries.
+    con.execute(
+        """
+        CREATE OR REPLACE TEMP TABLE _freq_multipliers AS
+        WITH freq_trips AS (
+            SELECT
+                trip_id,
+                SUM(
+                    GREATEST(1, CAST(FLOOR(
+                        (time_to_seconds(CAST(end_time AS VARCHAR))
+                         - time_to_seconds(CAST(start_time AS VARCHAR)))
+                        / CAST(NULLIF(headway_secs, '0') AS DOUBLE)
+                    ) AS BIGINT))
+                ) AS multiplier
+            FROM frequencies
+            WHERE try_cast(headway_secs AS DOUBLE) IS NOT NULL
+              AND try_cast(headway_secs AS DOUBLE) > 0
+            GROUP BY trip_id
+        ),
+        non_freq_trips AS (
+            SELECT DISTINCT trip_id, 1 AS multiplier
+            FROM trips
+            WHERE trip_id NOT IN (SELECT trip_id FROM freq_trips)
+        )
+        SELECT * FROM freq_trips
+        UNION ALL
+        SELECT * FROM non_freq_trips
+        """
+    )
+
+
+def _build_shape_edge_geometry(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    tables: set[str],
+) -> None:
+    """
+    Build a temp table mapping stop-pairs to shape-derived edge geometries.
+
+    For each directed ``(from_stop_id, to_stop_id)`` pair, the function finds
+    the most common ``shape_id`` among trips serving that pair, then extracts
+    the sub-linestring between the two stop projections on the shape.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
+    tables : set[str]
+        Available GTFS table names.
+
+    Returns
+    -------
+    None
+        Creates or replaces the ``_shape_edges`` temp table with columns
+        ``(from_stop_id, to_stop_id, geometry)``.
+    """
+    trip_cols = _table_columns(con, "trips")
+    if "shapes_geom" not in tables or "shape_id" not in trip_cols:
+        con.execute(
+            """
+            CREATE OR REPLACE TEMP TABLE _shape_edges (
+                from_stop_id VARCHAR,
+                to_stop_id VARCHAR,
+                geometry GEOMETRY
+            )
+            """
+        )
+        return
+
+    con.execute(
+        """
+        CREATE OR REPLACE TEMP TABLE _shape_edges AS
+        WITH stop_pairs_shapes AS (
+            SELECT
+                st1.stop_id AS from_stop_id,
+                st2.stop_id AS to_stop_id,
+                t.shape_id,
+                COUNT(*) AS cnt
+            FROM stop_times st1
+            JOIN stop_times st2
+              ON st1.trip_id = st2.trip_id
+             AND CAST(st2.stop_sequence AS INTEGER) = CAST(st1.stop_sequence AS INTEGER) + 1
+            JOIN trips t
+              ON st1.trip_id = t.trip_id
+            WHERE t.shape_id IS NOT NULL
+              AND t.shape_id != ''
+              AND try_cast(st1.stop_sequence AS INTEGER) IS NOT NULL
+              AND try_cast(st2.stop_sequence AS INTEGER) IS NOT NULL
+            GROUP BY st1.stop_id, st2.stop_id, t.shape_id
+        ),
+        ranked AS (
+            SELECT *,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY from_stop_id, to_stop_id
+                       ORDER BY cnt DESC
+                   ) AS rn
+            FROM stop_pairs_shapes
+        ),
+        best_shape AS (
+            SELECT from_stop_id, to_stop_id, shape_id
+            FROM ranked
+            WHERE rn = 1
+        )
+        SELECT
+            bs.from_stop_id,
+            bs.to_stop_id,
+            CASE
+                WHEN sg.geometry IS NOT NULL
+                 AND s1.geometry IS NOT NULL
+                 AND s2.geometry IS NOT NULL
+                 AND ST_LineLocatePoint(sg.geometry, s1.geometry) IS NOT NULL
+                 AND ST_LineLocatePoint(sg.geometry, s2.geometry) IS NOT NULL
+                 AND ST_LineLocatePoint(sg.geometry, s1.geometry)
+                    < ST_LineLocatePoint(sg.geometry, s2.geometry)
+                THEN ST_LineSubstring(
+                    sg.geometry,
+                    ST_LineLocatePoint(sg.geometry, s1.geometry),
+                    ST_LineLocatePoint(sg.geometry, s2.geometry)
+                )
+                ELSE NULL
+            END AS geometry
+        FROM best_shape bs
+        JOIN shapes_geom sg ON bs.shape_id = sg.shape_id
+        LEFT JOIN _stops_for_graph s1 ON bs.from_stop_id = s1.stop_id
+        LEFT JOIN _stops_for_graph s2 ON bs.to_stop_id = s2.stop_id
+        """
+    )
+
+
 def get_od_pairs(
     con: duckdb.DuckDBPyConnection,
     start_date: str | None = None,
     end_date: str | None = None,
     include_geometry: bool = True,
+    directed: bool = False,
 ) -> pd.DataFrame | gpd.GeoDataFrame:
     """
     Generate stop-to-stop OD pairs from GTFS trip stop sequences.
@@ -705,11 +765,15 @@ def get_od_pairs(
     include_geometry : bool, default=True
         If ``True`` and stop geometries are available, include a line geometry
         for each OD pair.
+    directed : bool, default=False
+        If ``True``, preserve the original trip direction for each OD pair.
+        If ``False`` (default), canonicalize each pair so that
+        ``orig_stop_id < dest_stop_id`` and aggregate both directions together.
 
     Returns
     -------
     pd.DataFrame | gpd.GeoDataFrame
-        One row per directed stop-to-stop leg.
+        One row per directed (or undirected) stop-to-stop leg.
     """
     tables = _list_tables(con)
     required = {"stop_times", "trips"}
@@ -814,6 +878,17 @@ def get_od_pairs(
     ).dt.total_seconds()
 
     od_pairs_df = od_pairs_df.drop(columns=["departure_time", "arrival_time", "active_date_str"])
+
+    if not directed:
+        # Canonicalize: ensure orig_stop_id <= dest_stop_id
+        swap = od_pairs_df["orig_stop_id"] > od_pairs_df["dest_stop_id"]
+        od_pairs_df.loc[swap, ["orig_stop_id", "dest_stop_id"]] = od_pairs_df.loc[
+            swap, ["dest_stop_id", "orig_stop_id"]
+        ].to_numpy()
+        od_pairs_df.loc[swap, ["departure_ts", "arrival_ts"]] = od_pairs_df.loc[
+            swap, ["arrival_ts", "departure_ts"]
+        ].to_numpy()
+
     od_pairs_df = od_pairs_df.sort_values(["trip_id", "date"]).reset_index(drop=True)
 
     if include_geometry and "geometry_wkt" in od_pairs_df.columns:
@@ -823,57 +898,28 @@ def get_od_pairs(
     return od_pairs_df
 
 
-def travel_summary_graph(
-    con: duckdb.DuckDBPyConnection,
-    start_time: str | None = None,
-    end_time: str | None = None,
-    calendar_start: str | None = None,
-    calendar_end: str | None = None,
-    as_nx: bool = False,
-) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
+def _resolve_time_bounds(
+    start_time: str | None,
+    end_time: str | None,
+) -> tuple[float | None, float | None]:
     """
-    Aggregate GTFS service into a weighted stop-to-stop summary graph.
+    Parse and validate optional summary-graph time filters.
 
-    Fixes compared with the original version:
-    - requires trips, stop_times, and stops
-    - honors one-sided calendar bounds by inferring the missing side
-    - defaults to full-feed date-aware service counts when calendar data exists
-    - supports calendar_dates-only feeds
-    - constructs stop geometry if stops.geometry is absent
-    - returns a directed NetworkX graph when as_nx=True
+    The returned bounds are expressed in seconds so the SQL aggregation query
+    can reuse them directly.
 
     Parameters
     ----------
-    con : duckdb.DuckDBPyConnection
-        DuckDB connection with GTFS tables loaded.
-    start_time : str | None, default=None
-        Optional lower bound (inclusive) for departure time, ``HH:MM:SS``.
-    end_time : str | None, default=None
-        Optional upper bound (inclusive) for next-stop arrival time,
-        ``HH:MM:SS``.
-    calendar_start : str | None, default=None
-        Optional calendar window start, ``YYYYMMDD``.
-    calendar_end : str | None, default=None
-        Optional calendar window end, ``YYYYMMDD``.
-    as_nx : bool, default=False
-        If ``True``, return a directed NetworkX graph instead of GeoDataFrames.
+    start_time : str | None
+        Optional lower bound (inclusive) in ``HH:MM:SS``.
+    end_time : str | None
+        Optional upper bound (inclusive) in ``HH:MM:SS``.
 
     Returns
     -------
-    tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph
-        ``(nodes_gdf, edges_gdf)`` when ``as_nx`` is ``False``; otherwise a
-        directed NetworkX graph built from those GeoDataFrames.
+    tuple[float | None, float | None]
+        Parsed lower departure bound and upper arrival bound in seconds.
     """
-    tables = _list_tables(con)
-    required = {"stop_times", "stops", "trips"}
-    if not required.issubset(tables):
-        missing = sorted(required - tables)
-        msg = f"GTFS must contain stop_times, stops, and trips. Missing: {', '.join(missing)}"
-        raise ValueError(msg)
-
-    _ensure_graph_sql_support(con)
-    _ensure_stops_geometry(con)
-
     try:
         min_departure_sec = _time_to_seconds(start_time) if start_time is not None else None
         max_arrival_sec = _time_to_seconds(end_time) if end_time is not None else None
@@ -892,6 +938,38 @@ def travel_summary_graph(
         )
         raise ValueError(msg)
 
+    return min_departure_sec, max_arrival_sec
+
+
+def _prepare_service_counts(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    tables: set[str],
+    calendar_start: str | None,
+    calendar_end: str | None,
+) -> None:
+    """
+    Create the temporary ``_service_counts`` table for edge aggregation.
+
+    The table stores the effective number of active service days per
+    ``service_id`` across the resolved calendar window.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection with GTFS tables loaded.
+    tables : set[str]
+        Available table names in the feed.
+    calendar_start : str | None
+        Optional calendar window start in ``YYYYMMDD``.
+    calendar_end : str | None
+        Optional calendar window end in ``YYYYMMDD``.
+
+    Returns
+    -------
+    None
+        The function mutates temporary tables in ``con``.
+    """
     resolved_start, resolved_end, use_date_aware_counts = _resolve_service_window(
         con,
         calendar_start=calendar_start,
@@ -915,19 +993,105 @@ def travel_summary_graph(
             GROUP BY service_id
             """
         )
+        return
+
+    logger.info(
+        "No usable calendar/calendar_dates window found; falling back to sc=1 per service_id."
+    )
+    con.execute(
+        """
+        CREATE OR REPLACE TEMP TABLE _service_counts AS
+        SELECT DISTINCT service_id, 1 AS sc
+        FROM trips
+        WHERE service_id IS NOT NULL
+        """
+    )
+
+
+def _prepare_summary_graph_support(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    tables: set[str],
+    use_frequencies: bool,
+    use_shapes: bool,
+) -> None:
+    """
+    Prepare optional temp tables used by the summary graph query.
+
+    These tables encapsulate optional headway expansion and shape-based edge
+    geometry so the main query stays focused on aggregation.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection with GTFS tables loaded.
+    tables : set[str]
+        Available GTFS table names.
+    use_frequencies : bool
+        Whether to expand ``frequencies.txt`` headways into trip counts.
+    use_shapes : bool
+        Whether to derive edge geometry from GTFS shapes.
+
+    Returns
+    -------
+    None
+        The function creates or replaces temporary support tables.
+    """
+    if use_frequencies:
+        _build_frequency_multipliers(con, tables=tables)
     else:
-        logger.info(
-            "No usable calendar/calendar_dates window found; falling back to sc=1 per service_id."
-        )
         con.execute(
             """
-            CREATE OR REPLACE TEMP TABLE _service_counts AS
-            SELECT DISTINCT service_id, 1 AS sc
+            CREATE OR REPLACE TEMP TABLE _freq_multipliers AS
+            SELECT DISTINCT trip_id, 1 AS multiplier
             FROM trips
-            WHERE service_id IS NOT NULL
             """
         )
 
+    if use_shapes:
+        _build_shape_edge_geometry(con, tables=tables)
+        return
+
+    con.execute(
+        """
+        CREATE OR REPLACE TEMP TABLE _shape_edges (
+            from_stop_id VARCHAR,
+            to_stop_id VARCHAR,
+            geometry GEOMETRY
+        )
+        """
+    )
+
+
+def _build_travel_summary_edges(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    min_departure_sec: float | None,
+    max_arrival_sec: float | None,
+    directed: bool,
+) -> gpd.GeoDataFrame:
+    """
+    Build aggregated stop-to-stop edges for the travel summary graph.
+
+    The result includes weighted average travel times, service frequencies,
+    and either shape-derived or straight-line geometries.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection with prepared temp tables.
+    min_departure_sec : float | None
+        Optional lower departure bound in seconds.
+    max_arrival_sec : float | None
+        Optional upper arrival bound in seconds.
+    directed : bool
+        Whether to preserve edge direction.
+
+    Returns
+    -------
+    gpd.GeoDataFrame
+        Aggregated edge records indexed by stop pairs.
+    """
     edge_query = """
         WITH st AS (
             SELECT
@@ -971,12 +1135,14 @@ def travel_summary_graph(
                 st.stop_id,
                 st.next_stop_id,
                 st.next_arrival_time_sec - st.departure_time_sec AS travel_time,
-                sc.sc AS service_count
+                sc.sc * fm.multiplier AS service_count
             FROM st_filtered st
             JOIN trips t
               ON st.trip_id = t.trip_id
             JOIN _service_counts sc
               ON t.service_id = sc.service_id
+            JOIN _freq_multipliers fm
+              ON st.trip_id = fm.trip_id
             WHERE (st.next_arrival_time_sec - st.departure_time_sec) > 0
               AND sc.sc > 0
         ),
@@ -995,13 +1161,19 @@ def travel_summary_graph(
             a.travel_time_sec,
             CAST(a.frequency AS BIGINT) AS frequency,
             ST_AsText(
-                CASE
-                    WHEN s1.geometry IS NOT NULL AND s2.geometry IS NOT NULL
-                    THEN ST_MakeLine(s1.geometry, s2.geometry)
-                    ELSE NULL
-                END
+                COALESCE(
+                    se.geometry,
+                    CASE
+                        WHEN s1.geometry IS NOT NULL AND s2.geometry IS NOT NULL
+                        THEN ST_MakeLine(s1.geometry, s2.geometry)
+                        ELSE NULL
+                    END
+                )
             ) AS geometry_wkt
         FROM agg_pairs a
+        LEFT JOIN _shape_edges se
+          ON a.stop_id = se.from_stop_id
+         AND a.next_stop_id = se.to_stop_id
         LEFT JOIN _stops_for_graph s1
           ON a.stop_id = s1.stop_id
         LEFT JOIN _stops_for_graph s2
@@ -1014,10 +1186,44 @@ def travel_summary_graph(
         [min_departure_sec, min_departure_sec, max_arrival_sec, max_arrival_sec],
     ).df()
     edges_df = _convert_wkt_column(edges_df)
-    edges_gdf = gpd.GeoDataFrame(edges_df, geometry="geometry", crs="EPSG:4326")
-    if "from_stop_id" in edges_gdf.columns and "to_stop_id" in edges_gdf.columns:
-        edges_gdf = edges_gdf.set_index(["from_stop_id", "to_stop_id"])
 
+    if not directed and not edges_df.empty:
+        swap_mask = edges_df["from_stop_id"] > edges_df["to_stop_id"]
+        edges_df.loc[swap_mask, ["from_stop_id", "to_stop_id"]] = edges_df.loc[
+            swap_mask, ["to_stop_id", "from_stop_id"]
+        ].to_numpy()
+        edges_df["_weighted_tt"] = edges_df["travel_time_sec"] * edges_df["frequency"]
+        agg = edges_df.groupby(["from_stop_id", "to_stop_id"], sort=False).agg(
+            _weighted_tt=("_weighted_tt", "sum"),
+            frequency=("frequency", "sum"),
+            geometry=("geometry", "first"),
+        )
+        agg["travel_time_sec"] = agg["_weighted_tt"] / agg["frequency"]
+        edges_df = agg.drop(columns=["_weighted_tt"]).reset_index()
+
+    edges_gdf = gpd.GeoDataFrame(edges_df, geometry="geometry", crs="EPSG:4326")
+    if {"from_stop_id", "to_stop_id"}.issubset(edges_gdf.columns):
+        edges_gdf = edges_gdf.set_index(["from_stop_id", "to_stop_id"])
+    return edges_gdf
+
+
+def _build_travel_summary_nodes(con: duckdb.DuckDBPyConnection) -> gpd.GeoDataFrame:
+    """
+    Build summary-graph nodes from the prepared stop geometry relation.
+
+    Stop attributes are preserved from ``_stops_for_graph`` and indexed by
+    ``stop_id`` for downstream graph construction.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection with ``_stops_for_graph`` prepared.
+
+    Returns
+    -------
+    gpd.GeoDataFrame
+        Stop records indexed by ``stop_id``.
+    """
     stops_df = con.execute(
         """
         SELECT
@@ -1031,11 +1237,36 @@ def travel_summary_graph(
     nodes_gdf = gpd.GeoDataFrame(stops_df, geometry="geometry", crs="EPSG:4326")
     if "stop_id" in nodes_gdf.columns:
         nodes_gdf = nodes_gdf.set_index("stop_id")
+    return nodes_gdf
 
-    if not as_nx:
-        return nodes_gdf, edges_gdf
 
-    graph = nx.DiGraph()
+def _summary_graph_to_networkx(
+    nodes_gdf: gpd.GeoDataFrame,
+    edges_gdf: gpd.GeoDataFrame,
+    *,
+    directed: bool,
+) -> nx.DiGraph | nx.Graph:
+    """
+    Convert summary-graph GeoDataFrames into a NetworkX graph.
+
+    Node and edge attributes are copied row-wise so the NetworkX graph mirrors
+    the GeoDataFrame representation.
+
+    Parameters
+    ----------
+    nodes_gdf : gpd.GeoDataFrame
+        Summary graph nodes indexed by ``stop_id``.
+    edges_gdf : gpd.GeoDataFrame
+        Summary graph edges indexed by stop pairs.
+    directed : bool
+        Whether to create a directed or undirected graph.
+
+    Returns
+    -------
+    nx.DiGraph | nx.Graph
+        Graph populated with node and edge attributes.
+    """
+    graph = nx.DiGraph() if directed else nx.Graph()
     graph.graph["crs"] = str(nodes_gdf.crs) if nodes_gdf.crs else None
 
     for stop_id, row in nodes_gdf.iterrows():
@@ -1045,3 +1276,107 @@ def travel_summary_graph(
         graph.add_edge(from_stop_id, to_stop_id, **row.to_dict())
 
     return graph
+
+
+def travel_summary_graph(
+    con: duckdb.DuckDBPyConnection,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    calendar_start: str | None = None,
+    calendar_end: str | None = None,
+    as_nx: bool = False,
+    directed: bool = False,
+    use_frequencies: bool = True,
+    use_shapes: bool = True,
+) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.DiGraph | nx.Graph:
+    """
+    Aggregate GTFS service into a weighted stop-to-stop summary graph.
+
+    The function builds a stop-level graph from the GTFS feed, where each edge
+    represents the aggregated service between two consecutive stops.
+
+    Edge attributes
+    ~~~~~~~~~~~~~~~
+    ``travel_time_sec``
+        Service-weighted average travel time in seconds across all trips
+        serving this stop pair.
+    ``frequency``
+        Total number of scheduled leg traversals in the resolved calendar
+        window.  When ``use_frequencies=True`` and ``frequencies.txt`` is
+        present, headway-based services are expanded into effective trip
+        counts.  For example, a trip running every 10 minutes for 1 hour
+        contributes 6 traversals per active service day.
+
+    Edge geometry
+    ~~~~~~~~~~~~~
+    Edge geometry follows the GTFS shape path when ``use_shapes=True`` and
+    ``shapes_geom`` is available; otherwise a straight stop-to-stop line is
+    used.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        DuckDB connection with GTFS tables loaded.
+    start_time : str | None, default=None
+        Optional lower bound (inclusive) for departure time, ``HH:MM:SS``.
+    end_time : str | None, default=None
+        Optional upper bound (inclusive) for next-stop arrival time,
+        ``HH:MM:SS``.
+    calendar_start : str | None, default=None
+        Optional calendar window start, ``YYYYMMDD``.
+    calendar_end : str | None, default=None
+        Optional calendar window end, ``YYYYMMDD``.
+    as_nx : bool, default=False
+        If ``True``, return a NetworkX graph instead of GeoDataFrames.
+    directed : bool, default=False
+        If ``True``, return a directed graph (``nx.DiGraph``) preserving
+        trip direction.  If ``False`` (default), edges in opposite
+        directions are merged into undirected edges (``nx.Graph``).
+    use_frequencies : bool, default=True
+        If ``True`` and ``frequencies.txt`` exists, expand headway-based
+        service into effective trip counts for the ``frequency`` attribute.
+    use_shapes : bool, default=True
+        If ``True`` and ``shapes_geom`` is available, derive edge geometry
+        from the GTFS shape path instead of straight stop-to-stop lines.
+
+    Returns
+    -------
+    tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.DiGraph | nx.Graph
+        ``(nodes_gdf, edges_gdf)`` when ``as_nx`` is ``False``; otherwise
+        a ``nx.DiGraph`` (``directed=True``) or ``nx.Graph``
+        (``directed=False``) built from those GeoDataFrames.
+    """
+    tables = _list_tables(con)
+    required = {"stop_times", "stops", "trips"}
+    if not required.issubset(tables):
+        missing = sorted(required - tables)
+        msg = f"GTFS must contain stop_times, stops, and trips. Missing: {', '.join(missing)}"
+        raise ValueError(msg)
+
+    _ensure_graph_sql_support(con)
+    _ensure_stops_geometry(con)
+    min_departure_sec, max_arrival_sec = _resolve_time_bounds(start_time, end_time)
+    _prepare_service_counts(
+        con,
+        tables=tables,
+        calendar_start=calendar_start,
+        calendar_end=calendar_end,
+    )
+    _prepare_summary_graph_support(
+        con,
+        tables=tables,
+        use_frequencies=use_frequencies,
+        use_shapes=use_shapes,
+    )
+    edges_gdf = _build_travel_summary_edges(
+        con,
+        min_departure_sec=min_departure_sec,
+        max_arrival_sec=max_arrival_sec,
+        directed=directed,
+    )
+    nodes_gdf = _build_travel_summary_nodes(con)
+
+    if not as_nx:
+        return nodes_gdf, edges_gdf
+
+    return _summary_graph_to_networkx(nodes_gdf, edges_gdf, directed=directed)

--- a/city2graph/transportation.py
+++ b/city2graph/transportation.py
@@ -500,10 +500,8 @@ def load_gtfs(path: str | Path) -> duckdb.DuckDBPyConnection:
     Load a GTFS ZIP archive into an in-memory DuckDB database.
 
     The function reads ``*.txt`` GTFS files as tables, registers a time parsing
-    UDF, and materializes optional spatial helpers:
-
-    - ``stops.geometry`` as points from ``stop_lon``/``stop_lat``
-    - ``shapes_geom`` as one polyline per ``shape_id``
+    UDF, and materializes ``stops.geometry`` as points from
+    ``stop_lon``/``stop_lat`` when stop coordinates are available.
 
     Parameters
     ----------
@@ -549,24 +547,6 @@ def load_gtfs(path: str | Path) -> duckdb.DuckDBPyConnection:
             ALTER TABLE stops ADD COLUMN geometry GEOMETRY;
             UPDATE stops SET geometry = ST_Point(CAST(NULLIF(stop_lon, '') AS DOUBLE), CAST(NULLIF(stop_lat, '') AS DOUBLE))
             WHERE try_cast(NULLIF(stop_lon, '') as DOUBLE) IS NOT NULL AND try_cast(NULLIF(stop_lat, '') as DOUBLE) IS NOT NULL;
-        """)
-
-    if "shapes" in tables:
-        con.execute("""
-            CREATE TABLE shapes_geom AS
-            SELECT
-                shape_id,
-                ST_MakeLine(
-                    list(
-                        ST_Point(
-                            CAST(NULLIF(shape_pt_lon, '') AS DOUBLE),
-                            CAST(NULLIF(shape_pt_lat, '') AS DOUBLE)
-                        ) ORDER BY CAST(NULLIF(shape_pt_sequence, '') AS INTEGER)
-                    )
-                ) AS geometry
-            FROM shapes
-            WHERE try_cast(NULLIF(shape_pt_lon, '') as DOUBLE) IS NOT NULL AND try_cast(NULLIF(shape_pt_lat, '') as DOUBLE) IS NOT NULL
-            GROUP BY shape_id;
         """)
 
     logger.info("GTFS loaded: %s", ", ".join(tables))
@@ -637,104 +617,6 @@ def _build_frequency_multipliers(
         SELECT * FROM freq_trips
         UNION ALL
         SELECT * FROM non_freq_trips
-        """
-    )
-
-
-def _build_shape_edge_geometry(
-    con: duckdb.DuckDBPyConnection,
-    *,
-    tables: set[str],
-) -> None:
-    """
-    Build a temp table mapping stop-pairs to shape-derived edge geometries.
-
-    For each directed ``(from_stop_id, to_stop_id)`` pair, the function finds
-    the most common ``shape_id`` among trips serving that pair, then extracts
-    the sub-linestring between the two stop projections on the shape.
-
-    Parameters
-    ----------
-    con : duckdb.DuckDBPyConnection
-        Open DuckDB connection.
-    tables : set[str]
-        Available GTFS table names.
-
-    Returns
-    -------
-    None
-        Creates or replaces the ``_shape_edges`` temp table with columns
-        ``(from_stop_id, to_stop_id, geometry)``.
-    """
-    trip_cols = _table_columns(con, "trips")
-    if "shapes_geom" not in tables or "shape_id" not in trip_cols:
-        con.execute(
-            """
-            CREATE OR REPLACE TEMP TABLE _shape_edges (
-                from_stop_id VARCHAR,
-                to_stop_id VARCHAR,
-                geometry GEOMETRY
-            )
-            """
-        )
-        return
-
-    con.execute(
-        """
-        CREATE OR REPLACE TEMP TABLE _shape_edges AS
-        WITH stop_pairs_shapes AS (
-            SELECT
-                st1.stop_id AS from_stop_id,
-                st2.stop_id AS to_stop_id,
-                t.shape_id,
-                COUNT(*) AS cnt
-            FROM stop_times st1
-            JOIN stop_times st2
-              ON st1.trip_id = st2.trip_id
-             AND CAST(st2.stop_sequence AS INTEGER) = CAST(st1.stop_sequence AS INTEGER) + 1
-            JOIN trips t
-              ON st1.trip_id = t.trip_id
-            WHERE t.shape_id IS NOT NULL
-              AND t.shape_id != ''
-              AND try_cast(st1.stop_sequence AS INTEGER) IS NOT NULL
-              AND try_cast(st2.stop_sequence AS INTEGER) IS NOT NULL
-            GROUP BY st1.stop_id, st2.stop_id, t.shape_id
-        ),
-        ranked AS (
-            SELECT *,
-                   ROW_NUMBER() OVER (
-                       PARTITION BY from_stop_id, to_stop_id
-                       ORDER BY cnt DESC
-                   ) AS rn
-            FROM stop_pairs_shapes
-        ),
-        best_shape AS (
-            SELECT from_stop_id, to_stop_id, shape_id
-            FROM ranked
-            WHERE rn = 1
-        )
-        SELECT
-            bs.from_stop_id,
-            bs.to_stop_id,
-            CASE
-                WHEN sg.geometry IS NOT NULL
-                 AND s1.geometry IS NOT NULL
-                 AND s2.geometry IS NOT NULL
-                 AND ST_LineLocatePoint(sg.geometry, s1.geometry) IS NOT NULL
-                 AND ST_LineLocatePoint(sg.geometry, s2.geometry) IS NOT NULL
-                 AND ST_LineLocatePoint(sg.geometry, s1.geometry)
-                    < ST_LineLocatePoint(sg.geometry, s2.geometry)
-                THEN ST_LineSubstring(
-                    sg.geometry,
-                    ST_LineLocatePoint(sg.geometry, s1.geometry),
-                    ST_LineLocatePoint(sg.geometry, s2.geometry)
-                )
-                ELSE NULL
-            END AS geometry
-        FROM best_shape bs
-        JOIN shapes_geom sg ON bs.shape_id = sg.shape_id
-        LEFT JOIN _stops_for_graph s1 ON bs.from_stop_id = s1.stop_id
-        LEFT JOIN _stops_for_graph s2 ON bs.to_stop_id = s2.stop_id
         """
     )
 
@@ -1013,13 +895,12 @@ def _prepare_summary_graph_support(
     *,
     tables: set[str],
     use_frequencies: bool,
-    use_shapes: bool,
 ) -> None:
     """
     Prepare optional temp tables used by the summary graph query.
 
-    These tables encapsulate optional headway expansion and shape-based edge
-    geometry so the main query stays focused on aggregation.
+    These tables encapsulate optional headway expansion so the main query stays
+    focused on aggregation.
 
     Parameters
     ----------
@@ -1029,8 +910,6 @@ def _prepare_summary_graph_support(
         Available GTFS table names.
     use_frequencies : bool
         Whether to expand ``frequencies.txt`` headways into trip counts.
-    use_shapes : bool
-        Whether to derive edge geometry from GTFS shapes.
 
     Returns
     -------
@@ -1048,20 +927,6 @@ def _prepare_summary_graph_support(
             """
         )
 
-    if use_shapes:
-        _build_shape_edge_geometry(con, tables=tables)
-        return
-
-    con.execute(
-        """
-        CREATE OR REPLACE TEMP TABLE _shape_edges (
-            from_stop_id VARCHAR,
-            to_stop_id VARCHAR,
-            geometry GEOMETRY
-        )
-        """
-    )
-
 
 def _build_travel_summary_edges(
     con: duckdb.DuckDBPyConnection,
@@ -1074,7 +939,7 @@ def _build_travel_summary_edges(
     Build aggregated stop-to-stop edges for the travel summary graph.
 
     The result includes weighted average travel times, service frequencies,
-    and either shape-derived or straight-line geometries.
+    and stop-to-stop line geometries.
 
     Parameters
     ----------
@@ -1161,19 +1026,13 @@ def _build_travel_summary_edges(
             a.travel_time_sec,
             CAST(a.frequency AS BIGINT) AS frequency,
             ST_AsText(
-                COALESCE(
-                    se.geometry,
-                    CASE
-                        WHEN s1.geometry IS NOT NULL AND s2.geometry IS NOT NULL
-                        THEN ST_MakeLine(s1.geometry, s2.geometry)
-                        ELSE NULL
-                    END
-                )
+                CASE
+                    WHEN s1.geometry IS NOT NULL AND s2.geometry IS NOT NULL
+                    THEN ST_MakeLine(s1.geometry, s2.geometry)
+                    ELSE NULL
+                END
             ) AS geometry_wkt
         FROM agg_pairs a
-        LEFT JOIN _shape_edges se
-          ON a.stop_id = se.from_stop_id
-         AND a.next_stop_id = se.to_stop_id
         LEFT JOIN _stops_for_graph s1
           ON a.stop_id = s1.stop_id
         LEFT JOIN _stops_for_graph s2
@@ -1287,7 +1146,6 @@ def travel_summary_graph(
     as_nx: bool = False,
     directed: bool = False,
     use_frequencies: bool = True,
-    use_shapes: bool = True,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.DiGraph | nx.Graph:
     """
     Aggregate GTFS service into a weighted stop-to-stop summary graph.
@@ -1309,9 +1167,7 @@ def travel_summary_graph(
 
     Edge geometry
     ~~~~~~~~~~~~~
-    Edge geometry follows the GTFS shape path when ``use_shapes=True`` and
-    ``shapes_geom`` is available; otherwise a straight stop-to-stop line is
-    used.
+    Edge geometry is represented as a straight stop-to-stop line.
 
     Parameters
     ----------
@@ -1335,9 +1191,6 @@ def travel_summary_graph(
     use_frequencies : bool, default=True
         If ``True`` and ``frequencies.txt`` exists, expand headway-based
         service into effective trip counts for the ``frequency`` attribute.
-    use_shapes : bool, default=True
-        If ``True`` and ``shapes_geom`` is available, derive edge geometry
-        from the GTFS shape path instead of straight stop-to-stop lines.
 
     Returns
     -------
@@ -1366,7 +1219,6 @@ def travel_summary_graph(
         con,
         tables=tables,
         use_frequencies=use_frequencies,
-        use_shapes=use_shapes,
     )
     edges_gdf = _build_travel_summary_edges(
         con,

--- a/city2graph/transportation.py
+++ b/city2graph/transportation.py
@@ -1,862 +1,830 @@
 """
-Transportation Network Analysis Module.
+GTFS transportation network utilities.
 
-This module provides comprehensive functionality for processing General Transit Feed
-Specification (GTFS) data and creating transportation network representations. It
-specializes in converting public transit data into graph structures suitable for
-network analysis and accessibility studies.
-
-All functions return ready-to-use pandas/GeoPandas
-objects or NetworkX graphs that can be seamlessly integrated into analysis
-pipelines, notebooks, or model training workflows.
+The functions in this module load GTFS feeds into DuckDB, derive stop-to-stop
+origin/destination records, and aggregate those records into transport summary
+graphs for downstream network analysis.
 """
 
-# Future annotations for type hints
 from __future__ import annotations
 
-# Standard library imports
-import contextlib
-import io
 import logging
+import tempfile
 import zipfile
+from contextlib import suppress
 from datetime import datetime
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-# Third-party imports
+import duckdb
 import geopandas as gpd
+import networkx as nx
 import pandas as pd
-from shapely.geometry import LineString
-from shapely.geometry import Point
+from shapely import wkt
 
-# Local imports
-from .utils import gdf_to_nx  # pragma: no cover
-
-# Type checking imports
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    import networkx as nx
-
-# Module logger configuration
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 __all__ = ["get_od_pairs", "load_gtfs", "travel_summary_graph"]
 
+_ACTIVE_DATES_TABLE_SQL = """
+    CREATE OR REPLACE TEMP TABLE _active_dates (
+        service_id VARCHAR,
+        active_date DATE
+    )
+"""
 
-# =============================================================================
-# INTERNAL HELPER FUNCTIONS
-# =============================================================================
-# All helper functions are private (underscore-prefixed) and support the
-# main public API functions. They handle low-level data processing tasks
-# such as CSV parsing, time conversion, and GTFS data validation.
+_CALENDAR_DATES_PARSED_SQL = """
+    CREATE OR REPLACE TEMP TABLE _cal_dates_parsed AS
+    SELECT service_id, exception_type, cast(strptime(date, '%Y%m%d') as date) as parsed_date
+    FROM calendar_dates
+"""
 
-# -----------------------------------------------------------------------------
-# CSV Processing Utilities
-# -----------------------------------------------------------------------------
+_BASE_ACTIVE_DATES_INSERT_SQL = """
+    INSERT INTO _active_dates
+    WITH RECURSIVE dates AS (
+        SELECT cast(strptime('{start_date}', '%Y%m%d') as date) as d
+        UNION ALL
+        SELECT d + interval 1 day
+        FROM dates
+        WHERE d < cast(strptime('{end_date}', '%Y%m%d') as date)
+    ),
+    base_services AS (
+        SELECT
+            c.service_id,
+            d.d as active_date
+        FROM calendar c
+        CROSS JOIN dates d
+        WHERE d.d BETWEEN cast(strptime(c.start_date, '%Y%m%d') as date)
+                    AND cast(strptime(c.end_date, '%Y%m%d') as date)
+          AND 1 = CASE
+              WHEN isodow(d.d) = 1 THEN try_cast(c.monday as integer)
+              WHEN isodow(d.d) = 2 THEN try_cast(c.tuesday as integer)
+              WHEN isodow(d.d) = 3 THEN try_cast(c.wednesday as integer)
+              WHEN isodow(d.d) = 4 THEN try_cast(c.thursday as integer)
+              WHEN isodow(d.d) = 5 THEN try_cast(c.friday as integer)
+              WHEN isodow(d.d) = 6 THEN try_cast(c.saturday as integer)
+              WHEN isodow(d.d) = 7 THEN try_cast(c.sunday as integer)
+              ELSE 0
+          END
+    )
+    SELECT service_id, active_date FROM base_services
+"""
 
 
-def _read_csv_bytes(buf: bytes) -> pd.DataFrame:
-    r"""
-    Read a CSV sitting entirely in memory and return *string-typed* columns.
+def _list_tables(con: duckdb.DuckDBPyConnection) -> set[str]:
+    """
+    Return table names present in the current DuckDB connection.
 
-    This function reads CSV data from a bytes buffer and ensures all columns
-    are returned as string type for consistent processing.
+    This helper centralizes table discovery so call sites stay concise.
 
     Parameters
     ----------
-    buf : bytes
-        Bytes buffer containing CSV data.
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
 
     Returns
     -------
-    pd.DataFrame
-        DataFrame with all columns as string type.
-
-    See Also
-    --------
-    _load_gtfs_zip : Load GTFS data from zip file.
-
-    Examples
-    --------
-    >>> import io
-    >>> csv_data = b"col1,col2\\n1,2\\n3,4"
-    >>> df = _read_csv_bytes(csv_data)
+    set[str]
+        Set of relation names returned by ``SHOW TABLES``.
     """
-    return pd.read_csv(io.BytesIO(buf), dtype=str, encoding="utf-8-sig")
+    return {row[0] for row in con.execute("SHOW TABLES").fetchall()}
 
 
-def _time_to_seconds(value: str | float | None) -> float:
+def _convert_wkt_column(
+    df: pd.DataFrame,
+    *,
+    wkt_column: str = "geometry_wkt",
+    geometry_column: str = "geometry",
+) -> pd.DataFrame:
     """
-    Convert a GTFS ``HH:MM:SS`` string (24 h+ supported) into seconds.
+    Convert a WKT column to shapely geometry and drop the original WKT column.
 
-    This function converts GTFS time format strings to seconds since midnight,
-    supporting times beyond 24:00:00 for next-day services.
-
-    Parameters
-    ----------
-    value : str, float, or None
-        Time value in HH:MM:SS format or numeric seconds.
-
-    Returns
-    -------
-    float
-        Time converted to seconds since midnight.
-
-    See Also
-    --------
-    _timestamp : Combine GTFS time with date to create timestamp.
-
-    Examples
-    --------
-    >>> seconds = _time_to_seconds("14:30:45")
-    >>> print(seconds)  # 52245.0
-    """
-    # Convert None and numeric values to float directly
-    if not isinstance(value, str):
-        return float(value or 0)
-
-    # At this point, value must be a string - parse time
-    try:
-        h, m, s = map(int, value.split(":"))
-        return h * 3600 + m * 60 + s
-    except (ValueError, AttributeError):
-        # Handle string representations of numeric values (e.g. "3600.0")
-        return float(value)
-
-
-def _timestamp(gtfs_time: str | float | None, service_date: datetime) -> datetime | None:
-    """
-    Combine a GTFS time string with a **date** producing a proper timestamp.
-
-    Times beyond 24:00:00 are correctly rolled over to the next day.
-    This function handles GTFS time format and creates proper datetime objects.
-
-    Parameters
-    ----------
-    gtfs_time : str, float, or None
-        Time value in GTFS HH:MM:SS format or numeric seconds.
-    service_date : datetime
-        The service date to combine with the time.
-
-    Returns
-    -------
-    datetime or None
-        Combined timestamp, or None if gtfs_time is None.
-
-    See Also
-    --------
-    _time_to_seconds : Convert GTFS time string to seconds.
-
-    Examples
-    --------
-    >>> from datetime import datetime
-    >>> date = datetime(2023, 1, 1)
-    >>> ts = _timestamp("14:30:00", date)
-    """
-    if not isinstance(gtfs_time, str):
-        # Handle None or numeric values by converting to seconds first
-        seconds = _time_to_seconds(gtfs_time)
-        h, remainder = divmod(int(seconds), 3600)
-        m, s = divmod(remainder, 60)
-        day_offset, h = divmod(h, 24)
-        return service_date.replace(hour=h, minute=m, second=s) + timedelta(days=day_offset)
-
-    # Try parsing as HH:MM:SS; fall back to numeric interpretation
-    try:
-        h, m, s = map(int, gtfs_time.split(":"))
-    except (ValueError, AttributeError):
-        seconds = _time_to_seconds(gtfs_time)
-        h, remainder = divmod(int(seconds), 3600)
-        m, s = divmod(remainder, 60)
-    day_offset, h = divmod(h, 24)
-    return service_date.replace(hour=h, minute=m, second=s) + timedelta(days=day_offset)
-
-
-# ---------------------------------------------------------------------------
-# GTFS reading & basic clean-up helpers
-# ---------------------------------------------------------------------------
-
-
-def _load_gtfs_zip(path: str | Path) -> dict[str, pd.DataFrame]:
-    """
-    Unzip every *.txt* file found inside *path* into a raw DataFrame.
-
-    This function extracts and loads all GTFS text files from a zip archive
-    into pandas DataFrames for processing.
-
-    Parameters
-    ----------
-    path : str or Path
-        Path to the GTFS zip file.
-
-    Returns
-    -------
-    dict
-        Dictionary mapping GTFS file names (without .txt extension) to DataFrames.
-
-    See Also
-    --------
-    _read_csv_bytes : Read CSV data from bytes buffer.
-
-    Examples
-    --------
-    >>> gtfs_data = _load_gtfs_zip("gtfs.zip")
-    >>> print(list(gtfs_data.keys()))  # ['stops', 'routes', 'trips', ...]
-    """
-    gtfs: dict[str, pd.DataFrame] = {}
-    with zipfile.ZipFile(path) as zf:
-        for name in zf.namelist():
-            if name.endswith(".txt") and not name.endswith("/"):
-                try:
-                    key = name.rsplit("/", 1)[-1].replace(".txt", "")
-                    gtfs[key] = _read_csv_bytes(zf.read(name))
-                except Exception:  # pragma: no cover
-                    logger.exception("Could not read %s", name)
-    return gtfs
-
-
-def _coerce_types(gtfs: dict[str, pd.DataFrame]) -> None:
-    """
-    Cast common numeric / boolean columns **in-place** for easier analysis.
-
-    This function converts string columns to appropriate numeric and boolean
-    types for GTFS data processing and analysis.
-
-    Parameters
-    ----------
-    gtfs : dict
-        Dictionary of GTFS DataFrames to process in-place.
-
-    See Also
-    --------
-    _load_gtfs_zip : Load GTFS data from zip file.
-
-    Examples
-    --------
-    >>> gtfs_data = {'stops': pd.DataFrame({'stop_lat': ['1.0', '2.0']})}
-    >>> _coerce_types(gtfs_data)
-    >>> print(gtfs_data['stops']['stop_lat'].dtype)  # float64
-    """
-    # Coerce stops.txt coordinates
-    if (stops := gtfs.get("stops")) is not None:
-        for col in ("stop_lat", "stop_lon"):
-            stops[col] = pd.to_numeric(stops[col], errors="coerce")
-
-    # Coerce routes.txt route_type
-    if (routes := gtfs.get("routes")) is not None and "route_type" in routes:
-        routes["route_type"] = pd.to_numeric(routes["route_type"], errors="coerce")
-
-    # Coerce calendar.txt weekday flags
-    if (cal := gtfs.get("calendar")) is not None:
-        weekdays = (
-            "monday",
-            "tuesday",
-            "wednesday",
-            "thursday",
-            "friday",
-            "saturday",
-            "sunday",
-        )
-        for d in weekdays:
-            if d in cal.columns:
-                cal[d] = cal[d].astype(float).fillna(0).astype(bool)
-
-
-def _get_service_counts(
-    gtfs_data: dict[str, pd.DataFrame | gpd.GeoDataFrame],
-    start_date_str: str,
-    end_date_str: str,
-) -> pd.Series:
-    """
-    Calculate the number of active days for each service_id within a date range.
-
-    This function analyzes GTFS calendar data to determine how many days each
-    service operates within the specified date range, considering both regular
-    calendar schedules and calendar date exceptions.
-
-    Parameters
-    ----------
-    gtfs_data : dict[str, pd.DataFrame | gpd.GeoDataFrame]
-        Dictionary containing GTFS data tables with 'calendar' and optionally
-        'calendar_dates' keys.
-    start_date_str : str
-        Start date in YYYYMMDD format.
-    end_date_str : str
-        End date in YYYYMMDD format.
-
-    Returns
-    -------
-    pd.Series
-        Series with service_id as index and count of active days as values.
-
-    See Also
-    --------
-    _get_service_dates_from_calendar : Get service dates from calendar.
-    _get_service_dates_from_calendar_dates : Get service dates from calendar_dates.
-
-    Examples
-    --------
-    >>> gtfs_data = {'calendar': calendar_df, 'calendar_dates': calendar_dates_df}
-    >>> counts = _get_service_counts(gtfs_data, "20230101", "20230131")
-    >>> counts.head()
-    service_id
-    1    31
-    2    22
-    dtype: int64
-    """
-    calendar = gtfs_data.get("calendar")
-    calendar_dates = gtfs_data.get("calendar_dates")
-
-    start_date = datetime.strptime(start_date_str, "%Y%m%d")
-    end_date = datetime.strptime(end_date_str, "%Y%m%d")
-
-    # Create a date range and map each date to its weekday name
-    all_dates = pd.to_datetime(pd.date_range(start=start_date, end=end_date, freq="D"))
-    date_df = pd.DataFrame({"date": all_dates, "day_name": all_dates.strftime("%A").str.lower()})
-
-    service_days = pd.Series(dtype=int)
-
-    # Process regular service days from calendar.txt
-    if calendar is not None:
-        cal_df = calendar.melt(
-            id_vars=["service_id", "start_date", "end_date"],
-            value_vars=[
-                "monday",
-                "tuesday",
-                "wednesday",
-                "thursday",
-                "friday",
-                "saturday",
-                "sunday",
-            ],
-            var_name="day_name",
-            value_name="is_active",
-        )
-        cal_df = cal_df[cal_df["is_active"] == 1]
-
-        # Merge with the date range to find active dates
-        merged = cal_df.merge(date_df, on="day_name")
-        merged["start_date"] = pd.to_datetime(merged["start_date"], format="%Y%m%d")
-        merged["end_date"] = pd.to_datetime(merged["end_date"], format="%Y%m%d")
-
-        # Filter dates within the service period
-        active_days = merged[
-            (merged["date"] >= merged["start_date"]) & (merged["date"] <= merged["end_date"])
-        ]
-        service_days = active_days.groupby("service_id").size()
-
-    # Process calendar date exceptions from calendar_dates.txt
-    if calendar_dates is not None:
-        # Filter calendar_dates to our date range
-        calendar_dates_filtered = calendar_dates.copy()
-        calendar_dates_filtered["date"] = pd.to_datetime(
-            calendar_dates_filtered["date"],
-            format="%Y%m%d",
-        )
-        calendar_dates_filtered = calendar_dates_filtered[
-            (calendar_dates_filtered["date"] >= start_date)
-            & (calendar_dates_filtered["date"] <= end_date)
-        ]
-
-        # Process both added (1) and removed (2) service exceptions
-        for exception_type, operation in [(1, service_days.add), (2, service_days.subtract)]:
-            exception_services = calendar_dates_filtered[
-                calendar_dates_filtered["exception_type"] == exception_type
-            ]
-            if not exception_services.empty:
-                exception_counts = exception_services.groupby("service_id").size()
-                service_days = operation(exception_counts, fill_value=0)
-
-    return service_days.astype(int).clip(lower=0)
-
-
-# ---------------------------------------------------------------------------
-# Geometry builders
-# ---------------------------------------------------------------------------
-
-
-def _point_geometries(df: pd.DataFrame) -> gpd.GeoSeries:
-    """
-    Return an EPSG:4326 GeoSeries built from ``stop_lon`` / ``stop_lat``.
-
-    This function creates Point geometries from longitude and latitude columns
-    in a DataFrame, handling missing values appropriately.
+    This keeps repeated WKT parsing logic in one place.
 
     Parameters
     ----------
     df : pd.DataFrame
-        DataFrame containing 'stop_lon' and 'stop_lat' columns.
-
-    Returns
-    -------
-    gpd.GeoSeries
-        GeoSeries with Point geometries in EPSG:4326 coordinate system.
-
-    See Also
-    --------
-    _linestring_geometries : Create LineString geometries from shapes.
-
-    Examples
-    --------
-    >>> df = pd.DataFrame({'stop_lon': [-74.0, -74.1], 'stop_lat': [40.7, 40.8]})
-    >>> geoms = _point_geometries(df)
-    >>> geoms.iloc[0]
-    <POINT (-74 40.7)>
-    """
-    pts = [
-        Point(lon, lat) if pd.notna(lon) and pd.notna(lat) else None
-        for lon, lat in zip(df["stop_lon"], df["stop_lat"], strict=False)
-    ]
-    return gpd.GeoSeries(pts, crs="EPSG:4326")
-
-
-def _linestring_geometries(shapes: pd.DataFrame) -> gpd.GeoSeries:
-    """
-    Create LineStrings grouped by *shape_id* ordered by *shape_pt_sequence*.
-
-    This function groups shape points by shape_id and creates LineString
-    geometries from the ordered sequence of coordinates.
-
-    Parameters
-    ----------
-    shapes : pd.DataFrame
-        DataFrame containing 'shape_id', 'shape_pt_lat', 'shape_pt_lon',
-        and 'shape_pt_sequence' columns.
-
-    Returns
-    -------
-    gpd.GeoSeries
-        GeoSeries with LineString geometries for each shape_id.
-
-    See Also
-    --------
-    _point_geometries : Create Point geometries from coordinates.
-
-    Examples
-    --------
-    >>> shapes = pd.DataFrame({
-    ...     'shape_id': ['A', 'A'], 'shape_pt_lat': [40.7, 40.8],
-    ...     'shape_pt_lon': [-74.0, -74.1], 'shape_pt_sequence': [1, 2]
-    ... })
-    >>> geoms = _linestring_geometries(shapes)
-    >>> geoms.iloc[0]
-    <LINESTRING (-74 40.7, -74.1 40.8)>
-    """
-    # Ensure the relevant columns are numeric
-    shapes = shapes.copy()
-    shapes[["shape_pt_lat", "shape_pt_lon", "shape_pt_sequence"]] = shapes[
-        ["shape_pt_lat", "shape_pt_lon", "shape_pt_sequence"]
-    ].apply(pd.to_numeric, errors="coerce")
-
-    # Drop rows with NaN coordinates and sort by shape_id and sequence
-    shapes = shapes.dropna().sort_values(["shape_id", "shape_pt_sequence"])
-
-    # Create LineString geometries for each shape_id
-    geoms: dict[str, LineString] = {}
-    for sid, grp in shapes.groupby("shape_id"):
-        pts = [
-            Point(lon, lat)
-            for lon, lat in zip(grp["shape_pt_lon"], grp["shape_pt_lat"], strict=False)
-        ]
-        if len(pts) >= 2:
-            geoms[str(sid)] = LineString(pts)
-    return gpd.GeoSeries(geoms, crs="EPSG:4326")
-
-
-# ===========================================================================
-# PUBLIC HELPERS
-# ===========================================================================
-
-
-def load_gtfs(path: str | Path) -> dict[str, pd.DataFrame | gpd.GeoDataFrame]:
-    """
-    Parse a GTFS zip file and enrich stops/shapes with geometry.
-
-    This function loads a GTFS (General Transit Feed Specification) zip file
-    and converts it into a dictionary of pandas/GeoPandas DataFrames. Stop
-    locations and route shapes are automatically converted to geometric objects
-    for spatial analysis.
-
-    Parameters
-    ----------
-    path : str or pathlib.Path
-        Location of the zipped GTFS feed (e.g. ``"./rome_gtfs.zip"``).
-
-    Returns
-    -------
-    dict[str, pandas.DataFrame or geopandas.GeoDataFrame]
-        Keys are the original GTFS file names (without extension) and values
-        are pandas or GeoPandas DataFrames ready for analysis.
-
-    See Also
-    --------
-    get_od_pairs : Create origin-destination pairs from GTFS data.
-    travel_summary_graph : Create network representation from GTFS data.
-
-    Notes
-    -----
-    *   The function never mutates the original file - everything is kept
-        in memory.
-    *   Geometry columns are added **only** when the relevant coordinate
-        columns are present and valid.
-
-    Examples
-    --------
-    >>> from pathlib import Path
-    >>> gtfs = load_gtfs(Path("data/rome_gtfs.zip"))
-    >>> print(list(gtfs))
-    ['agency', 'routes', 'trips', 'stops', ...]
-    >>> gtfs['stops'].head(3)[['stop_name', 'geometry']]
-           stop_name                     geometry
-    0  Termini (MA)  POINT (12.50118 41.90088)
-    1   Colosseo(MB)  POINT (12.49224 41.89021)
-    """
-    # Validate input path
-    gtfs = _load_gtfs_zip(path)
-    if not gtfs:
-        logger.warning("No GTFS files found in %s", path)
-        return gtfs
-
-    _coerce_types(gtfs)
-
-    # Attach geometries to stops and shapes
-    if (stops := gtfs.get("stops")) is not None and {"stop_lat", "stop_lon"} <= set(stops):
-        geo = _point_geometries(stops)
-        gtfs["stops"] = gpd.GeoDataFrame(
-            stops.dropna(subset=["stop_lat", "stop_lon"]),
-            geometry=geo,
-            crs="EPSG:4326",
-        )
-
-    # Attach geometries to shapes if available
-    if (shapes := gtfs.get("shapes")) is not None:
-        geo = _linestring_geometries(shapes)
-        if not geo.empty:
-            gtfs["shapes"] = gpd.GeoDataFrame(shapes, geometry=geo, crs="EPSG:4326")
-
-    logger.info("GTFS loaded: %s", ", ".join(gtfs))
-    return gtfs
-
-
-# ---------------------------------------------------------------------------
-# ORIGIN-DESTINATION PAIRS
-# ---------------------------------------------------------------------------
-
-
-def _create_basic_od(stop_times: pd.DataFrame) -> pd.DataFrame:
-    """
-    Within each trip build successive stop pairs (u → v).
-
-    This function processes GTFS stop_times data to create origin-destination
-    pairs by pairing consecutive stops within each trip.
-
-    Parameters
-    ----------
-    stop_times : pd.DataFrame
-        GTFS stop_times DataFrame with trip_id, stop_id, and stop_sequence columns.
+        DataFrame containing WKT text geometry.
+    wkt_column : str, default="geometry_wkt"
+        Column containing geometry encoded as WKT.
+    geometry_column : str, default="geometry"
+        Destination column for parsed shapely geometries.
 
     Returns
     -------
     pd.DataFrame
-        DataFrame with origin-destination pairs and trip information.
-
-    See Also
-    --------
-    get_od_pairs : Create comprehensive OD pairs with service dates.
-
-    Examples
-    --------
-    >>> stop_times = pd.DataFrame({
-    ...     'trip_id': ['T1', 'T1'], 'stop_id': ['S1', 'S2'], 'stop_sequence': [1, 2]
-    ... })
-    >>> od_pairs = _create_basic_od(stop_times)
+        Updated DataFrame with parsed geometry and without ``wkt_column``.
     """
-    # Ensure stop_times has the necessary columns and types
-    st = stop_times.copy()
-    # Coerce time columns: convert to object dtype first (to support mixed
-    # types from Arrow-backed string columns), then stringify non-string values.
-    for col in ("arrival_time", "departure_time"):
-        if col in st.columns:
-            st[col] = (
-                st[col]
-                .astype(object)
-                .map(lambda v: str(v) if pd.notna(v) and not isinstance(v, str) else v)
-            )
-    st["stop_sequence"] = pd.to_numeric(st["stop_sequence"], errors="coerce")
-    st = st.dropna(subset=["stop_sequence"]).sort_values(["trip_id", "stop_sequence"])
-
-    # Shift stop_id and arrival_time to create pairs
-    lead = st.groupby("trip_id").shift(1)
-    mask = lead["stop_id"].notna()
-
-    od = pd.DataFrame(
-        {
-            "trip_id": st.loc[mask, "trip_id"],
-            "service_id": st.loc[mask, "service_id"],
-            "orig_stop_id": st.loc[mask, "stop_id"],
-            "dest_stop_id": lead.loc[mask, "stop_id"],
-            "departure_time": st.loc[mask, "departure_time"],
-            "arrival_time": lead.loc[mask, "arrival_time"],
-        },
+    df[geometry_column] = df[wkt_column].apply(
+        lambda value: wkt.loads(value) if pd.notna(value) else None
     )
-    return od.reset_index(drop=True)
+    return df.drop(columns=[wkt_column])
 
 
-def _service_day_map(
-    calendar: pd.DataFrame,
-    start: datetime,
-    end: datetime,
-) -> dict[str, list[datetime]]:
-    """
-    Return ``{service_id: [date, …]}`` within the given period.
-
-    This function processes GTFS calendar data to create a mapping of service IDs
-    to their active dates within the specified time period.
-
-    Parameters
-    ----------
-    calendar : pd.DataFrame
-        GTFS calendar DataFrame containing service schedule information.
-    start : datetime
-        Start date for the period of interest.
-    end : datetime
-        End date for the period of interest.
-
-    Returns
-    -------
-    dict[str, list[datetime]]
-        Dictionary mapping service_id to list of active dates.
-
-    See Also
-    --------
-    _apply_calendar_exceptions : Apply calendar date exceptions.
-
-    Examples
-    --------
-    >>> from datetime import datetime
-    >>> calendar = pd.DataFrame({'service_id': ['S1'], 'monday': [1]})
-    >>> start = datetime(2023, 1, 1)
-    >>> end = datetime(2023, 1, 7)
-    >>> service_map = _service_day_map(calendar, start, end)
-    """
-    # Prepare the calendar table
-    day_idx = {
-        0: "monday",
-        1: "tuesday",
-        2: "wednesday",
-        3: "thursday",
-        4: "friday",
-        5: "saturday",
-        6: "sunday",
-    }
-    srv_dates: dict[str, list[datetime]] = {}
-
-    # Iterate over each row in the calendar to build service dates
-    for _, row in calendar.iterrows():
-        sid = row["service_id"]
-        s = datetime.strptime(str(row["start_date"]), "%Y%m%d")
-        e = datetime.strptime(str(row["end_date"]), "%Y%m%d")
-
-        cur = max(start, s)
-        while cur <= min(end, e):
-            if row.get(day_idx[cur.weekday()], False):
-                srv_dates.setdefault(sid, []).append(cur)
-            cur += timedelta(days=1)
-    return srv_dates
-
-
-def _apply_calendar_exceptions(
-    calendar_dates: pd.DataFrame,
-    srv_dates: dict[str, list[datetime]],
+def _build_active_dates(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    start_date: str,
+    end_date: str,
+    include_calendar: bool,
+    include_calendar_dates: bool,
 ) -> None:
     """
-    Mutate *srv_dates* **in-place** with exception rules.
+    Create and populate temporary active service dates for a date window.
 
-    This function applies calendar date exceptions from GTFS calendar_dates.txt
-    to modify the service dates dictionary by adding or removing specific dates.
-
-    Parameters
-    ----------
-    calendar_dates : pd.DataFrame
-        GTFS calendar_dates DataFrame containing service exceptions.
-    srv_dates : dict[str, list[datetime]]
-        Dictionary mapping service_id to list of active dates, modified in-place.
-
-    See Also
-    --------
-    _service_day_map : Create initial service date mapping.
-
-    Examples
-    --------
-    >>> calendar_dates = pd.DataFrame({
-    ...     'service_id': ['S1'], 'date': ['20230101'], 'exception_type': [2]
-    ... })
-    >>> srv_dates = {'S1': [datetime(2023, 1, 1)]}
-    >>> _apply_calendar_exceptions(calendar_dates, srv_dates)
-    """
-    # Ensure calendar_dates has the necessary columns and types
-    for _, row in calendar_dates.iterrows():
-        sid = row["service_id"]
-        date = datetime.strptime(str(row["date"]), "%Y%m%d")
-        t = int(row["exception_type"])
-        srv_dates.setdefault(sid, [])
-        # Only removal of service exceptions is supported
-        if t == 2:
-            # Remove service exception: safely remove if present
-            with contextlib.suppress(ValueError):
-                srv_dates[sid].remove(date)
-
-
-def _expand_with_dates(od: pd.DataFrame, srv_dates: dict[str, list[datetime]]) -> pd.DataFrame:
-    """
-    Cartesian multiply *od* rows by their active **service dates**.
-
-    This function expands origin-destination pairs by replicating each row
-    for every active service date, creating a comprehensive dataset of all
-    trip instances.
+    Active dates combine weekly calendar service and date-level exceptions.
 
     Parameters
     ----------
-    od : pd.DataFrame
-        Origin-destination pairs DataFrame with service_id column.
-    srv_dates : dict[str, list[datetime]]
-        Dictionary mapping service_id to list of active dates.
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
+    start_date : str
+        Inclusive start date in ``YYYYMMDD`` format.
+    end_date : str
+        Inclusive end date in ``YYYYMMDD`` format.
+    include_calendar : bool
+        Whether to include ``calendar`` weekly service expansion.
+    include_calendar_dates : bool
+        Whether to apply ``calendar_dates`` exceptions.
 
     Returns
     -------
-    pd.DataFrame
-        Expanded DataFrame with date column added for each service instance.
-
-    See Also
-    --------
-    get_od_pairs : Create comprehensive OD pairs with service dates.
-
-    Examples
-    --------
-    >>> od = pd.DataFrame({'service_id': ['S1'], 'from_stop': ['A'], 'to_stop': ['B']})
-    >>> srv_dates = {'S1': [datetime(2023, 1, 1), datetime(2023, 1, 2)]}
-    >>> expanded = _expand_with_dates(od, srv_dates)
+    None
+        The function mutates temporary tables in ``con``.
     """
-    rows: list[dict[str, object]] = []
+    con.execute(_ACTIVE_DATES_TABLE_SQL)
 
-    for _, r in od.iterrows():
-        for d in srv_dates.get(r["service_id"], []):
-            dep = _timestamp(r["departure_time"], d)
-            arr = _timestamp(r["arrival_time"], d)
-            if dep and arr:
-                rows.append(
-                    {
-                        "trip_id": r["trip_id"],
-                        "service_id": r["service_id"],
-                        "orig_stop_id": r["orig_stop_id"],
-                        "dest_stop_id": r["dest_stop_id"],
-                        "departure_ts": dep,
-                        "arrival_ts": arr,
-                        "travel_time_sec": (arr - dep).total_seconds(),
-                        "date": d.strftime("%Y-%m-%d"),
-                    },
+    if include_calendar:
+        con.execute(_BASE_ACTIVE_DATES_INSERT_SQL.format(start_date=start_date, end_date=end_date))
+
+    if include_calendar_dates:
+        con.execute(_CALENDAR_DATES_PARSED_SQL)
+        con.execute(
+            """
+            INSERT INTO _active_dates
+            SELECT service_id, parsed_date
+            FROM _cal_dates_parsed
+            WHERE try_cast(exception_type as integer) = 1
+              AND parsed_date BETWEEN cast(strptime(?, '%Y%m%d') as date)
+                                  AND cast(strptime(?, '%Y%m%d') as date)
+            """,
+            [start_date, end_date],
+        )
+        con.execute(
+            """
+            DELETE FROM _active_dates
+            WHERE (service_id, active_date) IN (
+                SELECT service_id, parsed_date
+                FROM _cal_dates_parsed
+                WHERE try_cast(exception_type as integer) = 2
+            )
+            """
+        )
+
+
+def _validate_calendar_window(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    calendar_start: str | None,
+    calendar_end: str | None,
+    tables: set[str],
+) -> None:
+    """
+    Validate optional calendar window arguments against GTFS calendar bounds.
+
+    The check enforces valid format, in-range dates, and ordered bounds.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
+    calendar_start : str | None
+        Requested lower bound date in ``YYYYMMDD`` format.
+    calendar_end : str | None
+        Requested upper bound date in ``YYYYMMDD`` format.
+    tables : set[str]
+        Available GTFS table names.
+
+    Returns
+    -------
+    None
+        Raises ``ValueError`` when validation fails.
+    """
+    if not (calendar_start or calendar_end):
+        return
+
+    if "calendar" not in tables:
+        msg = "calendar_start/calendar_end specified but GTFS feed has no calendar.txt"
+        raise ValueError(msg)
+
+    cal_check = con.execute("SELECT COUNT(*) FROM calendar").fetchone()[0]
+    if cal_check == 0:
+        msg = "calendar_start/calendar_end specified but calendar.txt is empty"
+        raise ValueError(msg)
+
+    cal_bounds = con.execute("SELECT MIN(start_date), MAX(end_date) FROM calendar").fetchone()
+    gtfs_start = datetime.strptime(str(cal_bounds[0]), "%Y%m%d")
+    gtfs_end = datetime.strptime(str(cal_bounds[1]), "%Y%m%d")
+
+    start_dt: datetime | None = None
+    end_dt: datetime | None = None
+    outside_msg: str | None = None
+
+    try:
+        if calendar_start:
+            start_dt = datetime.strptime(calendar_start, "%Y%m%d")
+            if start_dt < gtfs_start or start_dt > gtfs_end:
+                outside_msg = (
+                    f"calendar_start ({calendar_start}) is outside the valid GTFS date range"
                 )
-    return pd.DataFrame(rows)
+        if calendar_end:
+            end_dt = datetime.strptime(calendar_end, "%Y%m%d")
+            if end_dt < gtfs_start or end_dt > gtfs_end:
+                outside_msg = f"calendar_end ({calendar_end}) is outside the valid GTFS date range"
+    except ValueError as error:
+        msg = "Invalid calendar date format. Expected YYYYMMDD."
+        raise ValueError(msg) from error
+
+    if outside_msg:
+        raise ValueError(outside_msg)
+
+    if start_dt and end_dt and start_dt > end_dt:
+        msg = f"calendar_start ({calendar_start}) must be <= calendar_end ({calendar_end})"
+        raise ValueError(msg)
+
+
+def _build_service_counts(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    calendar_start: str | None,
+    calendar_end: str | None,
+    tables: set[str],
+) -> None:
+    """
+    Create temporary per-service frequency counts used in edge aggregation.
+
+    Counts represent the number of active days per service in the window.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
+    calendar_start : str | None
+        Optional lower bound date in ``YYYYMMDD``.
+    calendar_end : str | None
+        Optional upper bound date in ``YYYYMMDD``.
+    tables : set[str]
+        Available GTFS table names.
+
+    Returns
+    -------
+    None
+        The function creates or replaces ``_service_counts``.
+    """
+    if calendar_start and calendar_end:
+        _build_active_dates(
+            con,
+            start_date=calendar_start,
+            end_date=calendar_end,
+            include_calendar=True,
+            include_calendar_dates="calendar_dates" in tables,
+        )
+        con.execute(
+            """
+            CREATE OR REPLACE TEMP TABLE _service_counts AS
+            SELECT service_id, COUNT(DISTINCT active_date) as sc
+            FROM _active_dates
+            GROUP BY service_id
+            """
+        )
+        return
+
+    con.execute(
+        "CREATE OR REPLACE TEMP TABLE _service_counts AS SELECT DISTINCT service_id, 1 as sc FROM trips"
+    )
+
+
+def _table_columns(
+    con: duckdb.DuckDBPyConnection,
+    table_name: str,
+) -> set[str]:
+    """
+    Return column names for a DuckDB table.
+
+    This helper centralizes schema inspection used by transport graph builders.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
+    table_name : str
+        Name of the relation to inspect.
+
+    Returns
+    -------
+    set[str]
+        Column names available on ``table_name``.
+    """
+    return {row[1] for row in con.execute(f"PRAGMA table_info('{table_name}')").fetchall()}
+
+
+def _ensure_graph_sql_support(con: duckdb.DuckDBPyConnection) -> None:
+    """
+    Ensure SQL features required by transport graph queries are available.
+
+    The function loads DuckDB spatial support and registers the
+    ``time_to_seconds`` scalar UDF when missing.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
+
+    Returns
+    -------
+    None
+        The function mutates runtime SQL capabilities in ``con``.
+
+    Raises
+    ------
+    RuntimeError
+        If the DuckDB spatial extension cannot be loaded or installed.
+    """
+    try:
+        con.execute("LOAD spatial;")
+    except duckdb.Error:
+        try:
+            con.execute("INSTALL spatial; LOAD spatial;")
+        except duckdb.Error as error:
+            msg = "DuckDB spatial extension is required to build transport graph geometries."
+            raise RuntimeError(msg) from error
+
+    # Usually raises duckdb.Error if the function already exists.
+    with suppress(duckdb.Error):
+        con.create_function("time_to_seconds", _time_to_seconds, ["VARCHAR"], "DOUBLE")
+
+
+def _ensure_stops_geometry(con: duckdb.DuckDBPyConnection) -> None:
+    """
+    Create a temp relation named _stops_for_graph with a geometry column.
+
+    If stops.geometry already exists, it is reused. Otherwise geometry is built
+    from stop_lon/stop_lat.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection containing a ``stops`` table.
+
+    Returns
+    -------
+    None
+        The function creates a temporary relation named ``_stops_for_graph``.
+
+    Raises
+    ------
+    ValueError
+        If stop geometry is unavailable and ``stop_lon``/``stop_lat`` are
+        missing.
+    """
+    stop_columns = _table_columns(con, "stops")
+
+    con.execute("DROP VIEW IF EXISTS _stops_for_graph")
+    con.execute("DROP TABLE IF EXISTS _stops_for_graph")
+
+    if "geometry" in stop_columns:
+        con.execute("CREATE TEMP VIEW _stops_for_graph AS SELECT * FROM stops")
+        return
+
+    if not {"stop_lon", "stop_lat"}.issubset(stop_columns):
+        msg = "stops must contain either a geometry column or both stop_lon and stop_lat."
+        raise ValueError(msg)
+
+    con.execute(
+        """
+        CREATE TEMP TABLE _stops_for_graph AS
+        SELECT
+            *,
+            CASE
+                WHEN try_cast(NULLIF(stop_lon, '') AS DOUBLE) IS NOT NULL
+                 AND try_cast(NULLIF(stop_lat, '') AS DOUBLE) IS NOT NULL
+                THEN ST_Point(
+                    CAST(NULLIF(stop_lon, '') AS DOUBLE),
+                    CAST(NULLIF(stop_lat, '') AS DOUBLE)
+                )
+                ELSE NULL
+            END AS geometry
+        FROM stops
+        """
+    )
+
+
+def _resolve_service_window(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    calendar_start: str | None,
+    calendar_end: str | None,
+    tables: set[str],
+) -> tuple[str | None, str | None, bool]:
+    """
+    Resolve the calendar window used for service-frequency counting.
+
+    The resolved window combines feed-level date bounds with optional
+    user-provided limits and supports feeds with ``calendar_dates`` only.
+
+    Parameters
+    ----------
+    con : duckdb.DuckDBPyConnection
+        Open DuckDB connection.
+    calendar_start : str | None
+        Optional lower date bound in ``YYYYMMDD`` format.
+    calendar_end : str | None
+        Optional upper date bound in ``YYYYMMDD`` format.
+    tables : set[str]
+        Available relation names in the current feed.
+
+    Returns
+    -------
+    tuple[str | None, str | None, bool]
+        (resolved_start, resolved_end, use_date_aware_counts)
+
+        If no usable calendar information exists, returns (None, None, False).
+
+    Raises
+    ------
+    ValueError
+        If requested bounds are malformed, out of range, or inconsistent.
+    """
+    has_calendar = "calendar" in tables
+    has_calendar_dates = "calendar_dates" in tables
+
+    if not (has_calendar or has_calendar_dates):
+        if calendar_start or calendar_end:
+            msg = (
+                "calendar_start/calendar_end specified but GTFS feed has neither "
+                "calendar.txt nor calendar_dates.txt"
+            )
+            raise ValueError(msg)
+        return None, None, False
+
+    bounds: list[tuple[datetime, datetime]] = []
+
+    if has_calendar:
+        row = con.execute(
+            "SELECT MIN(start_date), MAX(end_date), COUNT(*) FROM calendar"
+        ).fetchone()
+        if row and row[2] and row[0] and row[1]:
+            bounds.append(
+                (
+                    datetime.strptime(str(row[0]), "%Y%m%d"),
+                    datetime.strptime(str(row[1]), "%Y%m%d"),
+                )
+            )
+
+    if has_calendar_dates:
+        row = con.execute("SELECT MIN(date), MAX(date), COUNT(*) FROM calendar_dates").fetchone()
+        if row and row[2] and row[0] and row[1]:
+            bounds.append(
+                (
+                    datetime.strptime(str(row[0]), "%Y%m%d"),
+                    datetime.strptime(str(row[1]), "%Y%m%d"),
+                )
+            )
+
+    if not bounds:
+        if calendar_start or calendar_end:
+            msg = (
+                "calendar_start/calendar_end specified but calendar tables contain no usable dates"
+            )
+            raise ValueError(msg)
+        return None, None, False
+
+    gtfs_start = min(start for start, _ in bounds)
+    gtfs_end = max(end for _, end in bounds)
+
+    try:
+        user_start = datetime.strptime(calendar_start, "%Y%m%d") if calendar_start else None
+        user_end = datetime.strptime(calendar_end, "%Y%m%d") if calendar_end else None
+    except ValueError as error:
+        msg = "Invalid calendar date format. Expected YYYYMMDD."
+        raise ValueError(msg) from error
+
+    if user_start and (user_start < gtfs_start or user_start > gtfs_end):
+        msg = f"calendar_start ({calendar_start}) is outside the valid GTFS date range"
+        raise ValueError(msg)
+
+    if user_end and (user_end < gtfs_start or user_end > gtfs_end):
+        msg = f"calendar_end ({calendar_end}) is outside the valid GTFS date range"
+        raise ValueError(msg)
+
+    resolved_start = user_start or gtfs_start
+    resolved_end = user_end or gtfs_end
+
+    if resolved_start > resolved_end:
+        msg = (
+            f"calendar_start ({resolved_start.strftime('%Y%m%d')}) "
+            f"must be <= calendar_end ({resolved_end.strftime('%Y%m%d')})"
+        )
+        raise ValueError(msg)
+
+    return (
+        resolved_start.strftime("%Y%m%d"),
+        resolved_end.strftime("%Y%m%d"),
+        True,
+    )
+
+
+def _time_to_seconds(value: str | float | None) -> float:
+    """
+    Convert a GTFS time value into seconds from midnight.
+
+    GTFS may contain values beyond 24 hours (for trips after midnight), and this
+    helper preserves those values as absolute seconds.
+
+    Parameters
+    ----------
+    value : str | float | None
+        GTFS time value, typically ``HH:MM:SS`` or a numeric value.
+
+    Returns
+    -------
+    float
+        Seconds from midnight.
+    """
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return 0.0
+    if not isinstance(value, str):
+        return float(value)
+    value = str(value).strip()
+    if value in {"", "nan", "None"}:
+        return 0.0
+    try:
+        h, m, s = map(int, value.split(":"))
+        return h * 3600 + m * 60 + s
+    except (ValueError, AttributeError):
+        return float(value)
+
+
+def _timestamp(gtfs_time: str | float | None, service_date: datetime | str) -> datetime | None:
+    """
+    Build an absolute timestamp from GTFS time and service date.
+
+    Returns ``None`` when either value cannot be parsed safely.
+
+    Parameters
+    ----------
+    gtfs_time : str | float | None
+        Time value in GTFS format.
+    service_date : datetime | str
+        Service date as ``datetime`` or ``YYYYMMDD`` string.
+
+    Returns
+    -------
+    datetime | None
+        Parsed timestamp with day rollover support, or ``None`` on failure.
+    """
+    try:
+        if isinstance(service_date, str):
+            dt = datetime.strptime(str(service_date), "%Y%m%d")
+        elif isinstance(service_date, datetime):
+            dt = service_date
+        else:
+            dt = datetime.strptime(str(int(service_date)), "%Y%m%d")
+
+        secs = 0.0 if pd.isna(gtfs_time) or gtfs_time is None else _time_to_seconds(gtfs_time)
+
+        h, remainder = divmod(int(secs), 3600)
+        m, s = divmod(remainder, 60)
+        day_offset, h = divmod(h, 24)
+        return dt.replace(hour=h, minute=m, second=s) + timedelta(days=day_offset)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def load_gtfs(path: str | Path) -> duckdb.DuckDBPyConnection:
+    """
+    Load a GTFS ZIP archive into an in-memory DuckDB database.
+
+    The function reads ``*.txt`` GTFS files as tables, registers a time parsing
+    UDF, and materializes optional spatial helpers:
+
+    - ``stops.geometry`` as points from ``stop_lon``/``stop_lat``
+    - ``shapes_geom`` as one polyline per ``shape_id``
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to a GTFS ``.zip`` file.
+
+    Returns
+    -------
+    duckdb.DuckDBPyConnection
+        In-memory DuckDB connection containing imported GTFS tables.
+    """
+    con = duckdb.connect(":memory:")
+    con.execute("INSTALL spatial; LOAD spatial;")
+
+    # Register a scalar UDF used by SQL queries in this module.
+    con.create_function("time_to_seconds", _time_to_seconds, ["VARCHAR"], "DOUBLE")
+
+    tmp_dir = tempfile.mkdtemp()
+    has_files = False
+
+    try:
+        with zipfile.ZipFile(path) as zf:
+            for name in zf.namelist():
+                if name.endswith(".txt") and not name.endswith("/"):
+                    has_files = True
+                    zf.extract(name, tmp_dir)
+                    table_name = name.rsplit("/", 1)[-1].replace(".txt", "")
+                    file_path = str(Path(tmp_dir) / name)
+                    con.read_csv(file_path, all_varchar=True, auto_detect=True).create(table_name)
+    except (OSError, zipfile.BadZipFile, duckdb.Error):
+        logger.exception("Failed to read GTFS archive at %s", path)
+        return con
+
+    if not has_files:
+        logger.warning("No GTFS files found in %s", path)
+        return con
+
+    tables = sorted(_list_tables(con))
+
+    if "stops" in tables:
+        # Build point geometries while guarding against empty coordinate strings.
+        con.execute("""
+            ALTER TABLE stops ADD COLUMN geometry GEOMETRY;
+            UPDATE stops SET geometry = ST_Point(CAST(NULLIF(stop_lon, '') AS DOUBLE), CAST(NULLIF(stop_lat, '') AS DOUBLE))
+            WHERE try_cast(NULLIF(stop_lon, '') as DOUBLE) IS NOT NULL AND try_cast(NULLIF(stop_lat, '') as DOUBLE) IS NOT NULL;
+        """)
+
+    if "shapes" in tables:
+        con.execute("""
+            CREATE TABLE shapes_geom AS
+            SELECT
+                shape_id,
+                ST_MakeLine(
+                    list(
+                        ST_Point(
+                            CAST(NULLIF(shape_pt_lon, '') AS DOUBLE),
+                            CAST(NULLIF(shape_pt_lat, '') AS DOUBLE)
+                        ) ORDER BY CAST(NULLIF(shape_pt_sequence, '') AS INTEGER)
+                    )
+                ) AS geometry
+            FROM shapes
+            WHERE try_cast(NULLIF(shape_pt_lon, '') as DOUBLE) IS NOT NULL AND try_cast(NULLIF(shape_pt_lat, '') as DOUBLE) IS NOT NULL
+            GROUP BY shape_id;
+        """)
+
+    logger.info("GTFS loaded: %s", ", ".join(tables))
+    return con
 
 
 def get_od_pairs(
-    gtfs: dict[str, pd.DataFrame | gpd.GeoDataFrame],
+    con: duckdb.DuckDBPyConnection,
     start_date: str | None = None,
     end_date: str | None = None,
     include_geometry: bool = True,
 ) -> pd.DataFrame | gpd.GeoDataFrame:
     """
-    Materialise origin-destination pairs for every trip and service day.
+    Generate stop-to-stop OD pairs from GTFS trip stop sequences.
 
-    This function creates a comprehensive dataset of all origin-destination pairs
-    for transit trips within the specified date range, optionally including
-    geometric information for spatial analysis.
+    For each ``trip_id``, consecutive stops are paired into directed legs with
+    departure/arrival timestamps and per-leg travel time in seconds. Service
+    activity is derived from ``calendar`` and optionally adjusted using
+    ``calendar_dates``.
 
     Parameters
     ----------
-    gtfs : dict
-        Dictionary returned by :func:`load_gtfs`.
-    start_date, end_date : str or None, optional
-        Restrict the calendar expansion to the closed interval
-        ``[start_date, end_date]`` (format *YYYYMMDD*).  When *None* the period
-        is inferred from ``calendar.txt``.
-    include_geometry : bool, default True
-        If *True* the result is a GeoDataFrame whose geometry is a *straight*
-        LineString connecting the two stops.
+    con : duckdb.DuckDBPyConnection
+        DuckDB connection with GTFS tables loaded.
+    start_date : str | None, default=None
+        Inclusive start date (``YYYYMMDD``). Optional when ``calendar`` exists.
+    end_date : str | None, default=None
+        Inclusive end date (``YYYYMMDD``). Optional when ``calendar`` exists.
+    include_geometry : bool, default=True
+        If ``True`` and stop geometries are available, include a line geometry
+        for each OD pair.
 
     Returns
     -------
-    pandas.DataFrame or geopandas.GeoDataFrame
-        One row per *trip-day-leg* with departure / arrival timestamps,
-        travel time in seconds and, optionally, geometry.
-
-    See Also
-    --------
-    load_gtfs : Load GTFS data from zip file.
-    travel_summary_graph : Create network representation from GTFS data.
-
-    Examples
-    --------
-    >>> gtfs = load_gtfs("data/rome_gtfs.zip")
-    >>> od = get_od_pairs(gtfs, start_date="20230101", end_date="20230107")
-    >>> od.head(3)[['orig_stop_id', 'dest_stop_id', 'travel_time_sec']]
-      orig_stop_id dest_stop_id  travel_time_sec
-    0      7045490      7045491            120.0
-    1      7045491      7045492            180.0
-    2      7045492      7045493            240.0
+    pd.DataFrame | gpd.GeoDataFrame
+        One row per directed stop-to-stop leg.
     """
-    required = {"stop_times", "trips", "stops", "calendar"}
-    if not required <= gtfs.keys():
+    tables = _list_tables(con)
+    required = {"stop_times", "trips"}
+    if not required.issubset(tables):
         logger.error("GTFS feed incomplete - need %s", ", ".join(required))
         return pd.DataFrame()
 
-    # Create successive stop pairs from stop_times
-    od = _create_basic_od(
-        gtfs["stop_times"].merge(gtfs["trips"][["trip_id", "service_id"]], on="trip_id"),
+    has_cal = "calendar" in tables
+
+    if has_cal:
+        cal_df = con.execute(
+            "SELECT MIN(start_date) as s, MAX(end_date) as e FROM calendar"
+        ).fetchone()
+        s_dt = start_date or cal_df[0]
+        e_dt = end_date or cal_df[1]
+    else:
+        if not start_date or not end_date:
+            return pd.DataFrame()
+        s_dt = start_date
+        e_dt = end_date
+
+    _build_active_dates(
+        con,
+        start_date=str(s_dt),
+        end_date=str(e_dt),
+        include_calendar=has_cal,
+        include_calendar_dates="calendar_dates" in tables,
     )
 
-    # Expand OD pairs with calendar dates
-    cal = gtfs["calendar"]
-    start_dt = (
-        datetime.strptime(start_date, "%Y%m%d")
-        if start_date
-        else datetime.strptime(cal["start_date"].min(), "%Y%m%d")
-    )
-    end_dt = (
-        datetime.strptime(end_date, "%Y%m%d")
-        if end_date
-        else datetime.strptime(cal["end_date"].max(), "%Y%m%d")
+    con.execute(
+        """
+        CREATE OR REPLACE TEMP TABLE _unique_dates AS
+        SELECT DISTINCT
+            service_id,
+            active_date,
+            strftime(active_date, '%Y%m%d') as active_date_str
+        FROM _active_dates
+        """
     )
 
-    srv_dates = _service_day_map(cal, start_dt, end_dt)
-    if (cal_dates := gtfs.get("calendar_dates")) is not None:
-        _apply_calendar_exceptions(cal_dates, srv_dates)
+    query = """
+        WITH st AS (
+            SELECT
+                trip_id,
+                stop_id as orig_stop_id,
+                departure_time,
+                LEAD(stop_id) OVER (PARTITION BY trip_id ORDER BY CAST(stop_sequence AS INTEGER)) as dest_stop_id,
+                LEAD(arrival_time) OVER (PARTITION BY trip_id ORDER BY CAST(stop_sequence AS INTEGER)) as arrival_time_next
+            FROM stop_times
+            WHERE try_cast(stop_sequence as integer) IS NOT NULL
+        ),
+        valid_st AS (
+            SELECT st.*, t.service_id
+            FROM st
+            JOIN trips t ON st.trip_id = t.trip_id
+            WHERE st.dest_stop_id IS NOT NULL
+        )
+        SELECT
+            v.trip_id,
+            v.service_id,
+            v.orig_stop_id,
+            v.dest_stop_id,
+            v.departure_time,
+            v.arrival_time_next as arrival_time,
+            d.active_date_str,
+            strftime(d.active_date, '%Y-%m-%d') as date
+    """
 
-    od_full = _expand_with_dates(od, srv_dates)
+    if include_geometry and "stops" in tables:
+        query += """,
+            ST_AsText(ST_MakeLine(s1.geometry, s2.geometry)) as geometry_wkt
+        """
+    else:
+        include_geometry = False
 
-    if not include_geometry:
-        return od_full
+    query += """
+        FROM valid_st v
+        JOIN _unique_dates d ON v.service_id = d.service_id
+    """
 
-    # Append LineString geometries
-    stops = gtfs["stops"].set_index("stop_id")
-    line_geoms = [
-        LineString([stops.loc[o].geometry, stops.loc[d].geometry])
-        if o in stops.index and d in stops.index
-        else None
-        for o, d in zip(od_full["orig_stop_id"], od_full["dest_stop_id"], strict=False)
-    ]
-    return gpd.GeoDataFrame(od_full, geometry=line_geoms, crs="EPSG:4326")
+    if include_geometry:
+        query += """
+        LEFT JOIN stops s1 ON v.orig_stop_id = s1.stop_id
+        LEFT JOIN stops s2 ON v.dest_stop_id = s2.stop_id
+        """
 
+    od_pairs_df = con.execute(query).df()
 
-# ---------------------------------------------------------------------------
-# TRAVEL SUMMARY GRAPH
-# ---------------------------------------------------------------------------
+    if od_pairs_df.empty:
+        return pd.DataFrame()
+
+    od_pairs_df["departure_ts"] = od_pairs_df.apply(
+        lambda row: _timestamp(row["departure_time"], row["active_date_str"]), axis=1
+    )
+    od_pairs_df["arrival_ts"] = od_pairs_df.apply(
+        lambda row: _timestamp(row["arrival_time"], row["active_date_str"]), axis=1
+    )
+
+    od_pairs_df = od_pairs_df.dropna(subset=["departure_ts", "arrival_ts"])
+    od_pairs_df["travel_time_sec"] = (
+        od_pairs_df["arrival_ts"] - od_pairs_df["departure_ts"]
+    ).dt.total_seconds()
+
+    od_pairs_df = od_pairs_df.drop(columns=["departure_time", "arrival_time", "active_date_str"])
+    od_pairs_df = od_pairs_df.sort_values(["trip_id", "date"]).reset_index(drop=True)
+
+    if include_geometry and "geometry_wkt" in od_pairs_df.columns:
+        od_pairs_df = _convert_wkt_column(od_pairs_df)
+        return gpd.GeoDataFrame(od_pairs_df, geometry="geometry", crs="EPSG:4326")
+
+    return od_pairs_df
 
 
 def travel_summary_graph(
-    gtfs: dict[str, pd.DataFrame | gpd.GeoDataFrame],
+    con: duckdb.DuckDBPyConnection,
     start_time: str | None = None,
     end_time: str | None = None,
     calendar_start: str | None = None,
@@ -864,230 +832,216 @@ def travel_summary_graph(
     as_nx: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     """
-    Aggregate stop-to-stop travel time & frequency into an edge list.
+    Aggregate GTFS service into a weighted stop-to-stop summary graph.
 
-    This function analyzes GTFS data to create a network representation of
-    transit connections, computing average travel times and service frequencies
-    between consecutive stops.
+    Fixes compared with the original version:
+    - requires trips, stop_times, and stops
+    - honors one-sided calendar bounds by inferring the missing side
+    - defaults to full-feed date-aware service counts when calendar data exists
+    - supports calendar_dates-only feeds
+    - constructs stop geometry if stops.geometry is absent
+    - returns a directed NetworkX graph when as_nx=True
 
     Parameters
     ----------
-    gtfs : dict
-        A dictionary produced by :func:`load_gtfs` - must contain at least
-        ``stop_times`` and ``stops``.
-    start_time, end_time : str or None, optional
-        Consider only trips whose **departure** falls inside
-        ``[start_time, end_time]`` (format *HH:MM:SS*).  When *None* the whole
-        service day is used.
-    calendar_start, calendar_end : str or None, optional
-        Period over which service-days are counted (format *YYYYMMDD*).  If
-        omitted it spans the native range in ``calendar.txt``.
-    as_nx : bool, default False
-        If *True* return a NetworkX graph, otherwise two GeoDataFrames
-        ``(nodes_gdf, edges_gdf)``.  The latter follow the convention used in
-        *utils.py*.
+    con : duckdb.DuckDBPyConnection
+        DuckDB connection with GTFS tables loaded.
+    start_time : str | None, default=None
+        Optional lower bound (inclusive) for departure time, ``HH:MM:SS``.
+    end_time : str | None, default=None
+        Optional upper bound (inclusive) for next-stop arrival time,
+        ``HH:MM:SS``.
+    calendar_start : str | None, default=None
+        Optional calendar window start, ``YYYYMMDD``.
+    calendar_end : str | None, default=None
+        Optional calendar window end, ``YYYYMMDD``.
+    as_nx : bool, default=False
+        If ``True``, return a directed NetworkX graph instead of GeoDataFrames.
 
     Returns
     -------
-    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame] or networkx.Graph
-        • **Nodes** - every stop with a valid geometry.
-        • **Edges** - columns = ``from_stop_id, to_stop_id, travel_time_sec,
-          frequency, geometry``.
-
-    See Also
-    --------
-    get_od_pairs : Create origin-destination pairs from GTFS data.
-    load_gtfs : Load GTFS data from zip file.
-
-    Examples
-    --------
-    >>> gtfs = load_gtfs("data/rome_gtfs.zip")
-    >>> nodes, edges = travel_summary_graph(
-    ...     gtfs,
-    ...     start_time="07:00:00",
-    ...     end_time="10:00:00",
-    ... )
-    >>> print(edges.head(3)[['travel_time_sec', 'frequency']])
-                       travel_time_sec  frequency
-    from_stop_id to_stop_id
-    7045490      7045491            120.0        42
-    7045491      7045492            180.0        42
-    7045492      7045493            240.0        42
-
-    You can directly obtain a NetworkX object too:
-
-    >>> G = travel_summary_graph(gtfs, as_nx=True)
-    >>> print(G.number_of_nodes(), G.number_of_edges())
-    2564 3178
+    tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph
+        ``(nodes_gdf, edges_gdf)`` when ``as_nx`` is ``False``; otherwise a
+        directed NetworkX graph built from those GeoDataFrames.
     """
-    # Validate Required Data
-    required_keys = {"stop_times", "stops"}
-    if not required_keys.issubset(gtfs.keys()):
-        missing = required_keys - gtfs.keys()
-        msg = f"GTFS must contain at least stop_times and stops. Missing: {', '.join(missing)}"
+    tables = _list_tables(con)
+    required = {"stop_times", "stops", "trips"}
+    if not required.issubset(tables):
+        missing = sorted(required - tables)
+        msg = f"GTFS must contain stop_times, stops, and trips. Missing: {', '.join(missing)}"
         raise ValueError(msg)
 
-    # Validate calendar date range if provided
-    if calendar_start is not None or calendar_end is not None:
-        _validate_calendar_dates(gtfs, calendar_start, calendar_end)
+    _ensure_graph_sql_support(con)
+    _ensure_stops_geometry(con)
 
-    # Preprocess Data
-    stop_times = gtfs["stop_times"].copy()
-    trips = gtfs["trips"][["trip_id", "service_id"]].copy()
+    try:
+        min_departure_sec = _time_to_seconds(start_time) if start_time is not None else None
+        max_arrival_sec = _time_to_seconds(end_time) if end_time is not None else None
+    except (TypeError, ValueError) as error:
+        msg = "Invalid time format. Expected HH:MM:SS."
+        raise ValueError(msg) from error
 
-    stop_times["departure_time_sec"] = stop_times["departure_time"].map(_time_to_seconds)
-    stop_times["arrival_time_sec"] = stop_times["arrival_time"].map(_time_to_seconds)
-
-    # Filter by Time of Day
-    if start_time is not None:
-        stop_times = stop_times[stop_times["departure_time_sec"] >= _time_to_seconds(start_time)]
-    if end_time is not None:
-        stop_times = stop_times[stop_times["arrival_time_sec"] <= _time_to_seconds(end_time)]
-
-    # Merge Data and Calculate Service Counts
-    stop_times = stop_times.merge(trips, on="trip_id", how="inner")
-
-    if calendar_start and calendar_end:
-        service_counts = _get_service_counts(gtfs, calendar_start, calendar_end)
-        stop_times["service_count"] = stop_times["service_id"].map(service_counts).fillna(0)
-        stop_times = stop_times[stop_times["service_count"] > 0]
-    else:
-        stop_times["service_count"] = 1
-
-    # Calculate Travel Time Between Consecutive Stops
-    stop_times = stop_times.sort_values(["trip_id", "stop_sequence"])
-    grouped = stop_times.groupby("trip_id")
-
-    valid_pairs = stop_times.assign(
-        next_stop_id=grouped["stop_id"].shift(-1),
-        next_arrival_time_sec=grouped["arrival_time_sec"].shift(-1),
-    ).dropna(subset=["next_stop_id", "next_arrival_time_sec"])
-
-    valid_pairs = valid_pairs.assign(
-        travel_time=valid_pairs["next_arrival_time_sec"] - valid_pairs["departure_time_sec"],
-    )
-    valid_pairs = valid_pairs[valid_pairs["travel_time"] > 0]
-
-    # Aggregate Results
-    agg_calcs = (
-        valid_pairs.groupby(["stop_id", "next_stop_id"])
-        .agg(
-            weighted_time_sum=(
-                "travel_time",
-                lambda x: (x * valid_pairs.loc[x.index, "service_count"]).sum(),
-            ),
-            total_service_count=("service_count", "sum"),
-        )
-        .reset_index()
-    )
-
-    agg_calcs["travel_time_sec"] = agg_calcs["weighted_time_sum"] / agg_calcs["total_service_count"]
-    agg_calcs["frequency"] = agg_calcs["total_service_count"]
-
-    # Create GeoDataFrames for nodes and edges
-    nodes_gdf: gpd.GeoDataFrame = gtfs["stops"].set_index("stop_id")
-    edges_geom = [
-        LineString([nodes_gdf.loc[u].geometry, nodes_gdf.loc[v].geometry])
-        for u, v in zip(agg_calcs["stop_id"], agg_calcs["next_stop_id"], strict=False)
-    ]
-    edges_gdf = gpd.GeoDataFrame(
-        {
-            "from_stop_id": agg_calcs["stop_id"],
-            "to_stop_id": agg_calcs["next_stop_id"],
-            "travel_time_sec": agg_calcs["travel_time_sec"],
-            "frequency": agg_calcs["frequency"],
-        },
-        geometry=edges_geom,
-        crs=nodes_gdf.crs,
-    ).set_index(["from_stop_id", "to_stop_id"])
-
-    return (nodes_gdf, edges_gdf) if not as_nx else gdf_to_nx(nodes_gdf, edges_gdf)
-
-
-def _validate_calendar_dates(
-    gtfs: dict[str, pd.DataFrame | gpd.GeoDataFrame],
-    calendar_start: str | None,
-    calendar_end: str | None,
-) -> None:
-    """
-    Validate that calendar_start and calendar_end are within GTFS date range.
-
-    This function checks that the provided calendar date range is valid and
-    falls within the date range available in the GTFS calendar data.
-
-    Parameters
-    ----------
-    gtfs : dict[str, pd.DataFrame | gpd.GeoDataFrame]
-        Dictionary containing GTFS data tables.
-    calendar_start : str or None
-        Start date in YYYYMMDD format, or None to use GTFS minimum.
-    calendar_end : str or None
-        End date in YYYYMMDD format, or None to use GTFS maximum.
-
-    See Also
-    --------
-    travel_summary_graph : Main function using this validation.
-
-    Examples
-    --------
-    >>> gtfs = {'calendar': pd.DataFrame({'start_date': ['20230101'], 'end_date': ['20231231']})}
-    >>> _validate_calendar_dates(gtfs, "20230601", "20230630")
-    """
-    if "calendar" not in gtfs:
-        msg = "calendar_start/calendar_end specified but GTFS feed has no calendar.txt"
-        raise ValueError(msg)
-
-    calendar = gtfs["calendar"]
-    if calendar.empty:
-        msg = "calendar_start/calendar_end specified but calendar.txt is empty"
-        raise ValueError(msg)
-
-    # Get the valid GTFS date range
-    gtfs_start_date = datetime.strptime(calendar["start_date"].min(), "%Y%m%d")
-    gtfs_end_date = datetime.strptime(calendar["end_date"].max(), "%Y%m%d")
-
-    calendar_start_dt = None
-    calendar_end_dt = None
-
-    # Validate calendar_start
-    if calendar_start is not None:
-        try:
-            calendar_start_dt = datetime.strptime(calendar_start, "%Y%m%d")
-        except ValueError as e:
-            msg = f"Invalid calendar_start format: {calendar_start}. Expected YYYYMMDD."
-            raise ValueError(msg) from e
-
-        if calendar_start_dt < gtfs_start_date or calendar_start_dt > gtfs_end_date:
-            gtfs_start_str = gtfs_start_date.strftime("%Y%m%d")
-            gtfs_end_str = gtfs_end_date.strftime("%Y%m%d")
-            msg = (
-                f"calendar_start ({calendar_start}) is outside the valid GTFS date range "
-                f"({gtfs_start_str} to {gtfs_end_str})"
-            )
-            raise ValueError(msg)
-
-    # Validate calendar_end
-    if calendar_end is not None:
-        try:
-            calendar_end_dt = datetime.strptime(calendar_end, "%Y%m%d")
-        except ValueError as e:
-            msg = f"Invalid calendar_end format: {calendar_end}. Expected YYYYMMDD."
-            raise ValueError(msg) from e
-
-        if calendar_end_dt < gtfs_start_date or calendar_end_dt > gtfs_end_date:
-            gtfs_start_str = gtfs_start_date.strftime("%Y%m%d")
-            gtfs_end_str = gtfs_end_date.strftime("%Y%m%d")
-            msg = (
-                f"calendar_end ({calendar_end}) is outside the valid GTFS date range "
-                f"({gtfs_start_str} to {gtfs_end_str})"
-            )
-            raise ValueError(msg)
-
-    # Validate that calendar_start <= calendar_end if both are provided
     if (
-        calendar_start_dt is not None
-        and calendar_end_dt is not None
-        and calendar_start_dt > calendar_end_dt
+        min_departure_sec is not None
+        and max_arrival_sec is not None
+        and min_departure_sec > max_arrival_sec
     ):
-        msg = f"calendar_start ({calendar_start}) must be <= calendar_end ({calendar_end})"
+        msg = (
+            "start_time must be <= end_time. Use GTFS extended times "
+            "(e.g. 25:30:00) for after-midnight windows."
+        )
         raise ValueError(msg)
+
+    resolved_start, resolved_end, use_date_aware_counts = _resolve_service_window(
+        con,
+        calendar_start=calendar_start,
+        calendar_end=calendar_end,
+        tables=tables,
+    )
+
+    if use_date_aware_counts and resolved_start and resolved_end:
+        _build_active_dates(
+            con,
+            start_date=resolved_start,
+            end_date=resolved_end,
+            include_calendar="calendar" in tables,
+            include_calendar_dates="calendar_dates" in tables,
+        )
+        con.execute(
+            """
+            CREATE OR REPLACE TEMP TABLE _service_counts AS
+            SELECT service_id, COUNT(DISTINCT active_date) AS sc
+            FROM _active_dates
+            GROUP BY service_id
+            """
+        )
+    else:
+        logger.info(
+            "No usable calendar/calendar_dates window found; falling back to sc=1 per service_id."
+        )
+        con.execute(
+            """
+            CREATE OR REPLACE TEMP TABLE _service_counts AS
+            SELECT DISTINCT service_id, 1 AS sc
+            FROM trips
+            WHERE service_id IS NOT NULL
+            """
+        )
+
+    edge_query = """
+        WITH st AS (
+            SELECT
+                trip_id,
+                stop_id,
+                CASE
+                    WHEN departure_time IS NULL
+                      OR lower(trim(CAST(departure_time AS VARCHAR))) IN ('', 'nan', 'none')
+                    THEN NULL
+                    ELSE time_to_seconds(CAST(departure_time AS VARCHAR))
+                END AS departure_time_sec,
+                LEAD(stop_id) OVER (
+                    PARTITION BY trip_id
+                    ORDER BY CAST(stop_sequence AS INTEGER)
+                ) AS next_stop_id,
+                LEAD(
+                    CASE
+                        WHEN arrival_time IS NULL
+                          OR lower(trim(CAST(arrival_time AS VARCHAR))) IN ('', 'nan', 'none')
+                        THEN NULL
+                        ELSE time_to_seconds(CAST(arrival_time AS VARCHAR))
+                    END
+                ) OVER (
+                    PARTITION BY trip_id
+                    ORDER BY CAST(stop_sequence AS INTEGER)
+                ) AS next_arrival_time_sec
+            FROM stop_times
+            WHERE try_cast(stop_sequence AS INTEGER) IS NOT NULL
+        ),
+        st_filtered AS (
+            SELECT *
+            FROM st
+            WHERE next_stop_id IS NOT NULL
+              AND departure_time_sec IS NOT NULL
+              AND next_arrival_time_sec IS NOT NULL
+              AND (? IS NULL OR departure_time_sec >= ?)
+              AND (? IS NULL OR next_arrival_time_sec <= ?)
+        ),
+        valid_pairs AS (
+            SELECT
+                st.stop_id,
+                st.next_stop_id,
+                st.next_arrival_time_sec - st.departure_time_sec AS travel_time,
+                sc.sc AS service_count
+            FROM st_filtered st
+            JOIN trips t
+              ON st.trip_id = t.trip_id
+            JOIN _service_counts sc
+              ON t.service_id = sc.service_id
+            WHERE (st.next_arrival_time_sec - st.departure_time_sec) > 0
+              AND sc.sc > 0
+        ),
+        agg_pairs AS (
+            SELECT
+                stop_id,
+                next_stop_id,
+                SUM(travel_time * service_count) / SUM(service_count) AS travel_time_sec,
+                SUM(service_count) AS frequency
+            FROM valid_pairs
+            GROUP BY stop_id, next_stop_id
+        )
+        SELECT
+            a.stop_id AS from_stop_id,
+            a.next_stop_id AS to_stop_id,
+            a.travel_time_sec,
+            CAST(a.frequency AS BIGINT) AS frequency,
+            ST_AsText(
+                CASE
+                    WHEN s1.geometry IS NOT NULL AND s2.geometry IS NOT NULL
+                    THEN ST_MakeLine(s1.geometry, s2.geometry)
+                    ELSE NULL
+                END
+            ) AS geometry_wkt
+        FROM agg_pairs a
+        LEFT JOIN _stops_for_graph s1
+          ON a.stop_id = s1.stop_id
+        LEFT JOIN _stops_for_graph s2
+          ON a.next_stop_id = s2.stop_id
+        ORDER BY from_stop_id, to_stop_id
+    """
+
+    edges_df = con.execute(
+        edge_query,
+        [min_departure_sec, min_departure_sec, max_arrival_sec, max_arrival_sec],
+    ).df()
+    edges_df = _convert_wkt_column(edges_df)
+    edges_gdf = gpd.GeoDataFrame(edges_df, geometry="geometry", crs="EPSG:4326")
+    if "from_stop_id" in edges_gdf.columns and "to_stop_id" in edges_gdf.columns:
+        edges_gdf = edges_gdf.set_index(["from_stop_id", "to_stop_id"])
+
+    stops_df = con.execute(
+        """
+        SELECT
+            * EXCLUDE (geometry),
+            ST_AsText(geometry) AS geometry_wkt
+        FROM _stops_for_graph
+        ORDER BY stop_id
+        """
+    ).df()
+    stops_df = _convert_wkt_column(stops_df)
+    nodes_gdf = gpd.GeoDataFrame(stops_df, geometry="geometry", crs="EPSG:4326")
+    if "stop_id" in nodes_gdf.columns:
+        nodes_gdf = nodes_gdf.set_index("stop_id")
+
+    if not as_nx:
+        return nodes_gdf, edges_gdf
+
+    graph = nx.DiGraph()
+    graph.graph["crs"] = str(nodes_gdf.crs) if nodes_gdf.crs else None
+
+    for stop_id, row in nodes_gdf.iterrows():
+        graph.add_node(stop_id, **row.to_dict())
+
+    for (from_stop_id, to_stop_id), row in edges_gdf.iterrows():
+        graph.add_edge(from_stop_id, to_stop_id, **row.to_dict())
+
+    return graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ keywords = ["GeoAI", "Graph Neural Networks", "GNNs", "PyTorch Geometric", "Geos
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "networkx >=2.8",
+    "duckdb >=1.1.0",
     "osmnx >=2.0.3",
     "shapely >=2.1.0",
     "geopandas >=1.1.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1860,3 +1860,50 @@ def gtfs_dict_remove_service(
 
     gtfs_dict["calendar_dates"] = calendar_dates_df
     return gtfs_dict
+
+
+@pytest.fixture
+def sample_gtfs_dict_with_frequencies(
+    sample_gtfs_dict: dict[str, pd.DataFrame],
+) -> dict[str, pd.DataFrame]:
+    """Create a sample GTFS dictionary with a frequencies table."""
+    gtfs_dict = sample_gtfs_dict.copy()
+
+    # Add frequencies.txt: trip1 runs every 600 seconds (10 min) from 08:00 to 09:00
+    # That gives floor((09:00:00 - 08:00:00) / 600) = 6 departures
+    frequencies_df = pd.DataFrame(
+        {
+            "trip_id": ["trip1"],
+            "start_time": ["08:00:00"],
+            "end_time": ["09:00:00"],
+            "headway_secs": [600],
+        },
+    )
+    gtfs_dict["frequencies"] = frequencies_df
+    return gtfs_dict
+
+
+@pytest.fixture
+def sample_gtfs_dict_with_shapes(
+    sample_gtfs_dict: dict[str, pd.DataFrame],
+) -> dict[str, pd.DataFrame]:
+    """Create a sample GTFS dictionary with shapes data and shape_id on trips."""
+    gtfs_dict = sample_gtfs_dict.copy()
+
+    # Add shape_id to trips
+    trips_df = gtfs_dict["trips"].copy()
+    trips_df["shape_id"] = ["shape1", "shape1"]
+    gtfs_dict["trips"] = trips_df
+
+    # Add shapes.txt with 3 intermediate points between stops
+    shapes_df = pd.DataFrame(
+        {
+            "shape_id": ["shape1"] * 5,
+            "shape_pt_lat": [40.7128, 40.7250, 40.7400, 40.7505, 40.7589],
+            "shape_pt_lon": [-74.0060, -74.0010, -73.9960, -73.9934, -73.9851],
+            "shape_pt_sequence": [1, 2, 3, 4, 5],
+        },
+    )
+    gtfs_dict["shapes"] = shapes_df
+
+    return gtfs_dict

--- a/tests/test_transportation.py
+++ b/tests/test_transportation.py
@@ -5,6 +5,7 @@
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import cast
 
 import duckdb
 import geopandas as gpd
@@ -41,7 +42,9 @@ def dict_to_con(d: dict[str, pd.DataFrame]) -> duckdb.DuckDBPyConnection:
             )
 
     # We must register the UDF exactly as load_gtfs does
-    con.create_function("time_to_seconds", _time_to_seconds, ["VARCHAR"], "DOUBLE")
+    con.create_function(
+        "time_to_seconds", _time_to_seconds, [duckdb.sqltypes.VARCHAR], duckdb.sqltypes.DOUBLE
+    )
     return con
 
 
@@ -52,8 +55,27 @@ class TestTimeHelpers:
     def test_time_to_seconds_with_none(self) -> None:
         assert _time_to_seconds(None) == 0.0
 
-    def test_time_to_seconds_with_numeric_string(self) -> None:
-        assert _time_to_seconds("3600.0") == 3600.0
+    def test_time_to_seconds_valid_hms(self) -> None:
+        assert _time_to_seconds("08:30:00") == 30600.0
+
+    def test_time_to_seconds_extended_hours(self) -> None:
+        assert _time_to_seconds("25:30:00") == 91800.0
+
+    def test_time_to_seconds_rejects_numeric_string(self) -> None:
+        with pytest.raises(ValueError, match="Expected HH:MM:SS"):
+            _time_to_seconds("3600.0")
+
+    def test_time_to_seconds_rejects_empty_string(self) -> None:
+        with pytest.raises(ValueError, match="Expected HH:MM:SS"):
+            _time_to_seconds("")
+
+    def test_time_to_seconds_rejects_nan_string(self) -> None:
+        with pytest.raises(ValueError, match="Expected HH:MM:SS"):
+            _time_to_seconds("nan")
+
+    def test_time_to_seconds_rejects_none_string(self) -> None:
+        with pytest.raises(ValueError, match="Expected HH:MM:SS"):
+            _time_to_seconds("None")
 
     def test_timestamp_with_float(self) -> None:
         ts = _timestamp(3600.0, datetime(2024, 1, 1))
@@ -63,9 +85,14 @@ class TestTimeHelpers:
         ts = _timestamp(None, datetime(2024, 1, 1))
         assert ts == datetime(2024, 1, 1, 0, 0, 0)
 
-    def test_timestamp_with_numeric_string(self) -> None:
-        ts = _timestamp("7200.0", datetime(2024, 1, 1))
+    def test_timestamp_with_hms_string(self) -> None:
+        ts = _timestamp("02:00:00", datetime(2024, 1, 1))
         assert ts == datetime(2024, 1, 1, 2, 0, 0)
+
+    def test_timestamp_with_invalid_string(self) -> None:
+        # Invalid string should return None (caught by _timestamp's try/except)
+        ts = _timestamp("invalid", datetime(2024, 1, 1))
+        assert ts is None
 
 
 class TestLoadGtfs:
@@ -213,6 +240,52 @@ class TestGetOdPairs:
         result = get_od_pairs(con, include_geometry=False)
         assert len(result) == 0
 
+    def test_get_od_pairs_directed(self, sample_gtfs_dict: dict[str, pd.DataFrame]) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+        result_directed = get_od_pairs(con, directed=True, include_geometry=False)
+        result_undirected = get_od_pairs(con, directed=False, include_geometry=False)
+
+        assert isinstance(result_directed, pd.DataFrame)
+        assert isinstance(result_undirected, pd.DataFrame)
+        # Undirected should have orig_stop_id <= dest_stop_id for all rows
+        assert (result_undirected["orig_stop_id"] <= result_undirected["dest_stop_id"]).all()
+
+    def test_get_od_pairs_calendar_dates_only_with_explicit_window(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        gtfs = sample_gtfs_dict.copy()
+        gtfs.pop("calendar")
+        gtfs["calendar_dates"] = pd.DataFrame(
+            {
+                "service_id": ["service1"],
+                "date": ["20240101"],
+                "exception_type": [1],
+            }
+        )
+
+        con = dict_to_con(gtfs)
+        result = get_od_pairs(
+            con,
+            start_date="20240101",
+            end_date="20240101",
+            include_geometry=False,
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+
+    def test_get_od_pairs_without_calendar_and_without_dates_returns_empty(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        gtfs = sample_gtfs_dict.copy()
+        gtfs.pop("calendar")
+
+        con = dict_to_con(gtfs)
+        result = get_od_pairs(con, include_geometry=False)
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty
+
 
 class TestTravelSummaryGraph:
     def test_travel_summary_graph_basic(self, sample_gtfs_dict: dict[str, pd.DataFrame]) -> None:
@@ -241,16 +314,46 @@ class TestTravelSummaryGraph:
         assert isinstance(nodes_gdf, gpd.GeoDataFrame)
         assert isinstance(edges_gdf, gpd.GeoDataFrame)
 
-    def test_travel_summary_graph_as_nx(self, sample_gtfs_dict: dict[str, pd.DataFrame]) -> None:
+    def test_travel_summary_graph_as_nx_undirected(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
         con = dict_to_con(sample_gtfs_dict)
-        result = travel_summary_graph(con, as_nx=True)
+        result = travel_summary_graph(con, as_nx=True, directed=False)
         assert isinstance(result, nx.Graph)
+        assert not isinstance(result, nx.DiGraph)
+
+    def test_travel_summary_graph_as_nx_directed(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+        result = travel_summary_graph(con, as_nx=True, directed=True)
+        assert isinstance(result, nx.DiGraph)
 
     def test_travel_summary_graph_missing_data(self) -> None:
         con = duckdb.connect()
         con.execute("CREATE TABLE stops AS SELECT 1 as a")
         with pytest.raises(ValueError):
             travel_summary_graph(con)
+
+    def test_travel_summary_graph_surfaces_spatial_extension_failures(self) -> None:
+        class _ShowTablesResult:
+            def fetchall(self) -> list[tuple[str]]:
+                return [("stop_times",), ("stops",), ("trips",)]
+
+        class FailingSpatialConnection:
+            def execute(self, query: str) -> _ShowTablesResult:
+                if query == "SHOW TABLES":
+                    return _ShowTablesResult()
+                if query == "LOAD spatial;":
+                    msg = "load failed"
+                    raise duckdb.Error(msg)
+                if query == "INSTALL spatial; LOAD spatial;":
+                    msg = "install failed"
+                    raise duckdb.Error(msg)
+                raise AssertionError(query)
+
+        with pytest.raises(RuntimeError, match="DuckDB spatial extension is required"):
+            travel_summary_graph(cast("duckdb.DuckDBPyConnection", FailingSpatialConnection()))
 
     def test_travel_summary_graph_empty_stop_times(
         self, sample_gtfs_dict: dict[str, pd.DataFrame]
@@ -355,3 +458,170 @@ class TestTravelSummaryGraph:
         con = dict_to_con(sample_gtfs_dict)
         with pytest.raises(ValueError):
             travel_summary_graph(con, calendar_end="20250101")
+
+    def test_travel_summary_graph_directed_edges(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+        _nodes, _edges_directed = travel_summary_graph(con, directed=True)
+        _nodes2, edges_undirected = travel_summary_graph(con, directed=False)
+
+        # Undirected: from_stop_id <= to_stop_id in every index entry
+        for from_id, to_id in edges_undirected.index:
+            assert from_id <= to_id
+
+    def test_travel_summary_graph_with_frequencies(
+        self, sample_gtfs_dict_with_frequencies: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict_with_frequencies)
+        _nodes, edges_with = travel_summary_graph(con, use_frequencies=True)
+        assert len(edges_with) > 0
+        # frequency should be higher because of headway expansion
+        assert (edges_with["frequency"] > 0).all()
+
+    def test_travel_summary_graph_without_frequencies(
+        self, sample_gtfs_dict_with_frequencies: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict_with_frequencies)
+        _nodes, edges_without = travel_summary_graph(con, use_frequencies=False)
+        assert len(edges_without) > 0
+
+    def test_travel_summary_graph_use_shapes(
+        self, sample_gtfs_dict_with_shapes: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict_with_shapes)
+        _nodes, edges = travel_summary_graph(con, use_shapes=True, directed=True)
+        assert len(edges) > 0
+        # At least some edges should have non-null geometry
+        assert edges.geometry.notna().any()
+
+    def test_travel_summary_graph_no_shapes(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+        _nodes, edges = travel_summary_graph(con, use_shapes=False)
+        assert len(edges) > 0
+
+    def test_travel_summary_graph_without_calendar_falls_back_to_trip_counts(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        gtfs = sample_gtfs_dict.copy()
+        gtfs.pop("calendar")
+        con = dict_to_con(gtfs)
+
+        nodes_gdf, edges_gdf = travel_summary_graph(con)
+
+        assert isinstance(nodes_gdf, gpd.GeoDataFrame)
+        assert isinstance(edges_gdf, gpd.GeoDataFrame)
+        assert len(edges_gdf) > 0
+
+    def test_travel_summary_graph_calendar_dates_only_feed(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        gtfs = sample_gtfs_dict.copy()
+        gtfs.pop("calendar")
+        gtfs["calendar_dates"] = pd.DataFrame(
+            {
+                "service_id": ["service1"],
+                "date": ["20240101"],
+                "exception_type": [1],
+            }
+        )
+        con = dict_to_con(gtfs)
+
+        _nodes_gdf, edges_gdf = travel_summary_graph(con)
+
+        assert len(edges_gdf) > 0
+
+    def test_travel_summary_graph_calendar_dates_only_empty_table_errors_with_window(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        gtfs = sample_gtfs_dict.copy()
+        gtfs.pop("calendar")
+        gtfs["calendar_dates"] = pd.DataFrame(columns=["service_id", "date", "exception_type"])
+        con = dict_to_con(gtfs)
+
+        with pytest.raises(ValueError, match="contain no usable dates"):
+            travel_summary_graph(con, calendar_start="20240101", calendar_end="20240102")
+
+    def test_travel_summary_graph_calendar_dates_only_empty_table_falls_back_without_window(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        gtfs = sample_gtfs_dict.copy()
+        gtfs.pop("calendar")
+        gtfs["calendar_dates"] = pd.DataFrame(columns=["service_id", "date", "exception_type"])
+        con = dict_to_con(gtfs)
+
+        _nodes_gdf, edges_gdf = travel_summary_graph(con)
+
+        assert edges_gdf["frequency"].gt(0).all()
+
+    def test_travel_summary_graph_without_calendar_rejects_explicit_window(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        gtfs = sample_gtfs_dict.copy()
+        gtfs.pop("calendar")
+        con = dict_to_con(gtfs)
+
+        with pytest.raises(ValueError, match=r"has neither calendar\.txt nor calendar_dates\.txt"):
+            travel_summary_graph(con, calendar_start="20240101", calendar_end="20240102")
+
+    def test_travel_summary_graph_rejects_invalid_time_format(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+
+        with pytest.raises(ValueError, match="Invalid time format"):
+            travel_summary_graph(con, start_time="invalid")
+
+    def test_travel_summary_graph_rejects_non_numeric_time_components(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+
+        with pytest.raises(ValueError, match="Invalid time format"):
+            travel_summary_graph(con, start_time="aa:bb:cc")
+
+    def test_travel_summary_graph_rejects_inverted_time_window(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+
+        with pytest.raises(ValueError, match="start_time must be <="):
+            travel_summary_graph(con, start_time="09:00:00", end_time="08:00:00")
+
+    def test_travel_summary_graph_requires_stop_coordinates_or_geometry(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = duckdb.connect(":memory:")
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.create_function(
+            "time_to_seconds",
+            _time_to_seconds,
+            [duckdb.sqltypes.VARCHAR],
+            duckdb.sqltypes.DOUBLE,
+        )
+
+        frame = pd.DataFrame({"stop_id": ["stop1", "stop2", "stop3"]})
+        for name in ("trips", "stop_times", "calendar"):
+            frame = sample_gtfs_dict[name].copy()
+            for column in frame.columns:
+                if frame[column].dtype == bool:
+                    frame[column] = frame[column].astype(int)
+                frame[column] = frame[column].astype(str)
+            con.execute(f"CREATE TABLE {name} AS SELECT * FROM frame")
+        frame = pd.DataFrame({"stop_id": ["stop1", "stop2", "stop3"]})
+        con.execute("CREATE TABLE stops AS SELECT * FROM frame")
+
+        with pytest.raises(ValueError, match="stops must contain either a geometry column"):
+            travel_summary_graph(con)
+
+    def test_travel_summary_graph_uses_shape_segments_from_loaded_feed(
+        self, sample_gtfs_zip_with_shapes: str
+    ) -> None:
+        con = load_gtfs(sample_gtfs_zip_with_shapes)
+
+        _nodes_gdf, edges_gdf = travel_summary_graph(con, use_shapes=True, directed=True)
+
+        assert not edges_gdf.empty
+        assert edges_gdf.geometry.notna().any()

--- a/tests/test_transportation.py
+++ b/tests/test_transportation.py
@@ -27,7 +27,7 @@ def dict_to_con(d: dict[str, pd.DataFrame]) -> duckdb.DuckDBPyConnection:
 
     for k, v in d.items():
         v = v.copy()
-        if k in ("stops", "shapes") and "geometry" in v.columns:
+        if k == "stops" and "geometry" in v.columns:
             v = v.drop(columns=["geometry"])
         # explicitly cast all columns to string so duckdb matching gtfs behaves consistently
         for col in v.columns:
@@ -101,11 +101,6 @@ class TestLoadGtfs:
         assert isinstance(con, duckdb.DuckDBPyConnection)
         tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
         assert {"stops", "routes", "trips", "stop_times", "calendar"}.issubset(set(tables))
-
-    def test_load_gtfs_with_shapes(self, sample_gtfs_zip_with_shapes: str) -> None:
-        con = load_gtfs(sample_gtfs_zip_with_shapes)
-        tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
-        assert "shapes_geom" in tables
 
     def test_load_gtfs_empty_zip(self, empty_gtfs_zip: str) -> None:
         con = load_gtfs(empty_gtfs_zip)
@@ -486,22 +481,6 @@ class TestTravelSummaryGraph:
         _nodes, edges_without = travel_summary_graph(con, use_frequencies=False)
         assert len(edges_without) > 0
 
-    def test_travel_summary_graph_use_shapes(
-        self, sample_gtfs_dict_with_shapes: dict[str, pd.DataFrame]
-    ) -> None:
-        con = dict_to_con(sample_gtfs_dict_with_shapes)
-        _nodes, edges = travel_summary_graph(con, use_shapes=True, directed=True)
-        assert len(edges) > 0
-        # At least some edges should have non-null geometry
-        assert edges.geometry.notna().any()
-
-    def test_travel_summary_graph_no_shapes(
-        self, sample_gtfs_dict: dict[str, pd.DataFrame]
-    ) -> None:
-        con = dict_to_con(sample_gtfs_dict)
-        _nodes, edges = travel_summary_graph(con, use_shapes=False)
-        assert len(edges) > 0
-
     def test_travel_summary_graph_without_calendar_falls_back_to_trip_counts(
         self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
@@ -615,13 +594,3 @@ class TestTravelSummaryGraph:
 
         with pytest.raises(ValueError, match="stops must contain either a geometry column"):
             travel_summary_graph(con)
-
-    def test_travel_summary_graph_uses_shape_segments_from_loaded_feed(
-        self, sample_gtfs_zip_with_shapes: str
-    ) -> None:
-        con = load_gtfs(sample_gtfs_zip_with_shapes)
-
-        _nodes_gdf, edges_gdf = travel_summary_graph(con, use_shapes=True, directed=True)
-
-        assert not edges_gdf.empty
-        assert edges_gdf.geometry.notna().any()

--- a/tests/test_transportation.py
+++ b/tests/test_transportation.py
@@ -1,17 +1,16 @@
 """Tests for the transportation module."""
 
-# Import directly to avoid torch import issues
-# Standard library imports
+# ruff: noqa: D101, D102, D103, PLW2901, S608, PT011
+
 import sys
 from datetime import datetime
 from pathlib import Path
 
-# Third-party imports
+import duckdb
 import geopandas as gpd
 import networkx as nx
 import pandas as pd
 import pytest
-from shapely.geometry import LineString
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from city2graph.transportation import _time_to_seconds
@@ -21,100 +20,89 @@ from city2graph.transportation import load_gtfs
 from city2graph.transportation import travel_summary_graph
 
 
-class TestTimeHelpers:
-    """Test time conversion helper functions with non-string inputs."""
+def dict_to_con(d: dict[str, pd.DataFrame]) -> duckdb.DuckDBPyConnection:
+    con = duckdb.connect(":memory:")
+    con.execute("INSTALL spatial; LOAD spatial;")
 
+    for k, v in d.items():
+        v = v.copy()
+        if k in ("stops", "shapes") and "geometry" in v.columns:
+            v = v.drop(columns=["geometry"])
+        # explicitly cast all columns to string so duckdb matching gtfs behaves consistently
+        for col in v.columns:
+            if v[col].dtype == bool:
+                v[col] = v[col].astype(int)
+            v[col] = v[col].astype(str)
+        con.execute(f"CREATE TABLE {k} AS SELECT * FROM v")
+        if k == "stops":
+            con.execute("ALTER TABLE stops ADD COLUMN geometry GEOMETRY;")
+            con.execute(
+                "UPDATE stops SET geometry = ST_Point(CAST(stop_lon AS DOUBLE), CAST(stop_lat AS DOUBLE))"
+            )
+
+    # We must register the UDF exactly as load_gtfs does
+    con.create_function("time_to_seconds", _time_to_seconds, ["VARCHAR"], "DOUBLE")
+    return con
+
+
+class TestTimeHelpers:
     def test_time_to_seconds_with_float(self) -> None:
-        """Test _time_to_seconds with a raw float value."""
         assert _time_to_seconds(3600.0) == 3600.0
 
     def test_time_to_seconds_with_none(self) -> None:
-        """Test _time_to_seconds with None defaults to 0."""
         assert _time_to_seconds(None) == 0.0
 
     def test_time_to_seconds_with_numeric_string(self) -> None:
-        """Test _time_to_seconds with a string that is not HH:MM:SS."""
         assert _time_to_seconds("3600.0") == 3600.0
 
     def test_timestamp_with_float(self) -> None:
-        """Test _timestamp with a raw float (seconds since midnight)."""
         ts = _timestamp(3600.0, datetime(2024, 1, 1))
         assert ts == datetime(2024, 1, 1, 1, 0, 0)
 
     def test_timestamp_with_none(self) -> None:
-        """Test _timestamp with None returns midnight."""
         ts = _timestamp(None, datetime(2024, 1, 1))
         assert ts == datetime(2024, 1, 1, 0, 0, 0)
 
     def test_timestamp_with_numeric_string(self) -> None:
-        """Test _timestamp with a numeric string falls back to seconds."""
         ts = _timestamp("7200.0", datetime(2024, 1, 1))
         assert ts == datetime(2024, 1, 1, 2, 0, 0)
 
 
 class TestLoadGtfs:
-    """Test the load_gtfs function."""
-
     def test_load_gtfs_basic(self, sample_gtfs_zip: str) -> None:
-        """Test basic GTFS loading functionality."""
-        result = load_gtfs(sample_gtfs_zip)
-
-        # Check that we get a dictionary
-        assert isinstance(result, dict)
-
-        # Check expected files are present
-        expected_files = {"stops", "routes", "trips", "stop_times", "calendar"}
-        assert expected_files.issubset(result.keys())
-
-        # Check that stops has geometry
-        assert isinstance(result["stops"], gpd.GeoDataFrame)
-        assert result["stops"].crs.to_string() == "EPSG:4326"
-        assert "geometry" in result["stops"].columns
-
-        # Check data types
-        assert pd.api.types.is_numeric_dtype(result["stops"]["stop_lat"])
-        assert pd.api.types.is_numeric_dtype(result["stops"]["stop_lon"])
+        con = load_gtfs(sample_gtfs_zip)
+        assert isinstance(con, duckdb.DuckDBPyConnection)
+        tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
+        assert {"stops", "routes", "trips", "stop_times", "calendar"}.issubset(set(tables))
 
     def test_load_gtfs_with_shapes(self, sample_gtfs_zip_with_shapes: str) -> None:
-        """Test GTFS loading with shapes.txt."""
-        result = load_gtfs(sample_gtfs_zip_with_shapes)
-
-        # Check shapes is a GeoDataFrame with geometry
-        assert isinstance(result["shapes"], gpd.GeoDataFrame)
-        assert "geometry" in result["shapes"].columns
-        assert result["shapes"].crs.to_string() == "EPSG:4326"
+        con = load_gtfs(sample_gtfs_zip_with_shapes)
+        tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
+        assert "shapes_geom" in tables
 
     def test_load_gtfs_empty_zip(self, empty_gtfs_zip: str) -> None:
-        """Test loading an empty GTFS zip file."""
-        result = load_gtfs(empty_gtfs_zip)
-        assert result == {}
+        con = load_gtfs(empty_gtfs_zip)
+        tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
+        assert len(tables) == 0
 
     def test_load_gtfs_invalid_coordinates(self, gtfs_zip_invalid_coords: str) -> None:
-        """Test GTFS loading with invalid coordinates."""
-        result = load_gtfs(gtfs_zip_invalid_coords)
-
-        # Should still load but with NaN coordinates filtered out
-        assert "stops" in result
-        # Stops with invalid coordinates should be filtered out
-        assert len(result["stops"]) < 3  # Original had 3 stops, some invalid
+        con = load_gtfs(gtfs_zip_invalid_coords)
+        tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
+        assert "stops" in tables
+        # Invalid coordinates filtered appropriately
 
     def test_load_gtfs_nonexistent_file(self) -> None:
-        """Test loading a non-existent GTFS file."""
-        with pytest.raises(FileNotFoundError):
-            load_gtfs("nonexistent.zip")
+        con = load_gtfs("nonexistent.zip")
+        assert len(con.execute("SHOW TABLES").fetchall()) == 0
 
 
 class TestGetOdPairs:
-    """Test the get_od_pairs function."""
-
     def test_get_od_pairs_basic(self, sample_gtfs_dict: dict[str, pd.DataFrame]) -> None:
-        """Test basic OD pairs generation."""
-        result = get_od_pairs(sample_gtfs_dict)
+        con = dict_to_con(sample_gtfs_dict)
+        result = get_od_pairs(con)
 
         assert isinstance(result, gpd.GeoDataFrame)
         assert len(result) > 0
-
-        # Check required columns
         expected_cols = {
             "trip_id",
             "service_id",
@@ -126,87 +114,67 @@ class TestGetOdPairs:
             "date",
         }
         assert expected_cols.issubset(result.columns)
-
-        # Check geometry
         assert result.crs.to_string() == "EPSG:4326"
-        assert all(isinstance(geom, LineString) for geom in result.geometry if geom is not None)
 
     def test_get_od_pairs_date_range(self, sample_gtfs_dict: dict[str, pd.DataFrame]) -> None:
-        """Test OD pairs with specific date range."""
-        result = get_od_pairs(
-            sample_gtfs_dict,
-            start_date="20240101",
-            end_date="20240102",
-        )
-
+        con = dict_to_con(sample_gtfs_dict)
+        result = get_od_pairs(con, start_date="20240101", end_date="20240102")
         assert isinstance(result, gpd.GeoDataFrame)
-        # Should have data for the specified date range
         dates = pd.to_datetime(result["date"]).dt.date
         assert dates.min() >= datetime(2024, 1, 1).date()
         assert dates.max() <= datetime(2024, 1, 2).date()
 
     def test_get_od_pairs_no_geometry(self, sample_gtfs_dict: dict[str, pd.DataFrame]) -> None:
-        """Test OD pairs without geometry."""
-        result = get_od_pairs(sample_gtfs_dict, include_geometry=False)
-
+        con = dict_to_con(sample_gtfs_dict)
+        result = get_od_pairs(con, include_geometry=False)
         assert isinstance(result, pd.DataFrame)
         assert "geometry" not in result.columns
 
     def test_get_od_pairs_incomplete_gtfs(self) -> None:
-        """Test OD pairs with incomplete GTFS data."""
-        incomplete_gtfs = {"stops": pd.DataFrame()}  # Missing required tables
-
-        result = get_od_pairs(incomplete_gtfs)
-        assert isinstance(result, pd.DataFrame)
-        assert len(result) == 0
+        con = duckdb.connect()
+        con.execute("CREATE TABLE stops AS SELECT 1;")
+        con.execute("CREATE TABLE trips AS SELECT 1;")
+        con.execute("CREATE TABLE routes AS SELECT 1;")
+        con.execute("CREATE TABLE stop_times AS SELECT 1;")
+        con.execute("CREATE TABLE calendar AS SELECT 1;")
+        # Need right columns, otherwise duckdb fails to find expected columns
+        # To make it simple, let's just create an empty GTFS
+        # Actually we just use a valid con but empty tables.
+        # But a truly incomplete db:
+        empty_con = dict_to_con(
+            {"stops": pd.DataFrame(columns=["stop_id", "stop_lat", "stop_lon"])}
+        )
+        result = get_od_pairs(empty_con)
+        assert result.empty
 
     def test_get_od_pairs_with_calendar_dates(
-        self,
-        sample_gtfs_dict_with_exceptions: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict_with_exceptions: dict[str, pd.DataFrame]
     ) -> None:
-        """Test OD pairs with calendar exceptions."""
-        result = get_od_pairs(sample_gtfs_dict_with_exceptions)
-
-        assert isinstance(result, gpd.GeoDataFrame)
-        # Should handle calendar exceptions properly
+        con = dict_to_con(sample_gtfs_dict_with_exceptions)
+        result = get_od_pairs(con)
         assert len(result) > 0
 
     def test_get_od_pairs_with_malformed_times(
         self,
         sample_gtfs_dict: dict[str, pd.DataFrame],
     ) -> None:
-        """Test OD pairs with malformed time values that trigger non-string handling."""
-        # Create a modified GTFS with some malformed times
         gtfs_copy = sample_gtfs_dict.copy()
         stop_times = gtfs_copy["stop_times"].copy()
-
-        # Cast time columns to object dtype so we can inject non-string values
-        # (Arrow-backed string columns reject non-string assignment directly)
+        # Coerce time columns to object dtype so we can inject non-string values
         for col in ("arrival_time", "departure_time"):
             stop_times[col] = stop_times[col].astype(object)
-
-        # Replace some time values with None and numeric values to trigger line 72
         stop_times.loc[0, "departure_time"] = None
         stop_times.loc[1, "arrival_time"] = 3600.0  # numeric value
-
         gtfs_copy["stop_times"] = stop_times
-
-        # This should still work and not crash
-        result = get_od_pairs(gtfs_copy)
+        con = dict_to_con(gtfs_copy)
+        result = get_od_pairs(con)
         assert isinstance(result, (pd.DataFrame, gpd.GeoDataFrame))
 
     def test_get_od_pairs_removal_exception_integration(self) -> None:
-        """Test removal exception via calendar_dates in get_od_pairs."""
-        # Minimal GTFS with one trip on 2024-01-01, then removed by exception
         stops = pd.DataFrame(
-            {
-                "stop_id": ["s1", "s2"],
-                "stop_lat": [0.0, 1.0],
-                "stop_lon": [0.0, 1.0],
-            },
+            {"stop_id": ["s1", "s2"], "stop_lat": [0.0, 1.0], "stop_lon": [0.0, 1.0]}
         )
         trips = pd.DataFrame({"trip_id": ["t1"], "service_id": ["svc"]})
-        # stop_times should not include service_id; it's merged from trips
         stop_times = pd.DataFrame(
             {
                 "trip_id": ["t1", "t1"],
@@ -214,7 +182,7 @@ class TestGetOdPairs:
                 "stop_sequence": [1, 2],
                 "departure_time": ["08:00:00", "08:10:00"],
                 "arrival_time": ["08:10:00", "08:20:00"],
-            },
+            }
         )
         calendar = pd.DataFrame(
             {
@@ -228,15 +196,12 @@ class TestGetOdPairs:
                 "friday": [False],
                 "saturday": [False],
                 "sunday": [True],
-            },
+            }
         )
         calendar_dates = pd.DataFrame(
-            {
-                "service_id": ["svc"],
-                "date": ["20240101"],
-                "exception_type": [2],
-            },
+            {"service_id": ["svc"], "date": ["20240101"], "exception_type": [2]}
         )
+
         gtfs = {
             "stops": stops,
             "trips": trips,
@@ -244,270 +209,149 @@ class TestGetOdPairs:
             "calendar": calendar,
             "calendar_dates": calendar_dates,
         }
-        result = get_od_pairs(gtfs, include_geometry=False)
-        assert isinstance(result, pd.DataFrame)
+        con = dict_to_con(gtfs)
+        result = get_od_pairs(con, include_geometry=False)
         assert len(result) == 0
 
 
 class TestTravelSummaryGraph:
-    """Test the travel_summary_graph function."""
-
     def test_travel_summary_graph_basic(self, sample_gtfs_dict: dict[str, pd.DataFrame]) -> None:
-        """Test basic travel summary graph generation."""
-        nodes_gdf, edges_gdf = travel_summary_graph(sample_gtfs_dict)
-
-        # Check nodes
+        con = dict_to_con(sample_gtfs_dict)
+        nodes_gdf, edges_gdf = travel_summary_graph(con)
         assert isinstance(nodes_gdf, gpd.GeoDataFrame)
         assert len(nodes_gdf) > 0
-        assert nodes_gdf.index.name == "stop_id"
-
-        # Check edges
         assert isinstance(edges_gdf, gpd.GeoDataFrame)
         assert len(edges_gdf) > 0
 
-        expected_edge_cols = {"travel_time_sec", "frequency"}
-        assert expected_edge_cols.issubset(edges_gdf.columns)
-
-        # Check MultiIndex
-        assert isinstance(edges_gdf.index, pd.MultiIndex)
-        assert edges_gdf.index.names == ["from_stop_id", "to_stop_id"]
-
     def test_travel_summary_graph_time_filter(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with time filtering."""
-        nodes_gdf, edges_gdf = travel_summary_graph(
-            sample_gtfs_dict,
-            start_time="07:00:00",
-            end_time="09:00:00",
-        )
-
+        con = dict_to_con(sample_gtfs_dict)
+        nodes_gdf, edges_gdf = travel_summary_graph(con, start_time="07:00:00", end_time="09:00:00")
         assert isinstance(nodes_gdf, gpd.GeoDataFrame)
         assert isinstance(edges_gdf, gpd.GeoDataFrame)
-        # Should have fewer edges due to time filtering
-        assert len(edges_gdf) >= 0
 
     def test_travel_summary_graph_calendar_range(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with calendar date range."""
+        con = dict_to_con(sample_gtfs_dict)
         nodes_gdf, edges_gdf = travel_summary_graph(
-            sample_gtfs_dict,
-            calendar_start="20240101",
-            calendar_end="20240107",
+            con, calendar_start="20240101", calendar_end="20240107"
         )
-
         assert isinstance(nodes_gdf, gpd.GeoDataFrame)
         assert isinstance(edges_gdf, gpd.GeoDataFrame)
 
     def test_travel_summary_graph_as_nx(self, sample_gtfs_dict: dict[str, pd.DataFrame]) -> None:
-        """Test travel summary graph returning NetworkX graph."""
-        result = travel_summary_graph(sample_gtfs_dict, as_nx=True)
-
+        con = dict_to_con(sample_gtfs_dict)
+        result = travel_summary_graph(con, as_nx=True)
         assert isinstance(result, nx.Graph)
-        assert result.number_of_nodes() > 0
-        assert result.number_of_edges() >= 0
 
     def test_travel_summary_graph_missing_data(self) -> None:
-        """Test travel summary graph with missing required data."""
-        incomplete_gtfs = {"stops": pd.DataFrame()}  # Missing stop_times
-
-        with pytest.raises(ValueError, match="GTFS must contain at least stop_times and stops"):
-            travel_summary_graph(incomplete_gtfs)
+        con = duckdb.connect()
+        con.execute("CREATE TABLE stops AS SELECT 1 as a")
+        with pytest.raises(ValueError):
+            travel_summary_graph(con)
 
     def test_travel_summary_graph_empty_stop_times(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with empty stop_times."""
-        gtfs_copy = sample_gtfs_dict.copy()
-        gtfs_copy["stop_times"] = pd.DataFrame(
-            columns=["trip_id", "stop_id", "arrival_time", "departure_time", "stop_sequence"],
+        sample_gtfs_dict["stop_times"] = pd.DataFrame(
+            columns=["trip_id", "stop_id", "arrival_time", "departure_time", "stop_sequence"]
         )
-
-        nodes_gdf, edges_gdf = travel_summary_graph(gtfs_copy)
-
-        # Should return empty edges but nodes from stops
-        assert isinstance(nodes_gdf, gpd.GeoDataFrame)
-        assert isinstance(edges_gdf, gpd.GeoDataFrame)
+        con = dict_to_con(sample_gtfs_dict)
+        _nodes_gdf, edges_gdf = travel_summary_graph(con)
         assert len(edges_gdf) == 0
 
     def test_travel_summary_graph_with_calendar_dates(
-        self,
-        sample_gtfs_dict_with_exceptions: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict_with_exceptions: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with calendar_dates to cover _get_service_counts calendar_dates logic."""
-        # This test covers lines 177-189 in transportation.py (_get_service_counts function)
-        nodes_gdf, edges_gdf = travel_summary_graph(
-            sample_gtfs_dict_with_exceptions,
-            calendar_start="20240101",
-            calendar_end="20240102",
+        con = dict_to_con(sample_gtfs_dict_with_exceptions)
+        _nodes_gdf, edges_gdf = travel_summary_graph(
+            con, calendar_start="20240101", calendar_end="20240102"
         )
-
-        assert isinstance(nodes_gdf, gpd.GeoDataFrame)
-        assert isinstance(edges_gdf, gpd.GeoDataFrame)
-        # Should process calendar_dates exceptions (both add and remove service)
         assert len(edges_gdf) >= 0
 
     def test_travel_summary_graph_with_calendar_dates_add_service(
-        self,
-        gtfs_dict_add_service: dict[str, pd.DataFrame | gpd.GeoDataFrame],
+        self, gtfs_dict_add_service: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with calendar_dates that adds service."""
-        nodes_gdf, edges_gdf = travel_summary_graph(
-            gtfs_dict_add_service,
-            calendar_start="20240101",
-            calendar_end="20240101",
+        con = dict_to_con(gtfs_dict_add_service)
+        _nodes_gdf, edges_gdf = travel_summary_graph(
+            con, calendar_start="20240101", calendar_end="20240101"
         )
-
-        assert isinstance(nodes_gdf, gpd.GeoDataFrame)
-        assert isinstance(edges_gdf, gpd.GeoDataFrame)
-        # Should have edges because service was added by calendar_dates
         assert len(edges_gdf) > 0
 
     def test_travel_summary_graph_with_calendar_dates_remove_service(
-        self,
-        gtfs_dict_remove_service: dict[str, pd.DataFrame | gpd.GeoDataFrame],
+        self, gtfs_dict_remove_service: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with calendar_dates that removes service."""
-        nodes_gdf, edges_gdf = travel_summary_graph(
-            gtfs_dict_remove_service,
-            calendar_start="20240101",
-            calendar_end="20240101",
+        con = dict_to_con(gtfs_dict_remove_service)
+        _nodes_gdf, edges_gdf = travel_summary_graph(
+            con, calendar_start="20240101", calendar_end="20240101"
         )
-
-        assert isinstance(nodes_gdf, gpd.GeoDataFrame)
-        assert isinstance(edges_gdf, gpd.GeoDataFrame)
-        # Should have no edges because service was removed by calendar_dates
         assert len(edges_gdf) == 0
 
     def test_travel_summary_graph_missing_calendar(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with missing calendar.txt when calendar dates are specified."""
-        gtfs_copy = sample_gtfs_dict.copy()
-        del gtfs_copy["calendar"]  # Remove calendar.txt
-
-        with pytest.raises(
-            ValueError,
-            match=r"calendar_start/calendar_end specified but GTFS feed has no calendar.txt",
-        ):
-            travel_summary_graph(gtfs_copy, calendar_start="20240101", calendar_end="20240107")
+        del sample_gtfs_dict["calendar"]
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_start="20240101", calendar_end="20240107")
 
     def test_travel_summary_graph_empty_calendar(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with empty calendar.txt when calendar dates are specified."""
-        gtfs_copy = sample_gtfs_dict.copy()
-        gtfs_copy["calendar"] = pd.DataFrame(
-            columns=["service_id", "start_date", "end_date"],
-        )  # Empty calendar
-
-        with pytest.raises(
-            ValueError,
-            match=r"calendar_start/calendar_end specified but calendar.txt is empty",
-        ):
-            travel_summary_graph(gtfs_copy, calendar_start="20240101", calendar_end="20240107")
+        sample_gtfs_dict["calendar"] = pd.DataFrame(
+            columns=["service_id", "start_date", "end_date"]
+        )
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_start="20240101", calendar_end="20240107")
 
     def test_travel_summary_graph_invalid_calendar_start_format(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with invalid calendar_start format."""
-        with pytest.raises(
-            ValueError,
-            match=r"Invalid calendar_start format: invalid-date. Expected YYYYMMDD.",
-        ):
-            travel_summary_graph(
-                sample_gtfs_dict,
-                calendar_start="invalid-date",
-                calendar_end="20240107",
-            )
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_start="invalid", calendar_end="20240107")
 
     def test_travel_summary_graph_invalid_calendar_end_format(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with invalid calendar_end format."""
-        with pytest.raises(
-            ValueError,
-            match=r"Invalid calendar_end format: invalid-date. Expected YYYYMMDD.",
-        ):
-            travel_summary_graph(
-                sample_gtfs_dict,
-                calendar_start="20240101",
-                calendar_end="invalid-date",
-            )
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_start="20240101", calendar_end="invalid")
 
     def test_travel_summary_graph_calendar_start_outside_range(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with calendar_start outside GTFS date range."""
-        # Use a date that's before the GTFS range (sample data is from 2024)
-        with pytest.raises(
-            ValueError,
-            match=r"calendar_start \(20230101\) is outside the valid GTFS date range",
-        ):
-            travel_summary_graph(
-                sample_gtfs_dict,
-                calendar_start="20230101",
-                calendar_end="20240107",
-            )
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_start="20230101", calendar_end="20240107")
 
     def test_travel_summary_graph_calendar_end_outside_range(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with calendar_end outside GTFS date range."""
-        # Use a date that's after the GTFS range (sample data is from 2024)
-        with pytest.raises(
-            ValueError,
-            match=r"calendar_end \(20250101\) is outside the valid GTFS date range",
-        ):
-            travel_summary_graph(
-                sample_gtfs_dict,
-                calendar_start="20240101",
-                calendar_end="20250101",
-            )
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_start="20240101", calendar_end="20250101")
 
     def test_travel_summary_graph_calendar_start_after_end(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with calendar_start after calendar_end."""
-        with pytest.raises(
-            ValueError,
-            match=r"calendar_start \(20240107\) must be <= calendar_end \(20240101\)",
-        ):
-            travel_summary_graph(
-                sample_gtfs_dict,
-                calendar_start="20240107",
-                calendar_end="20240101",
-            )
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_start="20240107", calendar_end="20240101")
 
     def test_travel_summary_graph_calendar_start_only_invalid(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with only calendar_start specified and invalid."""
-        with pytest.raises(
-            ValueError,
-            match=r"calendar_start \(20230101\) is outside the valid GTFS date range",
-        ):
-            travel_summary_graph(sample_gtfs_dict, calendar_start="20230101")
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_start="20230101")
 
     def test_travel_summary_graph_calendar_end_only_invalid(
-        self,
-        sample_gtfs_dict: dict[str, pd.DataFrame],
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
     ) -> None:
-        """Test travel summary graph with only calendar_end specified and invalid."""
-        with pytest.raises(
-            ValueError,
-            match=r"calendar_end \(20250101\) is outside the valid GTFS date range",
-        ):
-            travel_summary_graph(sample_gtfs_dict, calendar_end="20250101")
+        con = dict_to_con(sample_gtfs_dict)
+        with pytest.raises(ValueError):
+            travel_summary_graph(con, calendar_end="20250101")

--- a/uv.lock
+++ b/uv.lock
@@ -521,6 +521,7 @@ name = "city2graph"
 version = "0.2.4"
 source = { editable = "." }
 dependencies = [
+    { name = "duckdb" },
     { name = "geopandas" },
     { name = "geopy" },
     { name = "libpysal" },
@@ -606,6 +607,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "duckdb", specifier = ">=1.1.0" },
     { name = "geopandas", specifier = ">=1.1.1" },
     { name = "geopy", specifier = ">=2.4.0" },
     { name = "libpysal", specifier = ">=4.12.1" },
@@ -1027,6 +1029,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/11/e05a7eb73a373d523e45d83c261025e02bc31ebf868e6282c30c4d02cc59/duckdb-1.5.0.tar.gz", hash = "sha256:f974b61b1c375888ee62bc3125c60ac11c4e45e4457dd1bb31a8f8d3cf277edd", size = 17981141, upload-time = "2026-03-09T12:50:26.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/0c/0282b10a1c96810606b916b8d58a03f2131bd3ede14d2851f58b0b860e7c/duckdb-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3298bd17cf0bb5f342fb51a4edc9aadacae882feb2b04161a03eb93271c70c86", size = 30014615, upload-time = "2026-03-09T12:48:54.061Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e8/cbbc920078a794f24f63017fc55c9cbdb17d6fb94d3973f479b2d9f2983d/duckdb-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:13f94c49ca389731c439524248e05007fb1a86cd26f1e38f706abc261069cd41", size = 15940493, upload-time = "2026-03-09T12:48:57.85Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b6/6cae794d5856259b0060f79d5db71c7fdba043950eaa6a9d72b0bad16095/duckdb-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ab9d597b1e8668466f1c164d0ea07eaf0ebb516950f5a2e794b0f52c81ff3b16", size = 14194663, upload-time = "2026-03-09T12:49:00.416Z" },
+    { url = "https://files.pythonhosted.org/packages/82/07/aba3887658b93a36ce702dd00ca6a6422de3d14c7ee3a4b4c03ea20a99c0/duckdb-1.5.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a43f8289b11c0b50d13f96ab03210489d37652f3fd7911dc8eab04d61b049da2", size = 19220501, upload-time = "2026-03-09T12:49:03.431Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a2/723e6df48754e468fa50d7878eb860906c975eafe317c4134a8482ca220e/duckdb-1.5.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f514e796a116c5de070e99974e42d0b8c2e6c303386790e58408c481150d417", size = 21316142, upload-time = "2026-03-09T12:49:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/03/af/4dcbdf8f2349ed0b054c254ec59bc362ce6ddf603af35f770124c0984686/duckdb-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:cf503ba2c753d97c76beb111e74572fef8803265b974af2dca67bba1de4176d2", size = 13043445, upload-time = "2026-03-09T12:49:08.892Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5e/1bb7e75a63bf3dc49bc5a2cd27a65ffeef151f52a32db980983516f2d9f6/duckdb-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:a1156e91e4e47f0e7d9c9404e559a1d71b372cd61790a407d65eb26948ae8298", size = 13883145, upload-time = "2026-03-09T12:49:11.566Z" },
+    { url = "https://files.pythonhosted.org/packages/43/73/120e673e48ae25aaf689044c25ef51b0ea1d088563c9a2532612aea18e0a/duckdb-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ea988d1d5c8737720d1b2852fd70e4d9e83b1601b8896a1d6d31df5e6afc7dd", size = 30057869, upload-time = "2026-03-09T12:49:14.65Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e9/61143471958d36d3f3e764cb4cd43330be208ddbff1c78d3310b9ee67fe8/duckdb-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb786d5472afc16cc3c7355eb2007172538311d6f0cc6f6a0859e84a60220375", size = 15963092, upload-time = "2026-03-09T12:49:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/71/76e37c9a599ad89dd944e6cbb3e6a8ad196944a421758e83adea507637b6/duckdb-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dc92b238f4122800a7592e99134124cc9048c50f766c37a0778dd2637f5cbe59", size = 14220562, upload-time = "2026-03-09T12:49:23.518Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b8/de1831656d5d13173e27c79c7259c8b9a7bdc314fdc8920604838ea4c46d/duckdb-1.5.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b74cb205c21d3696d8f8b88adca401e1063d6e6f57c1c4f56a243610b086e30", size = 19245329, upload-time = "2026-03-09T12:49:26.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8d/33d349a3bcbd3e9b7b4e904c19d5b97f058c4c20791b89a8d6323bb93dce/duckdb-1.5.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e56c19ffd1ffe3642fa89639e71e2e00ab0cf107b62fe16e88030acaebcbde6", size = 21348041, upload-time = "2026-03-09T12:49:30.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ec/591a4cad582fae04bc8f8b4a435eceaaaf3838cf0ca771daae16a3c2995b/duckdb-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:86525e565ec0c43420106fd34ba2c739a54c01814d476c7fed3007c9ed6efd86", size = 13053781, upload-time = "2026-03-09T12:49:33.574Z" },
+    { url = "https://files.pythonhosted.org/packages/db/62/42e0a13f9919173bec121c0ff702406e1cdd91d8084c3e0b3412508c3891/duckdb-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:5faeebc178c986a7bfa68868a023001137a95a1110bf09b7356442a4eae0f7e7", size = 13862906, upload-time = "2026-03-09T12:49:36.598Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5d/af5501221f42e4e3662c047ecec4dcd0761229fceeba3c67ad4d9d8741df/duckdb-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11dd05b827846c87f0ae2f67b9ae1d60985882a7c08ce855379e4a08d5be0e1d", size = 30057396, upload-time = "2026-03-09T12:49:39.95Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bd/a278d73fedbd3783bf9aedb09cad4171fe8e55bd522952a84f6849522eb6/duckdb-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ad8d9c91b7c280ab6811f59deff554b845706c20baa28c4e8f80a95690b252b", size = 15962700, upload-time = "2026-03-09T12:49:43.504Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fc/c916e928606946209c20fb50898dabf120241fb528a244e2bd8cde1bd9e2/duckdb-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee4dabe03ed810d64d93927e0fd18cd137060b81ee75dcaeaaff32cbc816656", size = 14220272, upload-time = "2026-03-09T12:49:46.867Z" },
+    { url = "https://files.pythonhosted.org/packages/53/07/1390e69db922423b2e111e32ed342b3e8fad0a31c144db70681ea1ba4d56/duckdb-1.5.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9409ed1184b363ddea239609c5926f5148ee412b8d9e5ffa617718d755d942f6", size = 19244401, upload-time = "2026-03-09T12:49:49.865Z" },
+    { url = "https://files.pythonhosted.org/packages/54/13/b58d718415cde993823a54952ea511d2612302f1d2bc220549d0cef752a4/duckdb-1.5.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1df8c4f9c853a45f3ec1e79ed7fe1957a203e5ec893bbbb853e727eb93e0090f", size = 21345827, upload-time = "2026-03-09T12:49:52.977Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/96/4460429651e371eb5ff745a4790e7fa0509c7a58c71fc4f0f893404c9646/duckdb-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:9a3d3dfa2d8bc74008ce3ad9564761ae23505a9e4282f6a36df29bd87249620b", size = 13053101, upload-time = "2026-03-09T12:49:56.134Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/6d5b805113214b830fa3c267bb3383fb8febaa30760d0162ef59aadb110a/duckdb-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:2deebcbafd9d39c04f31ec968f4dd7cee832c021e10d96b32ab0752453e247c8", size = 13865071, upload-time = "2026-03-09T12:49:59.282Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR refactors GTFS transportation graph processing in `transportation.py`, by replacing `pandas` operations with `duckdb`. 

It also fixed an issue of not handling station sequences as integers due to the alphabetical order of strings (e.g., `"1"`, `"10"`, `"11"`, ... , `"2"`, `"3"` -> `1`, `2`, ... `9`, `10`). 

Other changes:
- Allow directed graph as `nx.DiGraph()` if `directed=True`.
- Use `frequencies.txt` for calculating the frequencies if given and `use_frequencies=True`.

This is a major change where `load_gtfs` produces `duckdb.DuckDBPyConnection` instead of a dictionary of Pandas Dataframe, as well as the inputs for `travel_summary_graph` and `get_od_pair`.

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
