### PR TITLE
Fix load_overture_data to properly clip the data before saving

### DIFF
--- a/city2graph/data.py
+++ b/city2graph/data.py
@@ -487,6 +487,7 @@ def _download_and_process_type(  # noqa: PLR0912, PLR0913, C901
     ...                                  './data', 'nyc', True, True, None, '2024-11-13.0')
     """
     output_path = Path(output_dir) / f"{prefix}{data_type}.geojson"
+    needs_postprocessing = clip_geom is not None or data_type == "segment"
 
     # Build and execute download command
     cmd = ["overturemaps", "download", f"--bbox={bbox_str}", "-f", "geojson", f"--type={data_type}"]
@@ -503,11 +504,12 @@ def _download_and_process_type(  # noqa: PLR0912, PLR0913, C901
 
     result = subprocess.run(cmd, check=True, capture_output=not save_to_file, text=True)
 
-    if not return_data:
+    output_exists = save_to_file and output_path.exists()
+    if not return_data and not (output_exists and needs_postprocessing):
         return gpd.GeoDataFrame(geometry=[], crs=WGS84_CRS)
 
     # Load and clip data if needed
-    if save_to_file and output_path.exists():
+    if output_exists:
         gdf = gpd.read_file(output_path)
     elif not save_to_file and result.stdout and isinstance(result.stdout, str):
         # Parse GeoJSON from subprocess stdout when not saving to file
@@ -557,6 +559,9 @@ def _download_and_process_type(  # noqa: PLR0912, PLR0913, C901
             exploded = multi.explode(index_parts=False)
             lines = pd.concat([lines, exploded])
         gdf = lines.reset_index(drop=True)
+
+    if output_exists and needs_postprocessing:
+        gdf.to_file(output_path, driver="GeoJSON")
 
     return gdf
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -139,6 +139,48 @@ class TestLoadOvertureData:
 
     @patch("city2graph.data.subprocess.run")
     @patch("city2graph.data.gpd.read_file")
+    @patch("city2graph.data.gpd.clip")
+    @patch("city2graph.data.Path.exists")
+    def test_polygon_clipping_rewrites_saved_file_when_not_returning_data(
+        self,
+        mock_exists: Mock,
+        mock_clip: Mock,
+        mock_read_file: Mock,
+        mock_subprocess: Mock,
+        test_polygon: Polygon,
+    ) -> None:
+        """Processed polygon queries should overwrite the saved GeoJSON on disk."""
+        raw_gdf = gpd.GeoDataFrame(
+            {"id": ["raw"]},
+            geometry=[Polygon([(0, 0), (2, 0), (2, 2), (0, 0)])],
+            crs=WGS84_CRS,
+        )
+        clipped_gdf = gpd.GeoDataFrame(
+            {"id": ["clipped"]},
+            geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 0)])],
+            crs=WGS84_CRS,
+        )
+        clipped_gdf.to_file = Mock()
+        mock_exists.return_value = True
+        mock_read_file.return_value = raw_gdf
+        mock_clip.return_value = clipped_gdf
+
+        result = load_overture_data(
+            test_polygon,
+            types=["building"],
+            return_data=False,
+            prefix="processed_",
+        )
+
+        assert result == {}
+        clipped_gdf.to_file.assert_called_once()
+        output_path = clipped_gdf.to_file.call_args.args[0]
+        assert output_path.name == "processed_building.geojson"
+        assert clipped_gdf.to_file.call_args.kwargs == {"driver": "GeoJSON"}
+        mock_subprocess.assert_called_once()
+
+    @patch("city2graph.data.subprocess.run")
+    @patch("city2graph.data.gpd.read_file")
     @patch("city2graph.data.clip_graph")
     @patch("city2graph.data.Path.exists")
     def test_segment_polygon_clipping_uses_topological_subset(


### PR DESCRIPTION
## Description

`load_overture_data` ensured that the data is clipped before saving it to GeoJSON if `save_to_file=True`.
## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
