### PR TITLE
Fix the treatment of undirected edges in `gdf_to_pyg` and `pyg_to_gdf`

### DIFF
--- a/city2graph/base.py
+++ b/city2graph/base.py
@@ -113,6 +113,24 @@ class GraphMetadata:
         # When False (default), gdf_to_pyg symmetrizes edges and pyg_to_gdf deduplicates.
         self.is_directed: bool | dict[tuple[str, str, str], bool] = False
 
+        # Per-edge-type symmetrization tracking.
+        # Records what city2graph actually symmetrized during conversion.
+        # Reconstruction uses this (not just is_directed) to decide deduplication,
+        # because a hetero graph can mix directed and undirected edge types.
+        self.edge_was_symmetrized: bool | dict[tuple[str, str, str], bool] = False
+
+        # Cross-type reverse edge type mappings.
+        # Maps original cross-type edge types to generated reverse edge types.
+        self.reverse_edge_types: dict[tuple[str, str, str], tuple[str, str, str]] = {}
+        # Maps generated reverse edge types back to their original edge types.
+        self.generated_reverse_edge_types: dict[tuple[str, str, str], tuple[str, str, str]] = {}
+
+        # Edge types supplied by the user before city2graph added any generated
+        # reverse stores. Generated reverse edge stores are implementation
+        # artefacts for PyG message passing and should be skipped by default
+        # during pyg_to_gdf reconstruction.
+        self.original_edge_types: list[tuple[str, str, str]] = []
+
     def to_dict(self) -> dict[str, object]:
         """
         Convert to dictionary for NetworkX graph metadata.

--- a/city2graph/base.py
+++ b/city2graph/base.py
@@ -109,6 +109,10 @@ class GraphMetadata:
         self.node_geometries: dict[str, list[str]] | list[str] | None = None
         self.edge_geometries: dict[tuple[str, str, str], list[str]] | list[str] | None = None
 
+        # Directed flag: tracks whether edges are directed in the PyG representation.
+        # When False (default), gdf_to_pyg symmetrizes edges and pyg_to_gdf deduplicates.
+        self.is_directed: bool | dict[tuple[str, str, str], bool] = False
+
     def to_dict(self) -> dict[str, object]:
         """
         Convert to dictionary for NetworkX graph metadata.

--- a/city2graph/base.py
+++ b/city2graph/base.py
@@ -87,10 +87,10 @@ class GraphMetadata:
         self.edge_types: list[tuple[str, str, str]] = []
 
         # Index management
-        self.node_index_names: dict[str, list[str] | None] | list[str] | None = None
-        self.edge_index_names: dict[tuple[str, str, str], list[str] | None] | list[str] | None = (
-            None
-        )
+        self.node_index_names: dict[str, list[str | None] | None] | list[str | None] | None = None
+        self.edge_index_names: (
+            dict[tuple[str, str, str], list[str | None] | None] | list[str | None] | None
+        ) = None
 
         # Geometry column tracking
         self.node_geom_cols: list[str] = []
@@ -103,6 +103,9 @@ class GraphMetadata:
         self.edge_feature_cols: dict[tuple[str, str, str], list[str]] | list[str] | None = None
         self.edge_index_values: (
             dict[tuple[str, str, str], list[list[str | int]]] | list[list[str | int]] | None
+        ) = None
+        self.edge_index_keys: (
+            dict[tuple[str, str, str], list[str | int]] | list[str | int] | None
         ) = None
 
         # Geometry storage for exact reconstruction (WKB hexadecimal format)
@@ -118,6 +121,10 @@ class GraphMetadata:
         # Reconstruction uses this (not just is_directed) to decide deduplication,
         # because a hetero graph can mix directed and undirected edge types.
         self.edge_was_symmetrized: bool | dict[tuple[str, str, str], bool] = False
+
+        # Multigraph flag: true when edge identity includes an explicit key level
+        # or when conversion generated keys for opt-in multigraph handling.
+        self.is_multigraph: bool | dict[tuple[str, str, str], bool] = False
 
         # Cross-type reverse edge type mappings.
         # Maps original cross-type edge types to generated reverse edge types.

--- a/city2graph/graph.py
+++ b/city2graph/graph.py
@@ -108,6 +108,10 @@ class PyGConverter(BaseGraphConverter):
         Data type for float tensors.
     keep_geom : bool, default True
         Whether to preserve geometry information during conversion.
+    directed : bool, default False
+        Whether to treat edges as directed. If False (default), edges are
+        symmetrized during conversion to PyG (reverse edges are added) and
+        deduplicated during reconstruction back to GeoDataFrames.
     """
 
     def __init__(
@@ -118,6 +122,7 @@ class PyGConverter(BaseGraphConverter):
         device: str | torch.device | None = None,
         dtype: torch.dtype | None = None,
         keep_geom: bool = True,
+        directed: bool = False,
     ) -> None:
         """
         Initialize PyGConverter.
@@ -141,8 +146,12 @@ class PyGConverter(BaseGraphConverter):
             If True, original geometries are serialized and stored in metadata.
             If False, geometries are reconstructed from node positions during
             conversion back to GeoDataFrames.
+        directed : bool, default False
+            Whether to treat edges as directed. If False (default), edges are
+            symmetrized during conversion to PyG (reverse edges are added) and
+            deduplicated during reconstruction back to GeoDataFrames.
         """
-        super().__init__(keep_geom=keep_geom)
+        super().__init__(keep_geom=keep_geom, directed=directed)
         self.node_feature_cols = node_feature_cols
         self.node_label_cols = node_label_cols
         self.edge_feature_cols = edge_feature_cols
@@ -319,6 +328,10 @@ class PyGConverter(BaseGraphConverter):
                 )
             edge_attr = self._create_features(edges, edge_feature_cols_homo)
 
+            # Symmetrize edges for undirected graphs
+            if not self.directed and edge_index.size(1) > 0:
+                edge_index, edge_attr = self._symmetrize_edges(edge_index, edge_attr, device)
+
         data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr, y=y, pos=pos)
 
         # Store metadata
@@ -332,6 +345,7 @@ class PyGConverter(BaseGraphConverter):
             node_label_cols_homo,
             edge_feature_cols_homo,
         )
+        metadata.is_directed = self.directed
 
         data.graph_metadata = metadata
         return data
@@ -395,9 +409,15 @@ class PyGConverter(BaseGraphConverter):
             metadata.edge_index_names = edges.index.names
 
             # Store original edge index values for reconstruction
-            metadata.edge_index_values = [
+            edge_idx_vals = [
                 edges.index.get_level_values(i).tolist() for i in range(edges.index.nlevels)
             ]
+
+            # Symmetrize edge index values for undirected graphs
+            if not self.directed and len(edge_idx_vals) == 2:
+                edge_idx_vals = self._symmetrize_edge_index_values(edge_idx_vals)
+
+            metadata.edge_index_values = edge_idx_vals
         else:
             metadata.edge_index_names = None
             metadata.edge_index_values = None
@@ -410,7 +430,13 @@ class PyGConverter(BaseGraphConverter):
         if self.keep_geom:
             metadata.node_geometries = self._serialize_geometries(nodes)
             if edges is not None and not edges.empty:
-                metadata.edge_geometries = self._serialize_geometries(edges)
+                edge_geoms = self._serialize_geometries(edges)
+
+                # Symmetrize edge geometries for undirected graphs
+                if not self.directed and edge_geoms is not None:
+                    edge_geoms = self._symmetrize_edge_geometries(edges, edge_geoms)
+
+                metadata.edge_geometries = edge_geoms
 
         return metadata
 
@@ -599,10 +625,18 @@ class PyGConverter(BaseGraphConverter):
                     if edge_pairs
                     else torch.zeros((2, 0), dtype=torch.long, device=device)
                 )
-                data[edge_type].edge_index = edge_index
 
                 feature_cols = edge_feature_cols.get(edge_type) if edge_feature_cols else None
-                data[edge_type].edge_attr = self._create_features(edge_gdf, feature_cols)
+                edge_attr = self._create_features(edge_gdf, feature_cols)
+
+                # Symmetrize edges for undirected graphs (only same-type edges)
+                # Cross-type edges (src_type != dst_type) cannot be symmetrized
+                # within the same edge type.
+                if not self.directed and edge_index.size(1) > 0 and src_type == dst_type:
+                    edge_index, edge_attr = self._symmetrize_edges(edge_index, edge_attr, device)
+
+                data[edge_type].edge_index = edge_index
+                data[edge_type].edge_attr = edge_attr
             else:
                 data[edge_type].edge_index = torch.zeros((2, 0), dtype=torch.long, device=device)
                 data[edge_type].edge_attr = torch.empty(
@@ -667,10 +701,17 @@ class PyGConverter(BaseGraphConverter):
                 metadata.edge_index_names[edge_type] = edge_gdf.index.names
 
                 # Store original edge index values for reconstruction
-                metadata.edge_index_values[edge_type] = [
+                edge_idx_vals = [
                     edge_gdf.index.get_level_values(i).tolist()
                     for i in range(edge_gdf.index.nlevels)
                 ]
+
+                # Symmetrize edge index values for undirected same-type edges
+                src_type, _, dst_type = edge_type
+                if not self.directed and len(edge_idx_vals) == 2 and src_type == dst_type:
+                    edge_idx_vals = self._symmetrize_edge_index_values(edge_idx_vals)
+
+                metadata.edge_index_values[edge_type] = edge_idx_vals
 
         # Set CRS
         crs_values = [gdf.crs for gdf in nodes_dict.values() if hasattr(gdf, "crs") and gdf.crs]
@@ -691,8 +732,13 @@ class PyGConverter(BaseGraphConverter):
                 if edge_gdf is not None and not edge_gdf.empty:
                     geoms = self._serialize_geometries(edge_gdf)
                     if geoms is not None:
+                        # Symmetrize edge geometries for undirected same-type edges
+                        src_type, _, dst_type = edge_type
+                        if not self.directed and src_type == dst_type:
+                            geoms = self._symmetrize_edge_geometries(edge_gdf, geoms)
                         metadata.edge_geometries[edge_type] = geoms
 
+        metadata.is_directed = self.directed
         data.graph_metadata = metadata
 
     def _create_node_id_mapping(
@@ -788,6 +834,153 @@ class PyGConverter(BaseGraphConverter):
         combined_array = np.column_stack([from_indices, to_indices]).astype(int)
         result: list[list[int]] = combined_array.tolist()
         return result
+
+    def _symmetrize_edges(
+        self,
+        edge_index: torch.Tensor,
+        edge_attr: torch.Tensor,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Symmetrize directed edges to represent an undirected graph.
+
+        For each edge (u, v) where u != v, adds the reverse edge (v, u).
+        Self-loops (u, u) are not duplicated. Edge attributes are duplicated
+        accordingly.
+
+        Parameters
+        ----------
+        edge_index : torch.Tensor
+            Edge connectivity tensor of shape [2, num_edges].
+        edge_attr : torch.Tensor
+            Edge attribute tensor of shape [num_edges, num_features].
+        device : torch.device
+            Target device for tensors.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor]
+            Symmetrized (edge_index, edge_attr).
+        """
+        src, dst = edge_index[0], edge_index[1]
+
+        # Identify non-self-loop edges to reverse
+        non_self_loop_mask = src != dst
+
+        # Create reverse edges (only for non-self-loops)
+        rev_src = dst[non_self_loop_mask]
+        rev_dst = src[non_self_loop_mask]
+        rev_edge_index = torch.stack([rev_src, rev_dst], dim=0)  # noqa: PD013
+
+        # Concatenate original + reverse
+        edge_index = torch.cat([edge_index, rev_edge_index], dim=1)
+
+        # Symmetrize edge attributes
+        if edge_attr is not None and edge_attr.shape[0] > 0:
+            if edge_attr.shape[1] > 0:
+                # Has actual features: duplicate them for reverse edges
+                rev_edge_attr = edge_attr[non_self_loop_mask]
+                edge_attr = torch.cat([edge_attr, rev_edge_attr], dim=0)
+            else:
+                # Empty features (shape [N, 0]): resize to match new edge count
+                edge_attr = torch.empty(
+                    (edge_index.size(1), 0), dtype=edge_attr.dtype, device=device
+                )
+
+        return edge_index, edge_attr
+
+    @staticmethod
+    def _symmetrize_edge_index_values(
+        edge_idx_vals: list[list[str | int]],
+    ) -> list[list[str | int]]:
+        """
+        Symmetrize edge index values for undirected graph metadata.
+
+        Appends reverse pairs (level_1, level_0) for non-self-loop edges
+        so that reconstructed edge GeoDataFrame includes both directions.
+
+        Parameters
+        ----------
+        edge_idx_vals : list[list[str | int]]
+            Two-element list: [level_0_values, level_1_values].
+
+        Returns
+        -------
+        list[list[str | int]]
+            Symmetrized edge index values.
+        """
+        srcs, dsts = edge_idx_vals[0], edge_idx_vals[1]
+        rev_srcs = []
+        rev_dsts = []
+        for s, d in zip(srcs, dsts, strict=True):
+            if s != d:
+                rev_srcs.append(d)
+                rev_dsts.append(s)
+        return [srcs + rev_srcs, dsts + rev_dsts]
+
+    @staticmethod
+    def _symmetrize_edge_geometries(
+        edges: gpd.GeoDataFrame,
+        edge_geoms: list[str],
+    ) -> list[str]:
+        """
+        Symmetrize serialized edge geometries for undirected graph metadata.
+
+        Appends geometry entries for reverse edges (non-self-loops).
+
+        Parameters
+        ----------
+        edges : gpd.GeoDataFrame
+            Original edge GeoDataFrame with MultiIndex.
+        edge_geoms : list[str]
+            Serialized WKB hex geometries.
+
+        Returns
+        -------
+        list[str]
+            Symmetrized geometry list.
+        """
+        rev_geoms = []
+        for i, (src, dst) in enumerate(edges.index):
+            if src != dst:
+                rev_geoms.append(edge_geoms[i])
+        return edge_geoms + rev_geoms
+
+    @staticmethod
+    def _deduplicate_undirected_edges(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+        """
+        Deduplicate symmetrized edges back to canonical undirected pairs.
+
+        For each pair of edges (u, v) and (v, u), keeps only the canonical
+        form where the first index value is less than or equal to the second.
+        Self-loops (u, u) are always kept.
+
+        Parameters
+        ----------
+        gdf : gpd.GeoDataFrame
+            Edge GeoDataFrame with MultiIndex (source, target).
+
+        Returns
+        -------
+        gpd.GeoDataFrame
+            Deduplicated GeoDataFrame with only canonical edge pairs.
+        """
+        level_0 = gdf.index.get_level_values(0)
+        level_1 = gdf.index.get_level_values(1)
+
+        # Create canonical keys: sort each pair so (u,v) and (v,u) map to same key
+        canonical = pd.DataFrame(
+            {"a": level_0, "b": level_1},
+            index=gdf.index,
+        )
+        # For comparable types, use element-wise min/max
+        canonical["key_0"] = canonical[["a", "b"]].min(axis=1)
+        canonical["key_1"] = canonical[["a", "b"]].max(axis=1)
+        canonical["canonical_key"] = list(zip(canonical["key_0"], canonical["key_1"], strict=True))
+
+        # Keep first occurrence of each canonical pair
+        mask = ~canonical["canonical_key"].duplicated(keep="first")
+        return gdf[mask]
 
     def _reconstruct_node_gdf(
         self,
@@ -945,6 +1138,28 @@ class PyGConverter(BaseGraphConverter):
                 gdf.crs = metadata.crs
             else:
                 gdf.set_crs(metadata.crs, allow_override=True, inplace=True)
+
+        # Deduplicate edges for undirected graphs
+        # When is_directed is False, edges were symmetrized during gdf_to_pyg.
+        # Restore the original undirected edge table by keeping canonical pairs.
+        # For hetero graphs, only same-type edges were symmetrized.
+        is_directed_flag = metadata.is_directed
+        if isinstance(is_directed_flag, dict) and edge_type is not None:
+            is_directed_flag = is_directed_flag.get(edge_type, False)
+
+        # Check if this edge type was actually symmetrized
+        is_same_type = True
+        if is_hetero and isinstance(edge_type, tuple) and len(edge_type) == 3:
+            is_same_type = edge_type[0] == edge_type[2]
+
+        if (
+            not is_directed_flag
+            and is_same_type
+            and isinstance(gdf.index, pd.MultiIndex)
+            and gdf.index.nlevels == 2
+            and not gdf.empty
+        ):
+            gdf = self._deduplicate_undirected_edges(gdf)
 
         return gdf
 
@@ -1649,6 +1864,7 @@ def gdf_to_pyg(
     device: str | torch.device | None = None,
     dtype: torch.dtype | None = None,
     keep_geom: bool = True,
+    directed: bool = False,
 ) -> Data | HeteroData:
     """
     Convert GeoDataFrames (nodes/edges) to a PyTorch Geometric object.
@@ -1697,6 +1913,12 @@ def gdf_to_pyg(
         exact reconstruction. If False, geometries are reconstructed from node
         positions during conversion back to GeoDataFrames (creating straight-line
         edges between nodes).
+    directed : bool, default False
+        Whether to treat edges as directed. If False (default), each edge
+        ``(u, v)`` in the input GeoDataFrame is symmetrized by adding the
+        reverse edge ``(v, u)`` so that PyTorch Geometric receives a proper
+        undirected graph. Self-loops are not duplicated. Edge attributes are
+        duplicated for reverse edges. If True, edges are kept as-is.
 
     Returns
     -------
@@ -1772,6 +1994,7 @@ def gdf_to_pyg(
         device=device,
         dtype=dtype,
         keep_geom=keep_geom,
+        directed=directed,
     )
     return converter.gdf_to_pyg(nodes, edges)
 

--- a/city2graph/graph.py
+++ b/city2graph/graph.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
 from typing import cast
 
 if TYPE_CHECKING:
@@ -94,6 +95,12 @@ class PyGConverter(BaseGraphConverter):
     This converter handles feature extraction, tensor creation, and manages
     the bidirectional conversion while preserving spatial and attribute information.
 
+    For homogeneous graphs, ``directed`` is a single boolean. For heterogeneous
+    graphs, ``directed`` can be a complete dictionary keyed by edge type so that
+    each relation independently controls whether its edges are directed or
+    symmetrised. Cross-type undirected edges are represented as paired directed
+    stores (original + generated reverse) rather than in-place symmetrisation.
+
     Parameters
     ----------
     node_feature_cols : dict[str, list[str]] or list[str], optional
@@ -108,10 +115,18 @@ class PyGConverter(BaseGraphConverter):
         Data type for float tensors.
     keep_geom : bool, default True
         Whether to preserve geometry information during conversion.
-    directed : bool, default False
+    directed : bool or dict[tuple[str, str, str], bool], default False
         Whether to treat edges as directed. If False (default), edges are
         symmetrized during conversion to PyG (reverse edges are added) and
         deduplicated during reconstruction back to GeoDataFrames.
+        For heterogeneous graphs, can be a complete dictionary mapping each
+        edge type to its directionality flag.
+    reverse_edge_types : ``"auto"``, dict, or None, default ``"auto"``
+        Controls how undirected cross-type heterogeneous edges are handled.
+        ``"auto"`` generates ``(dst_type, "rev_<relation>", src_type)``
+        automatically. A dict provides explicit mappings from original to
+        reverse edge types. ``None`` raises ``ValueError`` for any undirected
+        cross-type edge (strict mode).
     """
 
     def __init__(
@@ -122,7 +137,10 @@ class PyGConverter(BaseGraphConverter):
         device: str | torch.device | None = None,
         dtype: torch.dtype | None = None,
         keep_geom: bool = True,
-        directed: bool = False,
+        directed: bool | dict[tuple[str, str, str], bool] = False,
+        reverse_edge_types: (
+            Literal["auto"] | dict[tuple[str, str, str], tuple[str, str, str]] | None
+        ) = "auto",
     ) -> None:
         """
         Initialize PyGConverter.
@@ -146,12 +164,25 @@ class PyGConverter(BaseGraphConverter):
             If True, original geometries are serialized and stored in metadata.
             If False, geometries are reconstructed from node positions during
             conversion back to GeoDataFrames.
-        directed : bool, default False
+        directed : bool or dict[tuple[str, str, str], bool], default False
             Whether to treat edges as directed. If False (default), edges are
             symmetrized during conversion to PyG (reverse edges are added) and
             deduplicated during reconstruction back to GeoDataFrames.
+            For heterogeneous graphs, can be a complete dictionary mapping each
+            edge type to its directionality flag.
+        reverse_edge_types : ``"auto"``, dict, or None, default ``"auto"``
+            Controls how undirected cross-type heterogeneous edges are handled.
+            ``"auto"`` generates ``(dst_type, "rev_<relation>", src_type)``
+            automatically. A dict provides explicit mappings. ``None`` raises
+            ``ValueError`` for any undirected cross-type edge (strict mode).
         """
-        super().__init__(keep_geom=keep_geom, directed=directed)
+        # BaseGraphConverter expects a bool; pass True if any dict form is used,
+        # since per-edge-type resolution happens later in the PyG-specific code.
+        directed_bool = directed if isinstance(directed, bool) else False
+        super().__init__(keep_geom=keep_geom, directed=directed_bool)
+        # Store the full directed spec (bool or dict) for per-edge-type use.
+        self.directed: bool | dict[tuple[str, str, str], bool] = directed  # type: ignore[assignment]
+        self.reverse_edge_types_spec = reverse_edge_types
         self.node_feature_cols = node_feature_cols
         self.node_label_cols = node_label_cols
         self.edge_feature_cols = edge_feature_cols
@@ -292,6 +323,12 @@ class PyGConverter(BaseGraphConverter):
             msg = "Nodes GeoDataFrame is required for PyG conversion"
             raise ValueError(msg)
 
+        # Resolve directed to a single bool for homogeneous graphs
+        if isinstance(self.directed, dict):
+            msg = "directed must be a bool for homogeneous graphs, not a dict"
+            raise TypeError(msg)
+        directed_bool: bool = self.directed
+
         # Validate column types
         node_feature_cols_homo, node_label_cols_homo, edge_feature_cols_homo = (
             self._validate_homogeneous_columns()
@@ -315,6 +352,9 @@ class PyGConverter(BaseGraphConverter):
         edge_attr = torch.empty((0, 0), dtype=self.dtype or torch.float32, device=device)
 
         if edges is not None and not edges.empty:
+            # Validate edge table
+            self._validate_edge_gdf_for_pyg(edges, directed=directed_bool)
+
             edge_pairs = self._create_edge_indices(
                 edges,
                 id_mapping,
@@ -329,7 +369,7 @@ class PyGConverter(BaseGraphConverter):
             edge_attr = self._create_features(edges, edge_feature_cols_homo)
 
             # Symmetrize edges for undirected graphs
-            if not self.directed and edge_index.size(1) > 0:
+            if not directed_bool and edge_index.size(1) > 0:
                 edge_index, edge_attr = self._symmetrize_edges(edge_index, edge_attr, device)
 
         data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr, y=y, pos=pos)
@@ -345,7 +385,8 @@ class PyGConverter(BaseGraphConverter):
             node_label_cols_homo,
             edge_feature_cols_homo,
         )
-        metadata.is_directed = self.directed
+        metadata.is_directed = directed_bool
+        metadata.edge_was_symmetrized = not directed_bool
 
         data.graph_metadata = metadata
         return data
@@ -499,11 +540,13 @@ class PyGConverter(BaseGraphConverter):
         )
 
         # Process edges
-        self._process_hetero_edges(
-            data,
-            edges_dict,
-            node_mappings,
-            edge_feature_cols_hetero,
+        directed_by_et, symmetrized_by_et, reverse_et_map, gen_reverse_et_map = (
+            self._process_hetero_edges(
+                data,
+                edges_dict,
+                node_mappings,
+                edge_feature_cols_hetero,
+            )
         )
 
         # Store metadata
@@ -515,6 +558,10 @@ class PyGConverter(BaseGraphConverter):
             node_feature_cols_hetero,
             node_label_cols_hetero,
             edge_feature_cols_hetero,
+            directed_by_et=directed_by_et,
+            symmetrized_by_et=symmetrized_by_et,
+            reverse_et_map=reverse_et_map,
+            gen_reverse_et_map=gen_reverse_et_map,
         )
 
         return data
@@ -579,11 +626,18 @@ class PyGConverter(BaseGraphConverter):
         edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
         node_mappings: dict[str, dict[str, dict[str | int, int] | str | list[str | int]]],
         edge_feature_cols: dict[tuple[str, str, str], list[str]] | None,
-    ) -> None:
+    ) -> tuple[
+        dict[tuple[str, str, str], bool],
+        dict[tuple[str, str, str], bool],
+        dict[tuple[str, str, str], tuple[str, str, str]],
+        dict[tuple[str, str, str], tuple[str, str, str]],
+    ]:
         """
         Process all edge types for heterogeneous graph.
 
-        Extended summary of edge processing for heterogeneous graphs.
+        Resolves per-edge-type directionality, validates each edge table,
+        symmetrises safe same-type undirected edges in-place, and creates
+        generated reverse edge stores for cross-type undirected relations.
 
         Parameters
         ----------
@@ -595,26 +649,42 @@ class PyGConverter(BaseGraphConverter):
             Dictionary containing node mapping information.
         edge_feature_cols : dict[tuple[str, str, str], list[str]], optional
             Dictionary mapping edge types to feature column names.
+
+        Returns
+        -------
+        tuple
+            ``(directed_by_et, symmetrized_by_et, reverse_et_map, gen_reverse_et_map)``
+            used by ``_store_hetero_metadata`` to record provenance.
         """
         device = _get_device(self.device)
 
-        for edge_type, edge_gdf in edges_dict.items():
-            # Extract source, relation, and destination types from edge_type tuple
-            src_type, _, dst_type = edge_type
+        # Resolve per-edge-type direction flags
+        directed_by_et = self._resolve_edge_directedness(edges_dict)
 
-            # Get the mapping dictionaries (not the full metadata)
-            # The type system guarantees these are dictionaries based on _process_hetero_nodes
+        # Track symmetrization and reverse store generation
+        symmetrized_by_et: dict[tuple[str, str, str], bool] = {}
+        reverse_et_map: dict[tuple[str, str, str], tuple[str, str, str]] = {}
+        gen_reverse_et_map: dict[tuple[str, str, str], tuple[str, str, str]] = {}
+        user_et_keys = set(edges_dict.keys())
+
+        for edge_type, edge_gdf in edges_dict.items():
+            src_type, _, dst_type = edge_type
+            is_directed_et = directed_by_et[edge_type]
+
+            # Get the mapping dictionaries
             src_mapping_raw = node_mappings[src_type]["mapping"]
             dst_mapping_raw = node_mappings[dst_type]["mapping"]
-
-            # Type assertion for mypy - these are guaranteed to be dicts by construction
             assert isinstance(src_mapping_raw, dict), f"Expected dict mapping for {src_type}"
             assert isinstance(dst_mapping_raw, dict), f"Expected dict mapping for {dst_type}"
-
             src_mapping: dict[str | int, int] = src_mapping_raw
             dst_mapping: dict[str | int, int] = dst_mapping_raw
 
             if edge_gdf is not None and not edge_gdf.empty:
+                # Validate edge table
+                self._validate_edge_gdf_for_pyg(
+                    edge_gdf, directed=is_directed_et, edge_type=edge_type
+                )
+
                 edge_pairs = self._create_edge_indices(
                     edge_gdf,
                     src_mapping,
@@ -629,14 +699,24 @@ class PyGConverter(BaseGraphConverter):
                 feature_cols = edge_feature_cols.get(edge_type) if edge_feature_cols else None
                 edge_attr = self._create_features(edge_gdf, feature_cols)
 
-                # Symmetrize edges for undirected graphs (only same-type edges)
-                # Cross-type edges (src_type != dst_type) cannot be symmetrized
-                # within the same edge type.
-                if not self.directed and edge_index.size(1) > 0 and src_type == dst_type:
+                # Decide symmetrization strategy
+                is_same_type = src_type == dst_type
+                if not is_directed_et and edge_index.size(1) > 0 and is_same_type:
+                    # Same-type undirected: symmetrise in-place
                     edge_index, edge_attr = self._symmetrize_edges(edge_index, edge_attr, device)
+                    symmetrized_by_et[edge_type] = True
+                else:
+                    symmetrized_by_et[edge_type] = False
 
                 data[edge_type].edge_index = edge_index
                 data[edge_type].edge_attr = edge_attr
+
+                # Cross-type undirected: create generated reverse edge store
+                if not is_directed_et and not is_same_type and edge_index.size(1) > 0:
+                    reverse_et = self._resolve_reverse_edge_type(edge_type, user_et_keys)
+                    self._add_generated_reverse_edge_store(data, edge_type, reverse_et)
+                    reverse_et_map[edge_type] = reverse_et
+                    gen_reverse_et_map[reverse_et] = edge_type
             else:
                 data[edge_type].edge_index = torch.zeros((2, 0), dtype=torch.long, device=device)
                 data[edge_type].edge_attr = torch.empty(
@@ -644,6 +724,9 @@ class PyGConverter(BaseGraphConverter):
                     dtype=self.dtype or torch.float32,
                     device=device,
                 )
+                symmetrized_by_et[edge_type] = False
+
+        return directed_by_et, symmetrized_by_et, reverse_et_map, gen_reverse_et_map
 
     def _store_hetero_metadata(
         self,
@@ -654,11 +737,17 @@ class PyGConverter(BaseGraphConverter):
         node_feature_cols: dict[str, list[str]] | None,
         node_label_cols: dict[str, list[str]] | None,
         edge_feature_cols: dict[tuple[str, str, str], list[str]] | None,
+        *,
+        directed_by_et: dict[tuple[str, str, str], bool],
+        symmetrized_by_et: dict[tuple[str, str, str], bool],
+        reverse_et_map: dict[tuple[str, str, str], tuple[str, str, str]],
+        gen_reverse_et_map: dict[tuple[str, str, str], tuple[str, str, str]],
     ) -> None:
         """
         Store metadata for heterogeneous graph.
 
-        Extended summary of metadata storage for heterogeneous graphs.
+        Records per-edge-type directionality, symmetrisation provenance, and
+        cross-type reverse edge type mappings alongside the standard metadata.
 
         Parameters
         ----------
@@ -676,6 +765,14 @@ class PyGConverter(BaseGraphConverter):
             Dictionary mapping node types to label column names.
         edge_feature_cols : dict[tuple[str, str, str], list[str]], optional
             Dictionary mapping edge types to feature column names.
+        directed_by_et : dict[tuple[str, str, str], bool]
+            Per-edge-type direction flags.
+        symmetrized_by_et : dict[tuple[str, str, str], bool]
+            Per-edge-type symmetrisation flags.
+        reverse_et_map : dict[tuple[str, str, str], tuple[str, str, str]]
+            Maps original edge types to generated reverse edge types.
+        gen_reverse_et_map : dict[tuple[str, str, str], tuple[str, str, str]]
+            Maps generated reverse edge types back to originals.
         """
         # Store mappings and column metadata
         metadata = GraphMetadata(is_hetero=True)
@@ -706,9 +803,8 @@ class PyGConverter(BaseGraphConverter):
                     for i in range(edge_gdf.index.nlevels)
                 ]
 
-                # Symmetrize edge index values for undirected same-type edges
-                src_type, _, dst_type = edge_type
-                if not self.directed and len(edge_idx_vals) == 2 and src_type == dst_type:
+                # Symmetrize edge index values only for edges that were symmetrized
+                if symmetrized_by_et.get(edge_type, False) and len(edge_idx_vals) == 2:
                     edge_idx_vals = self._symmetrize_edge_index_values(edge_idx_vals)
 
                 metadata.edge_index_values[edge_type] = edge_idx_vals
@@ -732,13 +828,17 @@ class PyGConverter(BaseGraphConverter):
                 if edge_gdf is not None and not edge_gdf.empty:
                     geoms = self._serialize_geometries(edge_gdf)
                     if geoms is not None:
-                        # Symmetrize edge geometries for undirected same-type edges
-                        src_type, _, dst_type = edge_type
-                        if not self.directed and src_type == dst_type:
+                        # Symmetrize edge geometries only for edges that were symmetrized
+                        if symmetrized_by_et.get(edge_type, False):
                             geoms = self._symmetrize_edge_geometries(edge_gdf, geoms)
                         metadata.edge_geometries[edge_type] = geoms
 
-        metadata.is_directed = self.directed
+        # Per-edge-type directionality and provenance metadata
+        metadata.is_directed = directed_by_et
+        metadata.edge_was_symmetrized = symmetrized_by_et
+        metadata.original_edge_types = list(edges_dict.keys())
+        metadata.reverse_edge_types = reverse_et_map
+        metadata.generated_reverse_edge_types = gen_reverse_et_map
         data.graph_metadata = metadata
 
     def _create_node_id_mapping(
@@ -834,6 +934,242 @@ class PyGConverter(BaseGraphConverter):
         combined_array = np.column_stack([from_indices, to_indices]).astype(int)
         result: list[list[int]] = combined_array.tolist()
         return result
+
+    # ------------------------------------------------------------------
+    # Edge validation and directedness resolution helpers (Steps 3 & 4)
+    # ------------------------------------------------------------------
+
+    def _validate_edge_gdf_for_pyg(
+        self,
+        edges: gpd.GeoDataFrame,
+        *,
+        directed: bool,
+        edge_type: tuple[str, str, str] | None = None,
+    ) -> None:
+        """
+        Validate an edge GeoDataFrame before creating PyG edge tensors.
+
+        Ensures the edge table has a proper two-level MultiIndex, and rejects
+        ambiguous inputs when ``directed=False``:
+        * already-bidirectional pairs (both ``(u, v)`` and ``(v, u)`` present)
+        * parallel undirected rows (duplicate unordered keys)
+        Self-loops are always allowed and not considered duplicates.
+
+        Parameters
+        ----------
+        edges : gpd.GeoDataFrame
+            Edge GeoDataFrame to validate.
+        directed : bool
+            Whether this edge table is treated as directed.
+        edge_type : tuple[str, str, str] or None, optional
+            Edge type tuple for error messages in heterogeneous graphs.
+        """
+        if edges.empty:
+            return
+
+        # 1. Require at least a two-level MultiIndex (source, target).
+        # MultiGraph/MultiDiGraph edges from nx_to_gdf may have a 3-level
+        # MultiIndex (source, target, key), which is also acceptable.
+        if not isinstance(edges.index, pd.MultiIndex) or edges.index.nlevels < 2:
+            et_label = f" for edge type {edge_type}" if edge_type else ""
+            msg = (
+                f"Edge GeoDataFrame index must be a MultiIndex with at least "
+                f"two levels (source, target){et_label}."
+            )
+            raise ValueError(msg)
+
+        if directed:
+            return  # No further validation needed for directed edges
+
+        # 2. Reject already-bidirectional pairs when directed=False
+        srcs = edges.index.get_level_values(0)
+        dsts = edges.index.get_level_values(1)
+        # Build sets of ordered edges; check for reverse presence
+        edge_set: set[tuple[object, object]] = set()
+        for s, d in zip(srcs, dsts, strict=True):
+            if s == d:
+                continue  # self-loops are fine
+            if (d, s) in edge_set:
+                et_label = f" for edge type {edge_type}" if edge_type else ""
+                msg = (
+                    f"Ambiguous undirected input{et_label}: both ({s}, {d}) and "
+                    f"({d}, {s}) are present. Pass directed=True for directed edges, "
+                    f"or provide only one row per undirected edge."
+                )
+                raise ValueError(msg)
+            edge_set.add((s, d))
+
+        # 3. Reject parallel undirected rows (duplicate unordered keys)
+        canonical_keys: list[tuple[object, object]] = []
+        for s, d in zip(srcs, dsts, strict=True):
+            key = (min(s, d), max(s, d)) if s != d else (s, d)
+            canonical_keys.append(key)
+        if len(canonical_keys) != len(set(canonical_keys)):
+            et_label = f" for edge type {edge_type}" if edge_type else ""
+            msg = (
+                f"Parallel undirected edges detected{et_label}. "
+                f"Round-trip reconstruction cannot safely preserve multiple "
+                f"geometries/attributes for the same unordered pair without "
+                f"explicit multigraph support. Pass directed=True to keep "
+                f"parallel edges as directed rows."
+            )
+            raise ValueError(msg)
+
+    def _resolve_edge_directedness(
+        self,
+        edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
+    ) -> dict[tuple[str, str, str], bool]:
+        """
+        Resolve per-edge-type directionality flags.
+
+        If ``self.directed`` is a ``bool``, applies it globally to every edge
+        type as a convenience. If it is a ``dict``, requires exact key equality
+        with the edge types present in *edges_dict*: missing or extra keys
+        raise ``ValueError``.
+
+        Parameters
+        ----------
+        edges_dict : dict[tuple[str, str, str], gpd.GeoDataFrame]
+            Dictionary mapping edge types to GeoDataFrames.
+
+        Returns
+        -------
+        dict[tuple[str, str, str], bool]
+            Complete mapping from every edge type to its direction flag.
+        """
+        if isinstance(self.directed, bool):
+            return dict.fromkeys(edges_dict, self.directed)
+
+        directed_dict = self.directed
+        provided = set(directed_dict.keys())
+        expected = set(edges_dict.keys())
+        missing = expected - provided
+        extra = provided - expected
+        if missing:
+            msg = (
+                f"directed dict is missing keys for edge types: {missing}. "
+                f"Provide a complete dictionary with one entry per edge type."
+            )
+            raise ValueError(msg)
+        if extra:
+            msg = (
+                f"directed dict has extra keys not in edges: {extra}. "
+                f"Remove keys that do not correspond to any edge type."
+            )
+            raise ValueError(msg)
+        return dict(directed_dict)
+
+    def _resolve_reverse_edge_type(
+        self,
+        edge_type: tuple[str, str, str],
+        edges_dict_keys: set[tuple[str, str, str]],
+    ) -> tuple[str, str, str]:
+        """
+        Resolve the concrete reverse edge type for a cross-type undirected relation.
+
+        Same-type edges (``src_type == dst_type``) do not require reverse types
+        because they are symmetrised in-place. This method should only be called
+        for cross-type edges that are declared undirected.
+
+        Parameters
+        ----------
+        edge_type : tuple[str, str, str]
+            The original ``(src_type, relation, dst_type)`` edge type.
+        edges_dict_keys : set[tuple[str, str, str]]
+            The set of all user-supplied edge type keys, used for collision
+            detection.
+
+        Returns
+        -------
+        tuple[str, str, str]
+            The reverse edge type ``(dst_type, rev_relation, src_type)``.
+
+        Raises
+        ------
+        ValueError
+            If ``reverse_edge_types`` is ``None`` (strict mode), or if the
+            generated/explicit reverse type collides with a user-supplied type,
+            or if explicit reverse type endpoints are inconsistent.
+        """
+        src_type, relation, dst_type = edge_type
+        spec = self.reverse_edge_types_spec
+
+        if spec is None:
+            msg = (
+                f"Cross-type edge {edge_type} is declared undirected but "
+                f"reverse_edge_types=None (strict mode). Either set the edge "
+                f"to directed=True, or provide reverse_edge_types='auto' or "
+                f"an explicit mapping."
+            )
+            raise ValueError(msg)
+
+        if spec == "auto":
+            reverse_et: tuple[str, str, str] = (dst_type, f"rev_{relation}", src_type)
+        elif isinstance(spec, dict):
+            if edge_type not in spec:
+                msg = (
+                    f"reverse_edge_types dict is missing a mapping for "
+                    f"undirected cross-type edge {edge_type}."
+                )
+                raise ValueError(msg)
+            reverse_et = spec[edge_type]
+            # Validate endpoint consistency
+            if reverse_et[0] != dst_type or reverse_et[2] != src_type:
+                msg = (
+                    f"Explicit reverse edge type {reverse_et} has inconsistent "
+                    f"endpoints for original edge type {edge_type}. Expected "
+                    f"reverse_edge_type[0]=={dst_type!r} and "
+                    f"reverse_edge_type[2]=={src_type!r}."
+                )
+                raise ValueError(msg)
+        else:
+            msg = (  # pragma: no cover
+                f"reverse_edge_types must be 'auto', a dict, or None; got {type(spec).__name__}"
+            )
+            raise TypeError(msg)  # pragma: no cover
+
+        # Collision detection
+        if reverse_et in edges_dict_keys:
+            msg = (
+                f"Generated reverse edge type {reverse_et} for original "
+                f"edge type {edge_type} collides with an existing "
+                f"user-supplied edge type. Provide an explicit "
+                f"reverse_edge_types mapping to resolve this."
+            )
+            raise ValueError(msg)
+
+        return reverse_et
+
+    @staticmethod
+    def _add_generated_reverse_edge_store(
+        data: HeteroData,
+        edge_type: tuple[str, str, str],
+        reverse_edge_type: tuple[str, str, str],
+    ) -> None:
+        """
+        Create a generated reverse edge store for cross-type undirected edges.
+
+        Instead of symmetrising a cross-type edge table in-place (which is
+        impossible because the source and destination node types differ), this
+        method creates a new PyG edge store with the reversed edge index and
+        cloned edge attributes.
+
+        Generated reverse stores are PyG message-passing artefacts, not original
+        input edge tables. They are skipped by default during ``pyg_to_gdf``
+        reconstruction.
+
+        Parameters
+        ----------
+        data : HeteroData
+            HeteroData object to add the reverse store to.
+        edge_type : tuple[str, str, str]
+            Original edge type whose edges are being reversed.
+        reverse_edge_type : tuple[str, str, str]
+            The new reverse edge type to create.
+        """
+        data[reverse_edge_type].edge_index = data[edge_type].edge_index.flip(0)
+        if hasattr(data[edge_type], "edge_attr") and data[edge_type].edge_attr is not None:
+            data[reverse_edge_type].edge_attr = data[edge_type].edge_attr.clone()
 
     def _symmetrize_edges(
         self,
@@ -1139,22 +1475,9 @@ class PyGConverter(BaseGraphConverter):
             else:
                 gdf.set_crs(metadata.crs, allow_override=True, inplace=True)
 
-        # Deduplicate edges for undirected graphs
-        # When is_directed is False, edges were symmetrized during gdf_to_pyg.
-        # Restore the original undirected edge table by keeping canonical pairs.
-        # For hetero graphs, only same-type edges were symmetrized.
-        is_directed_flag = metadata.is_directed
-        if isinstance(is_directed_flag, dict) and edge_type is not None:
-            is_directed_flag = is_directed_flag.get(edge_type, False)
-
-        # Check if this edge type was actually symmetrized
-        is_same_type = True
-        if is_hetero and isinstance(edge_type, tuple) and len(edge_type) == 3:
-            is_same_type = edge_type[0] == edge_type[2]
-
+        # Deduplicate edges that city2graph symmetrized for PyG message passing.
         if (
-            not is_directed_flag
-            and is_same_type
+            self._should_deduplicate_edges(metadata, edge_type, is_hetero)
             and isinstance(gdf.index, pd.MultiIndex)
             and gdf.index.nlevels == 2
             and not gdf.empty
@@ -1162,6 +1485,56 @@ class PyGConverter(BaseGraphConverter):
             gdf = self._deduplicate_undirected_edges(gdf)
 
         return gdf
+
+    @staticmethod
+    def _should_deduplicate_edges(
+        metadata: GraphMetadata,
+        edge_type: tuple[str, str, str] | None,
+        is_hetero: bool,
+    ) -> bool:
+        """
+        Decide whether reconstructed edges should be deduplicated.
+
+        Uses ``edge_was_symmetrized`` (preferred) with a backward-compatible
+        fallback to ``is_directed``. Never deduplicates directed edge types,
+        cross-type heterogeneous relations, or edge types that were never
+        symmetrised.
+
+        Parameters
+        ----------
+        metadata : GraphMetadata
+            Graph metadata from the PyG object.
+        edge_type : tuple or None
+            Edge type tuple for heterogeneous graphs.
+        is_hetero : bool
+            Whether this is a heterogeneous graph.
+
+        Returns
+        -------
+        bool
+            True if the edges should be deduplicated.
+        """
+        edge_was_symmetrized = getattr(metadata, "edge_was_symmetrized", False)
+
+        if isinstance(edge_was_symmetrized, dict):
+            return bool(edge_was_symmetrized.get(edge_type, False))
+        if isinstance(edge_was_symmetrized, bool):
+            return edge_was_symmetrized
+
+        # Backward compatibility: fall back to is_directed if edge_was_symmetrized
+        # is not present (old metadata). Default to True (directed) to avoid
+        # accidentally deduplicating old directed-looking edge tables.
+        if not hasattr(metadata, "edge_was_symmetrized"):
+            is_directed_flag = getattr(metadata, "is_directed", True)
+            if isinstance(is_directed_flag, dict) and edge_type is not None:
+                is_directed_flag = is_directed_flag.get(edge_type, True)
+
+            is_same_type = True
+            if is_hetero and isinstance(edge_type, tuple) and len(edge_type) == 3:
+                is_same_type = edge_type[0] == edge_type[2]
+            return not is_directed_flag and is_same_type
+
+        return False
 
     def _extract_tensor_columns(
         self,
@@ -1639,7 +2012,18 @@ class PyGConverter(BaseGraphConverter):
                 )
 
         if edges and metadata.edge_types:
-            for edge_type in metadata.edge_types:
+            # Determine which edge types to reconstruct: only original user-supplied
+            # edge types. Generated reverse edge stores are message-passing
+            # artefacts and should be skipped during reconstruction.
+            gen_reverse = getattr(metadata, "generated_reverse_edge_types", {})
+            original_ets = getattr(metadata, "original_edge_types", None)
+            reconstruct_ets = original_ets or metadata.edge_types
+
+            for edge_type in reconstruct_ets:
+                # Skip any edge type that is a generated reverse
+                if edge_type in gen_reverse:
+                    continue
+
                 add_cols = None
                 if additional_edge_cols and isinstance(additional_edge_cols, dict):
                     # Try to match edge type tuple
@@ -1864,7 +2248,10 @@ def gdf_to_pyg(
     device: str | torch.device | None = None,
     dtype: torch.dtype | None = None,
     keep_geom: bool = True,
-    directed: bool = False,
+    directed: bool | dict[tuple[str, str, str], bool] = False,
+    reverse_edge_types: (
+        Literal["auto"] | dict[tuple[str, str, str], tuple[str, str, str]] | None
+    ) = "auto",
 ) -> Data | HeteroData:
     """
     Convert GeoDataFrames (nodes/edges) to a PyTorch Geometric object.
@@ -1913,12 +2300,21 @@ def gdf_to_pyg(
         exact reconstruction. If False, geometries are reconstructed from node
         positions during conversion back to GeoDataFrames (creating straight-line
         edges between nodes).
-    directed : bool, default False
+    directed : bool or dict[tuple[str, str, str], bool], default False
         Whether to treat edges as directed. If False (default), each edge
         ``(u, v)`` in the input GeoDataFrame is symmetrized by adding the
         reverse edge ``(v, u)`` so that PyTorch Geometric receives a proper
         undirected graph. Self-loops are not duplicated. Edge attributes are
         duplicated for reverse edges. If True, edges are kept as-is.
+        For heterogeneous graphs, can be a complete dictionary mapping each
+        edge type to its directionality flag so that different relations can
+        independently be directed or undirected.
+    reverse_edge_types : ``"auto"``, dict, or None, default ``"auto"``
+        Controls how undirected cross-type heterogeneous edges are handled.
+        ``"auto"`` generates ``(dst_type, "rev_<relation>", src_type)``
+        automatically. A dict provides explicit mappings from original to
+        reverse edge types. ``None`` raises ``ValueError`` for any undirected
+        cross-type edge (strict mode).
 
     Returns
     -------
@@ -1995,6 +2391,7 @@ def gdf_to_pyg(
         dtype=dtype,
         keep_geom=keep_geom,
         directed=directed,
+        reverse_edge_types=reverse_edge_types,
     )
     return converter.gdf_to_pyg(nodes, edges)
 
@@ -2275,7 +2672,9 @@ def nx_to_pyg(
     # Get nodes and edges GeoDataFrames
     nodes_gdf, edges_gdf = nx_to_gdf(graph, nodes=True, edges=True)
 
-    # Convert to PyG using existing function
+    # Convert to PyG using existing function.
+    # Preserve NetworkX graph semantics: nx.DiGraph / nx.MultiDiGraph stay
+    # directed in PyG; nx.Graph / nx.MultiGraph become bidirectional.
     return gdf_to_pyg(
         nodes=nodes_gdf,
         edges=edges_gdf,
@@ -2285,6 +2684,7 @@ def nx_to_pyg(
         device=device,
         dtype=dtype,
         keep_geom=keep_geom,
+        directed=graph.is_directed(),
     )
 
 
@@ -2525,6 +2925,9 @@ def _validate_hetero_structure(data: HeteroData, metadata: GraphMetadata) -> Non
     if metadata.edge_types:
         actual_edge_types = set(data.edge_types)
         expected_edge_types = set(metadata.edge_types)
+        # Include generated reverse edge types in the expected set
+        gen_reverse = getattr(metadata, "generated_reverse_edge_types", {})
+        expected_edge_types |= set(gen_reverse.keys())
         if actual_edge_types != expected_edge_types:
             msg = (
                 f"Edge types mismatch: metadata expects {expected_edge_types}, "

--- a/city2graph/graph.py
+++ b/city2graph/graph.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
 # Third-party imports
 import geopandas as gpd
+import networkx as nx
 import numpy as np
 import pandas as pd
 from shapely import wkb
@@ -351,10 +352,11 @@ class PyGConverter(BaseGraphConverter):
         edge_index = torch.zeros((2, 0), dtype=torch.long, device=device)
         edge_attr = torch.empty((0, 0), dtype=self.dtype or torch.float32, device=device)
 
-        if edges is not None and not edges.empty:
+        if edges is not None:
             # Validate edge table
             self._validate_edge_gdf_for_pyg(edges, directed=directed_bool)
 
+        if edges is not None and not edges.empty:
             edge_pairs = self._create_edge_indices(
                 edges,
                 id_mapping,
@@ -1277,7 +1279,8 @@ class PyGConverter(BaseGraphConverter):
             Symmetrized geometry list.
         """
         rev_geoms = []
-        for i, (src, dst) in enumerate(edges.index):
+        for i, edge_key in enumerate(edges.index):
+            src, dst = edge_key[:2] if isinstance(edge_key, tuple) else (edge_key, edge_key)
             if src != dst:
                 rev_geoms.append(edge_geoms[i])
         return edge_geoms + rev_geoms
@@ -1514,13 +1517,6 @@ class PyGConverter(BaseGraphConverter):
         bool
             True if the edges should be deduplicated.
         """
-        edge_was_symmetrized = getattr(metadata, "edge_was_symmetrized", False)
-
-        if isinstance(edge_was_symmetrized, dict):
-            return bool(edge_was_symmetrized.get(edge_type, False))
-        if isinstance(edge_was_symmetrized, bool):
-            return edge_was_symmetrized
-
         # Backward compatibility: fall back to is_directed if edge_was_symmetrized
         # is not present (old metadata). Default to True (directed) to avoid
         # accidentally deduplicating old directed-looking edge tables.
@@ -1533,6 +1529,13 @@ class PyGConverter(BaseGraphConverter):
             if is_hetero and isinstance(edge_type, tuple) and len(edge_type) == 3:
                 is_same_type = edge_type[0] == edge_type[2]
             return not is_directed_flag and is_same_type
+
+        edge_was_symmetrized = getattr(metadata, "edge_was_symmetrized", False)
+
+        if isinstance(edge_was_symmetrized, dict):
+            return bool(edge_was_symmetrized.get(edge_type, False))
+        if isinstance(edge_was_symmetrized, bool):
+            return edge_was_symmetrized
 
         return False
 
@@ -2563,7 +2566,30 @@ def pyg_to_nx(
         additional_node_cols=additional_node_cols,
         additional_edge_cols=additional_edge_cols,
     )
-    return gdf_to_nx(nodes, edges)
+    metadata = getattr(data, "graph_metadata", None)
+    directed = False
+    if metadata is not None:
+        is_directed = getattr(metadata, "is_directed", False)
+        if isinstance(is_directed, bool):
+            directed = is_directed
+        elif isinstance(is_directed, dict):
+            directed = all(is_directed.values())
+
+    graph = gdf_to_nx(nodes, edges, directed=directed)
+    if (
+        metadata is not None
+        and getattr(metadata, "is_hetero", False) is False
+        and isinstance(nodes, gpd.GeoDataFrame)
+    ):
+        relabel = {
+            node: attrs["_original_index"]
+            for node, attrs in graph.nodes(data=True)
+            if "_original_index" in attrs
+        }
+        if len(relabel) == graph.number_of_nodes() and len(set(relabel.values())) == len(relabel):
+            graph = nx.relabel_nodes(graph, relabel, copy=True)
+
+    return graph
 
 
 def nx_to_pyg(
@@ -2574,6 +2600,7 @@ def nx_to_pyg(
     device: torch.device | str | None = None,
     dtype: torch.dtype | None = None,
     keep_geom: bool = True,
+    directed: bool | None = None,
 ) -> Data | HeteroData:
     """
     Convert NetworkX graph to PyTorch Geometric Data object.
@@ -2604,6 +2631,10 @@ def nx_to_pyg(
         If True, original geometries are serialized and stored in metadata for
         exact reconstruction. If False, geometries are reconstructed from node
         positions during conversion back to GeoDataFrames.
+    directed : bool, optional
+        Explicit directionality override. If omitted, the NetworkX graph type is
+        used: ``Graph`` and ``MultiGraph`` are undirected, while ``DiGraph`` and
+        ``MultiDiGraph`` are directed.
 
     Returns
     -------
@@ -2673,8 +2704,11 @@ def nx_to_pyg(
     nodes_gdf, edges_gdf = nx_to_gdf(graph, nodes=True, edges=True)
 
     # Convert to PyG using existing function.
-    # Preserve NetworkX graph semantics: nx.DiGraph / nx.MultiDiGraph stay
-    # directed in PyG; nx.Graph / nx.MultiGraph become bidirectional.
+    directed_flag = graph.is_directed() if directed is None else directed
+
+    # Preserve NetworkX graph semantics by default: nx.DiGraph /
+    # nx.MultiDiGraph stay directed in PyG; nx.Graph / nx.MultiGraph become
+    # bidirectional. The public directed override can force either behaviour.
     return gdf_to_pyg(
         nodes=nodes_gdf,
         edges=edges_gdf,
@@ -2684,7 +2718,7 @@ def nx_to_pyg(
         device=device,
         dtype=dtype,
         keep_geom=keep_geom,
-        directed=graph.is_directed(),
+        directed=directed_flag,
     )
 
 

--- a/city2graph/graph.py
+++ b/city2graph/graph.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 # Standard library imports
 import logging
+import warnings
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
@@ -457,7 +458,7 @@ class PyGConverter(BaseGraphConverter):
             ]
 
             # Symmetrize edge index values for undirected graphs
-            if not self.directed and len(edge_idx_vals) == 2:
+            if self.directed is False and len(edge_idx_vals) == 2:
                 edge_idx_vals = self._symmetrize_edge_index_values(edge_idx_vals)
 
             metadata.edge_index_values = edge_idx_vals
@@ -476,7 +477,7 @@ class PyGConverter(BaseGraphConverter):
                 edge_geoms = self._serialize_geometries(edges)
 
                 # Symmetrize edge geometries for undirected graphs
-                if not self.directed and edge_geoms is not None:
+                if self.directed is False and edge_geoms is not None:
                     edge_geoms = self._symmetrize_edge_geometries(edges, edge_geoms)
 
                 metadata.edge_geometries = edge_geoms
@@ -983,30 +984,53 @@ class PyGConverter(BaseGraphConverter):
         if directed:
             return  # No further validation needed for directed edges
 
-        # 2. Reject already-bidirectional pairs when directed=False
         srcs = edges.index.get_level_values(0)
         dsts = edges.index.get_level_values(1)
-        # Build sets of ordered edges; check for reverse presence
-        edge_set: set[tuple[object, object]] = set()
-        for s, d in zip(srcs, dsts, strict=True):
-            if s == d:
-                continue  # self-loops are fine
-            if (d, s) in edge_set:
-                et_label = f" for edge type {edge_type}" if edge_type else ""
-                msg = (
-                    f"Ambiguous undirected input{et_label}: both ({s}, {d}) and "
-                    f"({d}, {s}) are present. Pass directed=True for directed edges, "
-                    f"or provide only one row per undirected edge."
-                )
-                raise ValueError(msg)
-            edge_set.add((s, d))
+        pairs = pd.DataFrame(
+            {
+                "src": pd.Series(srcs, dtype=object),
+                "dst": pd.Series(dsts, dtype=object),
+            }
+        )
+        non_loop_pairs = pairs[pairs["src"] != pairs["dst"]]
+
+        # 2. Reject already-bidirectional pairs when directed=False.
+        # Drop exact duplicate rows first so repeated same-direction rows are
+        # reported by the parallel-edge branch below.
+        unique_pairs = non_loop_pairs.drop_duplicates(ignore_index=True)
+        reverse_pairs = unique_pairs.rename(columns={"src": "dst", "dst": "src"})
+        bidirectional = unique_pairs.merge(reverse_pairs, on=["src", "dst"], how="inner")
+        if not bidirectional.empty:
+            s = bidirectional.iloc[0]["src"]
+            d = bidirectional.iloc[0]["dst"]
+            et_label = f" for edge type {edge_type}" if edge_type else ""
+            msg = (
+                f"Ambiguous undirected input{et_label}: both ({s}, {d}) and "
+                f"({d}, {s}) are present. Pass directed=True for directed edges, "
+                f"or provide only one row per undirected edge."
+            )
+            raise ValueError(msg)
 
         # 3. Reject parallel undirected rows (duplicate unordered keys)
-        canonical_keys: list[tuple[object, object]] = []
-        for s, d in zip(srcs, dsts, strict=True):
-            key = (min(s, d), max(s, d)) if s != d else (s, d)
-            canonical_keys.append(key)
-        if len(canonical_keys) != len(set(canonical_keys)):
+        if not non_loop_pairs.empty:
+            id_codes = pd.factorize(
+                pd.concat([pairs["src"], pairs["dst"]], ignore_index=True),
+                sort=False,
+            )[0]
+            src_codes = id_codes[: len(pairs)]
+            dst_codes = id_codes[len(pairs) :]
+            non_loop_mask = (pairs["src"] != pairs["dst"]).to_numpy()
+            canonical = pd.DataFrame(
+                {
+                    "key_0": np.minimum(src_codes, dst_codes)[non_loop_mask],
+                    "key_1": np.maximum(src_codes, dst_codes)[non_loop_mask],
+                }
+            )
+            has_parallel = bool(canonical.duplicated(keep=False).any())
+        else:
+            has_parallel = False
+
+        if has_parallel:
             et_label = f" for edge type {edge_type}" if edge_type else ""
             msg = (
                 f"Parallel undirected edges detected{et_label}. "
@@ -1307,18 +1331,25 @@ class PyGConverter(BaseGraphConverter):
         level_0 = gdf.index.get_level_values(0)
         level_1 = gdf.index.get_level_values(1)
 
-        # Create canonical keys: sort each pair so (u,v) and (v,u) map to same key
+        id_codes = pd.factorize(
+            pd.concat(
+                [pd.Series(level_0, copy=False), pd.Series(level_1, copy=False)],
+                ignore_index=True,
+            ),
+            sort=False,
+        )[0]
+        src_codes = id_codes[: len(gdf)]
+        dst_codes = id_codes[len(gdf) :]
         canonical = pd.DataFrame(
-            {"a": level_0, "b": level_1},
+            {
+                "key_0": np.minimum(src_codes, dst_codes),
+                "key_1": np.maximum(src_codes, dst_codes),
+            },
             index=gdf.index,
         )
-        # For comparable types, use element-wise min/max
-        canonical["key_0"] = canonical[["a", "b"]].min(axis=1)
-        canonical["key_1"] = canonical[["a", "b"]].max(axis=1)
-        canonical["canonical_key"] = list(zip(canonical["key_0"], canonical["key_1"], strict=True))
 
         # Keep first occurrence of each canonical pair
-        mask = ~canonical["canonical_key"].duplicated(keep="first")
+        mask = ~canonical.duplicated(keep="first")
         return gdf[mask]
 
     def _reconstruct_node_gdf(
@@ -2309,6 +2340,9 @@ def gdf_to_pyg(
         reverse edge ``(v, u)`` so that PyTorch Geometric receives a proper
         undirected graph. Self-loops are not duplicated. Edge attributes are
         duplicated for reverse edges. If True, edges are kept as-is.
+        With the undirected default, already-bidirectional inputs and parallel
+        rows for the same unordered pair are rejected because they cannot be
+        safely deduplicated during ``pyg_to_gdf`` reconstruction.
         For heterogeneous graphs, can be a complete dictionary mapping each
         edge type to its directionality flag so that different relations can
         independently be directed or undirected.
@@ -2347,6 +2381,9 @@ def gdf_to_pyg(
     This function automatically detects the graph type based on input structure.
     For heterogeneous graphs, provide dictionaries mapping types to GeoDataFrames.
     Node positions are automatically extracted from geometry centroids when available.
+    Undirected conversion accepts unique unordered edge pairs only. This also
+    applies to three-level MultiGraph-style edge indexes: parallel undirected
+    rows for the same unordered pair must use ``directed=True``.
     - Preserves original coordinate reference systems (CRS)
     - Maintains index structure for bidirectional conversion
     - Handles both Point and non-Point geometries (using centroids)
@@ -2465,6 +2502,7 @@ def pyg_to_gdf(
     - Maintains coordinate reference system (CRS) information
     - Converts feature tensors back to named DataFrame columns
     - Handles both homogeneous and heterogeneous graph structures
+    - Deduplicates only edges that city2graph symmetrized during conversion
 
     Examples
     --------
@@ -2574,6 +2612,14 @@ def pyg_to_nx(
             directed = is_directed
         elif isinstance(is_directed, dict):
             directed = all(is_directed.values())
+            if len(set(is_directed.values())) > 1:
+                warnings.warn(
+                    "pyg_to_nx collapses mixed heterogeneous edge directedness to a "
+                    "single NetworkX graph direction; mixed metadata is converted "
+                    "to an undirected graph.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
     graph = gdf_to_nx(nodes, edges, directed=directed)
     if (

--- a/city2graph/graph.py
+++ b/city2graph/graph.py
@@ -129,6 +129,10 @@ class PyGConverter(BaseGraphConverter):
         automatically. A dict provides explicit mappings from original to
         reverse edge types. ``None`` raises ``ValueError`` for any undirected
         cross-type edge (strict mode).
+    multigraph : bool, default False
+        Whether two-level edge indexes should be treated as multigraph inputs
+        by generating a key level. Three-level ``(source, target, key)`` edge
+        indexes are always treated as multigraph inputs.
     """
 
     def __init__(
@@ -143,6 +147,7 @@ class PyGConverter(BaseGraphConverter):
         reverse_edge_types: (
             Literal["auto"] | dict[tuple[str, str, str], tuple[str, str, str]] | None
         ) = "auto",
+        multigraph: bool = False,
     ) -> None:
         """
         Initialize PyGConverter.
@@ -177,11 +182,14 @@ class PyGConverter(BaseGraphConverter):
             ``"auto"`` generates ``(dst_type, "rev_<relation>", src_type)``
             automatically. A dict provides explicit mappings. ``None`` raises
             ``ValueError`` for any undirected cross-type edge (strict mode).
+        multigraph : bool, default False
+            Whether two-level edge indexes should be promoted to keyed
+            multigraph indexes. Three-level indexes keep their original keys.
         """
         # BaseGraphConverter expects a bool; pass True if any dict form is used,
         # since per-edge-type resolution happens later in the PyG-specific code.
         directed_bool = directed if isinstance(directed, bool) else False
-        super().__init__(keep_geom=keep_geom, directed=directed_bool)
+        super().__init__(keep_geom=keep_geom, directed=directed_bool, multigraph=multigraph)
         # Store the full directed spec (bool or dict) for per-edge-type use.
         self.directed: bool | dict[tuple[str, str, str], bool] = directed  # type: ignore[assignment]
         self.reverse_edge_types_spec = reverse_edge_types
@@ -450,21 +458,18 @@ class PyGConverter(BaseGraphConverter):
         # Store index names and values for preservation
         metadata.node_index_names = nodes.index.names if hasattr(nodes.index, "names") else None
         if edges is not None and hasattr(edges.index, "names"):
-            metadata.edge_index_names = edges.index.names
-
-            # Store original edge index values for reconstruction
-            edge_idx_vals = [
-                edges.index.get_level_values(i).tolist() for i in range(edges.index.nlevels)
-            ]
-
-            # Symmetrize edge index values for undirected graphs
-            if self.directed is False and len(edge_idx_vals) == 2:
-                edge_idx_vals = self._symmetrize_edge_index_values(edge_idx_vals)
-
+            edge_index_names, edge_idx_vals, edge_keys, is_multigraph = self._edge_index_metadata(
+                edges, symmetrize=self.directed is False
+            )
+            metadata.edge_index_names = edge_index_names
             metadata.edge_index_values = edge_idx_vals
+            metadata.edge_index_keys = edge_keys
+            metadata.is_multigraph = is_multigraph
         else:
             metadata.edge_index_names = None
             metadata.edge_index_values = None
+            metadata.edge_index_keys = None
+            metadata.is_multigraph = False
 
         # Set CRS
         if hasattr(nodes, "crs") and nodes.crs:
@@ -795,22 +800,21 @@ class PyGConverter(BaseGraphConverter):
         # Store edge index names and values for reconstruction
         metadata.edge_index_names = {}
         metadata.edge_index_values = {}
+        metadata.edge_index_keys = {}
+        multigraph_by_et: dict[tuple[str, str, str], bool] = {}
         for edge_type, edge_gdf in edges_dict.items():
             if edge_gdf is not None and hasattr(edge_gdf.index, "names"):
-                # Store edge index names
-                metadata.edge_index_names[edge_type] = edge_gdf.index.names
-
-                # Store original edge index values for reconstruction
-                edge_idx_vals = [
-                    edge_gdf.index.get_level_values(i).tolist()
-                    for i in range(edge_gdf.index.nlevels)
-                ]
-
-                # Symmetrize edge index values only for edges that were symmetrized
-                if symmetrized_by_et.get(edge_type, False) and len(edge_idx_vals) == 2:
-                    edge_idx_vals = self._symmetrize_edge_index_values(edge_idx_vals)
-
+                edge_index_names, edge_idx_vals, edge_keys, is_multigraph = (
+                    self._edge_index_metadata(
+                        edge_gdf,
+                        symmetrize=symmetrized_by_et.get(edge_type, False),
+                    )
+                )
+                metadata.edge_index_names[edge_type] = edge_index_names
                 metadata.edge_index_values[edge_type] = edge_idx_vals
+                if edge_keys is not None:
+                    metadata.edge_index_keys[edge_type] = edge_keys
+                multigraph_by_et[edge_type] = is_multigraph
 
         # Set CRS
         crs_values = [gdf.crs for gdf in nodes_dict.values() if hasattr(gdf, "crs") and gdf.crs]
@@ -839,6 +843,7 @@ class PyGConverter(BaseGraphConverter):
         # Per-edge-type directionality and provenance metadata
         metadata.is_directed = directed_by_et
         metadata.edge_was_symmetrized = symmetrized_by_et
+        metadata.is_multigraph = multigraph_by_et
         metadata.original_edge_types = list(edges_dict.keys())
         metadata.reverse_edge_types = reverse_et_map
         metadata.generated_reverse_edge_types = gen_reverse_et_map
@@ -938,6 +943,49 @@ class PyGConverter(BaseGraphConverter):
         result: list[list[int]] = combined_array.tolist()
         return result
 
+    def _edge_index_metadata(
+        self,
+        edges: gpd.GeoDataFrame,
+        *,
+        symmetrize: bool,
+    ) -> tuple[list[str | None] | None, list[list[str | int]], list[str | int] | None, bool]:
+        """
+        Build edge index metadata, promoting opt-in multigraphs to keyed indexes.
+
+        The first two index levels always represent source and target IDs.
+        Three-level inputs keep their supplied edge keys, while opt-in
+        two-level multigraph inputs receive generated integer keys.
+
+        Parameters
+        ----------
+        edges : gpd.GeoDataFrame
+            Edge GeoDataFrame with a two- or three-level MultiIndex.
+        symmetrize : bool
+            Whether to append reverse non-self-loop index values.
+
+        Returns
+        -------
+        tuple
+            ``(index_names, index_values, key_values, is_multigraph)``.
+        """
+        index_names = list(edges.index.names) if hasattr(edges.index, "names") else None
+        edge_idx_vals = [
+            edges.index.get_level_values(i).tolist() for i in range(edges.index.nlevels)
+        ]
+
+        is_multigraph = edges.index.nlevels >= 3
+        if self.multigraph and len(edge_idx_vals) == 2:
+            edge_idx_vals.append(list(range(len(edges))))
+            if index_names is not None:
+                index_names.append("key")
+            is_multigraph = True
+
+        if symmetrize:
+            edge_idx_vals = self._symmetrize_edge_index_values(edge_idx_vals)
+
+        edge_keys = edge_idx_vals[2] if len(edge_idx_vals) >= 3 else None
+        return index_names, edge_idx_vals, edge_keys, is_multigraph
+
     # ------------------------------------------------------------------
     # Edge validation and directedness resolution helpers (Steps 3 & 4)
     # ------------------------------------------------------------------
@@ -984,22 +1032,30 @@ class PyGConverter(BaseGraphConverter):
         if directed:
             return  # No further validation needed for directed edges
 
-        srcs = edges.index.get_level_values(0)
-        dsts = edges.index.get_level_values(1)
-        pairs = pd.DataFrame(
-            {
-                "src": pd.Series(srcs, dtype=object),
-                "dst": pd.Series(dsts, dtype=object),
-            }
+        srcs = pd.Series(edges.index.get_level_values(0), dtype=object)
+        dsts = pd.Series(edges.index.get_level_values(1), dtype=object)
+        has_key_level = edges.index.nlevels >= 3
+        key_values = (
+            pd.Series(edges.index.get_level_values(2), dtype=object)
+            if has_key_level
+            else pd.Series(np.arange(len(edges)), dtype=object)
         )
+        pairs_data: dict[str, pd.Series] = {
+            "src": srcs,
+            "dst": dsts,
+        }
+        if has_key_level or self.multigraph:
+            pairs_data["key"] = key_values
+        pairs = pd.DataFrame(pairs_data)
         non_loop_pairs = pairs[pairs["src"] != pairs["dst"]]
 
         # 2. Reject already-bidirectional pairs when directed=False.
+        merge_cols = ["src", "dst", "key"] if "key" in pairs else ["src", "dst"]
         # Drop exact duplicate rows first so repeated same-direction rows are
         # reported by the parallel-edge branch below.
         unique_pairs = non_loop_pairs.drop_duplicates(ignore_index=True)
         reverse_pairs = unique_pairs.rename(columns={"src": "dst", "dst": "src"})
-        bidirectional = unique_pairs.merge(reverse_pairs, on=["src", "dst"], how="inner")
+        bidirectional = unique_pairs.merge(reverse_pairs, on=merge_cols, how="inner")
         if not bidirectional.empty:
             s = bidirectional.iloc[0]["src"]
             d = bidirectional.iloc[0]["dst"]
@@ -1011,7 +1067,9 @@ class PyGConverter(BaseGraphConverter):
             )
             raise ValueError(msg)
 
-        # 3. Reject parallel undirected rows (duplicate unordered keys)
+        # 3. Reject duplicate unordered keys. In simple graphs the key is the
+        # unordered pair. In multigraph inputs it is (unordered pair, edge key),
+        # so distinct parallel keys are first-class edges.
         if not non_loop_pairs.empty:
             id_codes = pd.factorize(
                 pd.concat([pairs["src"], pairs["dst"]], ignore_index=True),
@@ -1026,6 +1084,8 @@ class PyGConverter(BaseGraphConverter):
                     "key_1": np.maximum(src_codes, dst_codes)[non_loop_mask],
                 }
             )
+            if "key" in pairs:
+                canonical["key_2"] = pairs.loc[non_loop_mask, "key"].to_numpy()
             has_parallel = bool(canonical.duplicated(keep=False).any())
         else:
             has_parallel = False
@@ -1036,8 +1096,10 @@ class PyGConverter(BaseGraphConverter):
                 f"Parallel undirected edges detected{et_label}. "
                 f"Round-trip reconstruction cannot safely preserve multiple "
                 f"geometries/attributes for the same unordered pair without "
-                f"explicit multigraph support. Pass directed=True to keep "
-                f"parallel edges as directed rows."
+                f"explicit multigraph support. Provide a three-level "
+                f"(source, target, key) index, pass multigraph=True to "
+                f"generate keys, or pass directed=True to keep parallel edges "
+                f"as directed rows."
             )
             raise ValueError(msg)
 
@@ -1271,14 +1333,20 @@ class PyGConverter(BaseGraphConverter):
         list[list[str | int]]
             Symmetrized edge index values.
         """
-        srcs, dsts = edge_idx_vals[0], edge_idx_vals[1]
-        rev_srcs = []
-        rev_dsts = []
-        for s, d in zip(srcs, dsts, strict=True):
-            if s != d:
-                rev_srcs.append(d)
-                rev_dsts.append(s)
-        return [srcs + rev_srcs, dsts + rev_dsts]
+        if len(edge_idx_vals) < 2:
+            return edge_idx_vals
+
+        srcs = np.asarray(edge_idx_vals[0], dtype=object)
+        dsts = np.asarray(edge_idx_vals[1], dtype=object)
+        non_self_loop_mask = srcs != dsts
+
+        symmetrized = [list(values) for values in edge_idx_vals]
+        symmetrized[0].extend(dsts[non_self_loop_mask].tolist())
+        symmetrized[1].extend(srcs[non_self_loop_mask].tolist())
+        for level_idx in range(2, len(edge_idx_vals)):
+            level_values = np.asarray(edge_idx_vals[level_idx], dtype=object)
+            symmetrized[level_idx].extend(level_values[non_self_loop_mask].tolist())
+        return symmetrized
 
     @staticmethod
     def _symmetrize_edge_geometries(
@@ -1302,12 +1370,12 @@ class PyGConverter(BaseGraphConverter):
         list[str]
             Symmetrized geometry list.
         """
-        rev_geoms = []
-        for i, edge_key in enumerate(edges.index):
-            src, dst = edge_key[:2] if isinstance(edge_key, tuple) else (edge_key, edge_key)
-            if src != dst:
-                rev_geoms.append(edge_geoms[i])
-        return edge_geoms + rev_geoms
+        srcs = np.asarray(edges.index.get_level_values(0), dtype=object)
+        dsts = np.asarray(edges.index.get_level_values(1), dtype=object)
+        non_self_loop_mask = srcs != dsts
+        geoms_array = np.asarray(edge_geoms, dtype=object)
+        reverse_geoms = cast("list[str]", geoms_array[non_self_loop_mask].tolist())
+        return edge_geoms + reverse_geoms
 
     @staticmethod
     def _deduplicate_undirected_edges(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -1340,11 +1408,15 @@ class PyGConverter(BaseGraphConverter):
         )[0]
         src_codes = id_codes[: len(gdf)]
         dst_codes = id_codes[len(gdf) :]
+        canonical_data = {
+            "key_0": np.minimum(src_codes, dst_codes),
+            "key_1": np.maximum(src_codes, dst_codes),
+        }
+        if gdf.index.nlevels >= 3:
+            canonical_data["key_2"] = gdf.index.get_level_values(2).to_numpy()
+
         canonical = pd.DataFrame(
-            {
-                "key_0": np.minimum(src_codes, dst_codes),
-                "key_1": np.maximum(src_codes, dst_codes),
-            },
+            canonical_data,
             index=gdf.index,
         )
 
@@ -1513,7 +1585,7 @@ class PyGConverter(BaseGraphConverter):
         if (
             self._should_deduplicate_edges(metadata, edge_type, is_hetero)
             and isinstance(gdf.index, pd.MultiIndex)
-            and gdf.index.nlevels == 2
+            and gdf.index.nlevels >= 2
             and not gdf.empty
         ):
             gdf = self._deduplicate_undirected_edges(gdf)
@@ -1776,7 +1848,7 @@ class PyGConverter(BaseGraphConverter):
         """
         # Set index names
         if metadata.node_index_names:
-            index_names: list[str] | None = None
+            index_names: list[str | None] | None = None
             # Get index names based on heterogeneity and node type
             if metadata.is_hetero and node_type and isinstance(metadata.node_index_names, dict):
                 index_names = metadata.node_index_names.get(node_type)
@@ -1912,7 +1984,7 @@ class PyGConverter(BaseGraphConverter):
         metadata : GraphMetadata
             Graph metadata containing edge index name information.
         """
-        index_names: list[str] | None = None
+        index_names: list[str | None] | None = None
         if is_hetero and edge_type and isinstance(metadata.edge_index_names, dict):
             if isinstance(edge_type, tuple):
                 index_names = metadata.edge_index_names.get(edge_type)
@@ -2286,6 +2358,7 @@ def gdf_to_pyg(
     reverse_edge_types: (
         Literal["auto"] | dict[tuple[str, str, str], tuple[str, str, str]] | None
     ) = "auto",
+    multigraph: bool = False,
 ) -> Data | HeteroData:
     """
     Convert GeoDataFrames (nodes/edges) to a PyTorch Geometric object.
@@ -2352,6 +2425,11 @@ def gdf_to_pyg(
         automatically. A dict provides explicit mappings from original to
         reverse edge types. ``None`` raises ``ValueError`` for any undirected
         cross-type edge (strict mode).
+    multigraph : bool, default False
+        If True, two-level edge indexes are promoted to a generated
+        ``(source, target, key)`` contract so parallel rows can be preserved.
+        Edge GeoDataFrames that already use a three-level MultiIndex always
+        preserve their supplied key level.
 
     Returns
     -------
@@ -2381,9 +2459,11 @@ def gdf_to_pyg(
     This function automatically detects the graph type based on input structure.
     For heterogeneous graphs, provide dictionaries mapping types to GeoDataFrames.
     Node positions are automatically extracted from geometry centroids when available.
-    Undirected conversion accepts unique unordered edge pairs only. This also
-    applies to three-level MultiGraph-style edge indexes: parallel undirected
-    rows for the same unordered pair must use ``directed=True``.
+    Undirected conversion accepts unique unordered edge pairs for two-level
+    edge indexes. Three-level MultiGraph-style indexes deduplicate by
+    ``(min(source, target), max(source, target), key)``, so parallel rows with
+    distinct keys are preserved. Passing ``multigraph=True`` promotes two-level
+    edge indexes to this keyed contract with generated integer keys.
     - Preserves original coordinate reference systems (CRS)
     - Maintains index structure for bidirectional conversion
     - Handles both Point and non-Point geometries (using centroids)
@@ -2432,6 +2512,7 @@ def gdf_to_pyg(
         keep_geom=keep_geom,
         directed=directed,
         reverse_edge_types=reverse_edge_types,
+        multigraph=multigraph,
     )
     return converter.gdf_to_pyg(nodes, edges)
 
@@ -2503,6 +2584,8 @@ def pyg_to_gdf(
     - Converts feature tensors back to named DataFrame columns
     - Handles both homogeneous and heterogeneous graph structures
     - Deduplicates only edges that city2graph symmetrized during conversion
+    - Preserves three-level ``(source, target, key)`` edge indexes for
+      multigraph round trips
 
     Examples
     --------
@@ -2565,6 +2648,8 @@ def pyg_to_nx(
     networkx.Graph
         The converted NetworkX graph with node and edge attributes.
         For heterogeneous graphs, node and edge types are stored as attributes.
+        If the PyG metadata or reconstructed edge indexes include edge keys,
+        returns a ``MultiGraph`` or ``MultiDiGraph`` as appropriate.
 
     Raises
     ------
@@ -2582,6 +2667,7 @@ def pyg_to_nx(
     - Edge features are stored as edge attributes
     - For heterogeneous graphs, type information is preserved
     - Geometry information is converted from tensor positions
+    - MultiGraph and MultiDiGraph edge keys are preserved when present
     - Maintains compatibility with NetworkX analysis algorithms
 
     Examples
@@ -2606,6 +2692,7 @@ def pyg_to_nx(
     )
     metadata = getattr(data, "graph_metadata", None)
     directed = False
+    multigraph = False
     if metadata is not None:
         is_directed = getattr(metadata, "is_directed", False)
         if isinstance(is_directed, bool):
@@ -2620,8 +2707,22 @@ def pyg_to_nx(
                     UserWarning,
                     stacklevel=2,
                 )
+        is_multigraph = getattr(metadata, "is_multigraph", False)
+        if isinstance(is_multigraph, bool):
+            multigraph = is_multigraph
+        elif isinstance(is_multigraph, dict):
+            multigraph = any(is_multigraph.values())
 
-    graph = gdf_to_nx(nodes, edges, directed=directed)
+    if not multigraph:
+        if isinstance(edges, gpd.GeoDataFrame) and isinstance(edges.index, pd.MultiIndex):
+            multigraph = edges.index.nlevels >= 3
+        elif isinstance(edges, dict):
+            multigraph = any(
+                isinstance(edge_gdf.index, pd.MultiIndex) and edge_gdf.index.nlevels >= 3
+                for edge_gdf in edges.values()
+            )
+
+    graph = gdf_to_nx(nodes, edges, directed=directed, multigraph=multigraph)
     if (
         metadata is not None
         and getattr(metadata, "is_hetero", False) is False
@@ -2680,7 +2781,8 @@ def nx_to_pyg(
     directed : bool, optional
         Explicit directionality override. If omitted, the NetworkX graph type is
         used: ``Graph`` and ``MultiGraph`` are undirected, while ``DiGraph`` and
-        ``MultiDiGraph`` are directed.
+        ``MultiDiGraph`` are directed. MultiGraph and MultiDiGraph edge keys are
+        preserved through the GeoDataFrame edge index.
 
     Returns
     -------
@@ -2765,6 +2867,7 @@ def nx_to_pyg(
         dtype=dtype,
         keep_geom=keep_geom,
         directed=directed_flag,
+        multigraph=graph.is_multigraph(),
     )
 
 

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -288,15 +288,13 @@ class NxConverter(BaseGraphConverter):
             self._add_homogeneous_nodes(graph, nodes)
             metadata.node_geom_cols = list(nodes.select_dtypes(include=["geometry"]).columns)
             metadata.node_index_names = typing.cast(
-                "list[str] | None", self._get_node_index_names(nodes)
+                "list[str | None] | None", self._get_node_index_names(nodes)
             )
 
         # Add edges
         self._add_homogeneous_edges(graph, edges, nodes)
         metadata.edge_geom_cols = list(edges.select_dtypes(include=["geometry"]).columns)
-        metadata.edge_index_names = typing.cast(
-            "list[str] | None", _coerce_name_sequence(edges.index.names)
-        )
+        metadata.edge_index_names = _coerce_name_sequence(edges.index.names)
 
         # Store metadata
         graph.graph.update(metadata.to_dict())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,12 +425,11 @@ def sample_hetero_edges_dict(
     )
 
     road_links_data = {
-        "source_road_id": ["r1", "r2"],
-        "target_road_id": ["r2", "r1"],
-        "link_feat1": [0.7, 0.7],
+        "source_road_id": ["r1"],
+        "target_road_id": ["r2"],
+        "link_feat1": [0.7],
         "geometry": [
             LineString([(10, 12), (12, 12)]),
-            LineString([(12, 12), (10, 12)]),
         ],
     }
     road_links_gdf = _edge_gdf(

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import geopandas as gpd
 import networkx as nx
+import osmnx as ox
 import pandas as pd
 import pytest
 import torch
@@ -1897,26 +1898,65 @@ class TestUndirectedEdgeHandling:
 
         assert data.num_edges == len(edges)
 
-    def test_three_level_parallel_undirected_edges_rejected(
+    def test_three_level_parallel_undirected_edges_round_trip(
         self, simple_nodes: gpd.GeoDataFrame
     ) -> None:
-        """Three-level MultiGraph-style parallel rows still need directed=True."""
+        """Three-level MultiGraph-style parallel rows round-trip with keys."""
         edges = gpd.GeoDataFrame(
             {
+                "weight": [1.0, 2.0, 3.0],
                 "geometry": [
                     LineString([(0, 0), (1, 0)]),
-                    LineString([(0, 0), (1, 0)]),
+                    LineString([(0, 0), (0.5, 0.2), (1, 0)]),
+                    LineString([(0, 0), (0, 0)]),
                 ],
             },
             index=pd.MultiIndex.from_arrays(
-                [[1, 1], [2, 2], [0, 1]],
+                [[1, 1, 1], [2, 2, 1], ["road", "rail", "loop"]],
                 names=["source_id", "target_id", "edge_key"],
             ),
             crs="EPSG:27700",
         )
 
-        with pytest.raises(ValueError, match="Parallel undirected edges"):
-            gdf_to_pyg(simple_nodes, edges)
+        data = gdf_to_pyg(simple_nodes, edges, edge_feature_cols=["weight"])
+        _, restored_edges = pyg_to_gdf(data)
+
+        assert data.num_edges == 5
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        pd.testing.assert_index_equal(restored_edges.index, edges.index)
+        assert restored_edges["weight"].tolist() == [1.0, 2.0, 3.0]
+        assert restored_edges.geometry.equals(edges.geometry)
+
+    def test_opt_in_multigraph_generates_key_level(self, simple_nodes: gpd.GeoDataFrame) -> None:
+        """multigraph=True preserves parallel two-level rows with generated keys."""
+        edges = gpd.GeoDataFrame(
+            {
+                "weight": [1.0, 2.0],
+                "geometry": [
+                    LineString([(0, 0), (1, 0)]),
+                    LineString([(0, 0), (0.5, 0.2), (1, 0)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [[1, 1], [2, 2]],
+                names=["source_id", "target_id"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        data = gdf_to_pyg(
+            simple_nodes,
+            edges,
+            edge_feature_cols=["weight"],
+            multigraph=True,
+        )
+        _, restored_edges = pyg_to_gdf(data)
+
+        assert data.num_edges == 4
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        assert restored_edges.index.names == ["source_id", "target_id", "key"]
+        assert restored_edges.index.get_level_values("key").tolist() == [0, 1]
+        assert restored_edges["weight"].tolist() == [1.0, 2.0]
 
     def test_empty_edge_features_resized_on_symmetrization(
         self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
@@ -2054,6 +2094,232 @@ class TestUndirectedEdgeHandling:
         assert data.num_edges == 2
         assert data.graph_metadata.is_directed is False
 
+    def test_nx_multigraph_round_trip_preserves_parallel_keys(self) -> None:
+        """nx.MultiGraph round-trips as a MultiGraph with edge keys."""
+        graph = nx.MultiGraph()
+        graph.add_node("a", pos=(0, 0), geometry=Point(0, 0))
+        graph.add_node("b", pos=(1, 0), geometry=Point(1, 0))
+        graph.add_edge(
+            "a",
+            "b",
+            key="road",
+            weight=1.0,
+            geometry=LineString([(0, 0), (1, 0)]),
+        )
+        graph.add_edge(
+            "a",
+            "b",
+            key="rail",
+            weight=2.0,
+            geometry=LineString([(0, 0), (0.5, 0.2), (1, 0)]),
+        )
+        graph.graph["crs"] = "EPSG:27700"
+        graph.graph["is_hetero"] = False
+
+        data = nx_to_pyg(graph, edge_feature_cols=["weight"])
+        restored = pyg_to_nx(data)
+
+        assert isinstance(restored, nx.MultiGraph)
+        assert restored.is_directed() is False
+        assert restored.number_of_edges("a", "b") == 2
+        assert {key for _, _, key in restored.edges(keys=True)} == {"road", "rail"}
+
+    def test_osmnx_shaped_multidigraph_gdfs_round_trip_preserve_edge_keys(self) -> None:
+        """OSMnx-shaped MultiDiGraph GeoDataFrames keep keyed edge identity."""
+        nodes = gpd.GeoDataFrame(
+            {
+                "x": [0.0, 1.0, 2.0],
+                "y": [0.0, 0.0, 0.0],
+                "geometry": [Point(0, 0), Point(1, 0), Point(2, 0)],
+            },
+            index=pd.Index([101, 202, 303], name="osmid"),
+            crs="EPSG:4326",
+        )
+        edges = gpd.GeoDataFrame(
+            {
+                "osmid": [10, 11, 12],
+                "length": [100.0, 110.0, 125.0],
+                "geometry": [
+                    LineString([(0, 0), (1, 0)]),
+                    LineString([(0, 0), (0.5, 0.1), (1, 0)]),
+                    LineString([(1, 0), (2, 0)]),
+                ],
+            },
+            index=pd.MultiIndex.from_tuples(
+                [(101, 202, 0), (101, 202, 1), (202, 303, 0)],
+                names=["u", "v", "key"],
+            ),
+            crs="EPSG:4326",
+        )
+
+        data = gdf_to_pyg(nodes, edges, edge_feature_cols=["length"], directed=True)
+        restored_nodes, restored_edges = pyg_to_gdf(data)
+
+        assert data.num_edges == len(edges)
+        assert isinstance(restored_nodes, gpd.GeoDataFrame)
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        assert len(restored_nodes) == len(nodes)
+        assert len(restored_edges) == len(edges)
+        assert restored_edges.index.nlevels == 3
+        assert restored_edges.index.names == ["u", "v", "key"]
+        assert set(restored_edges.index) == set(edges.index)
+        pd.testing.assert_series_equal(
+            restored_edges.sort_index()["length"],
+            edges.sort_index()["length"],
+            check_names=False,
+            check_dtype=False,
+        )
+
+    def test_osmnx_shaped_multigraph_gdfs_round_trip_deduplicates_symmetrized_edges(
+        self,
+    ) -> None:
+        """Undirected OSMnx-shaped MultiGraph GeoDataFrames dedupe by pair plus key."""
+        nodes = gpd.GeoDataFrame(
+            {
+                "x": [0.0, 1.0, 2.0],
+                "y": [0.0, 0.0, 0.0],
+                "geometry": [Point(0, 0), Point(1, 0), Point(2, 0)],
+            },
+            index=pd.Index([101, 202, 303], name="osmid"),
+            crs="EPSG:4326",
+        )
+        edges = gpd.GeoDataFrame(
+            {
+                "osmid": [10, 11, 12],
+                "length": [100.0, 110.0, 125.0],
+                "geometry": [
+                    LineString([(0, 0), (1, 0)]),
+                    LineString([(0, 0), (0.5, 0.1), (1, 0)]),
+                    LineString([(1, 0), (2, 0)]),
+                ],
+            },
+            index=pd.MultiIndex.from_tuples(
+                [(101, 202, 0), (101, 202, 1), (202, 303, 0)],
+                names=["u", "v", "key"],
+            ),
+            crs="EPSG:4326",
+        )
+
+        data = gdf_to_pyg(nodes, edges, edge_feature_cols=["length"], directed=False)
+        _, restored_edges = pyg_to_gdf(data)
+
+        assert data.num_edges == len(edges) * 2
+        assert data.graph_metadata.is_multigraph is True
+        assert data.graph_metadata.edge_was_symmetrized is True
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        assert len(restored_edges) == len(edges)
+        assert restored_edges.index.names == ["u", "v", "key"]
+        assert set(restored_edges.index) == set(edges.index)
+        pd.testing.assert_series_equal(
+            restored_edges.sort_index()["length"],
+            edges.sort_index()["length"],
+            check_names=False,
+            check_dtype=False,
+        )
+
+    def test_osmnx_downloaded_multidigraph_smoke(self) -> None:
+        """Downloaded OSMnx MultiDiGraph round-trips through PyG with keyed edges."""
+        graph = ox.graph_from_bbox(
+            (-0.128, 51.501, -0.124, 51.503),
+            network_type="drive",
+            simplify=True,
+            retain_all=False,
+        )
+        nodes, edges = ox.graph_to_gdfs(graph)
+
+        data = gdf_to_pyg(
+            nodes,
+            edges,
+            edge_feature_cols=["length"],
+            directed=graph.is_directed(),
+            multigraph=graph.is_multigraph(),
+        )
+        restored_nodes, restored_edges = pyg_to_gdf(data)
+
+        assert isinstance(graph, nx.MultiDiGraph)
+        assert isinstance(restored_nodes, gpd.GeoDataFrame)
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        assert len(restored_nodes) == len(nodes)
+        assert len(restored_edges) == len(edges)
+        assert restored_edges.index.nlevels == 3
+        assert set(restored_edges.index) == set(edges.index)
+
+        undirected_graph = ox.convert.to_undirected(graph)
+        undirected_nodes, undirected_edges = ox.graph_to_gdfs(undirected_graph)
+        undirected_data = gdf_to_pyg(
+            undirected_nodes,
+            undirected_edges,
+            edge_feature_cols=["length"],
+            directed=False,
+            multigraph=undirected_graph.is_multigraph(),
+        )
+        _, undirected_restored_edges = pyg_to_gdf(undirected_data)
+
+        assert isinstance(undirected_graph, nx.MultiGraph)
+        assert undirected_data.num_edges == len(undirected_edges) * 2
+        assert undirected_data.graph_metadata.is_multigraph is True
+        assert undirected_data.graph_metadata.edge_was_symmetrized is True
+        assert isinstance(undirected_restored_edges, gpd.GeoDataFrame)
+        assert len(undirected_restored_edges) == len(undirected_edges)
+        assert undirected_restored_edges.index.nlevels == 3
+        assert set(undirected_restored_edges.index) == set(undirected_edges.index)
+
+    def test_nx_multidigraph_round_trip_preserves_parallel_direction(self) -> None:
+        """nx.MultiDiGraph round-trips as directed with parallel keys."""
+        graph = nx.MultiDiGraph()
+        graph.add_node("a", pos=(0, 0), geometry=Point(0, 0))
+        graph.add_node("b", pos=(1, 0), geometry=Point(1, 0))
+        graph.add_edge(
+            "a",
+            "b",
+            key="ab",
+            weight=1.0,
+            geometry=LineString([(0, 0), (1, 0)]),
+        )
+        graph.add_edge(
+            "b",
+            "a",
+            key="ba",
+            weight=2.0,
+            geometry=LineString([(1, 0), (0, 0)]),
+        )
+        graph.graph["crs"] = "EPSG:27700"
+        graph.graph["is_hetero"] = False
+
+        restored = pyg_to_nx(nx_to_pyg(graph, edge_feature_cols=["weight"]))
+
+        assert isinstance(restored, nx.MultiDiGraph)
+        assert restored.is_directed() is True
+        assert set(restored.edges(keys=True)) == {("a", "b", "ab"), ("b", "a", "ba")}
+
+    def test_old_metadata_missing_multigraph_attrs_still_round_trips(
+        self, simple_nodes: gpd.GeoDataFrame
+    ) -> None:
+        """Older PyG metadata without new multigraph attrs still reconstructs."""
+        edges = gpd.GeoDataFrame(
+            {
+                "geometry": [
+                    LineString([(0, 0), (1, 0)]),
+                    LineString([(0, 0), (0.5, 0.2), (1, 0)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [[1, 1], [2, 2], ["road", "rail"]],
+                names=["source_id", "target_id", "edge_key"],
+            ),
+            crs="EPSG:27700",
+        )
+        data = gdf_to_pyg(simple_nodes, edges)
+        delattr(data.graph_metadata, "edge_index_keys")
+        delattr(data.graph_metadata, "is_multigraph")
+
+        _, restored_edges = pyg_to_gdf(data)
+        restored_graph = pyg_to_nx(data)
+
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        pd.testing.assert_index_equal(restored_edges.index, edges.index)
+        assert isinstance(restored_graph, nx.MultiGraph)
+
     def test_nx_to_pyg_directed_override(self) -> None:
         """The directed override takes precedence over nx.Graph semantics."""
         graph = nx.Graph()
@@ -2140,6 +2406,75 @@ class TestUndirectedEdgeHandling:
         assert set(edges_restored) == set(edges_dict)
         assert len(edges_restored[road_type]) == len(road_gdf)
         assert len(edges_restored[conn_type]) == len(conn_gdf)
+
+    def test_hetero_same_type_parallel_keys_round_trip(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Same-type hetero edges preserve parallel key-level rows."""
+        edge_type = ("road", "links_to", "road")
+        road_gdf = gpd.GeoDataFrame(
+            {
+                "weight": [1.0, 2.0],
+                "geometry": [
+                    LineString([(10, 12), (12, 12)]),
+                    LineString([(10, 12), (11, 12.5), (12, 12)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["r1", "r1"], ["r2", "r2"], ["road", "rail"]],
+                names=["source_road_id", "target_road_id", "edge_key"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            {edge_type: road_gdf},
+            edge_feature_cols={edge_type: ["weight"]},
+        )
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert data[edge_type].edge_index.size(1) == 4
+        assert isinstance(edges_restored, dict)
+        pd.testing.assert_index_equal(edges_restored[edge_type].index, road_gdf.index)
+        assert edges_restored[edge_type]["weight"].tolist() == [1.0, 2.0]
+
+    def test_hetero_cross_type_parallel_keys_skip_reverse_leakage(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Cross-type parallel keyed edges mirror for PyG without leaking back."""
+        edge_type = ("building", "connects_to", "road")
+        reverse_type = ("road", "rev_connects_to", "building")
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "weight": [1.0, 2.0],
+                "geometry": [
+                    LineString([(10, 10), (10, 12)]),
+                    LineString([(10, 10), (10.2, 11), (10, 12)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1", "b1"], ["r1", "r1"], ["walk", "service"]],
+                names=["building_id", "road_id", "edge_key"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            {edge_type: conn_gdf},
+            edge_feature_cols={edge_type: ["weight"]},
+        )
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert data[edge_type].edge_index.size(1) == 2
+        assert data[reverse_type].edge_index.size(1) == 2
+        assert torch.equal(data[reverse_type].edge_attr, data[edge_type].edge_attr)
+        assert isinstance(edges_restored, dict)
+        assert set(edges_restored) == {edge_type}
+        pd.testing.assert_index_equal(edges_restored[edge_type].index, conn_gdf.index)
 
     def test_hetero_directed_dict_round_trip(
         self,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -138,7 +138,8 @@ class TestGraphConversion:
             data = gdf_to_pyg(sample_nodes_gdf, sample_edges_gdf)
             assert isinstance(data, Data)
             assert data.num_nodes == len(sample_nodes_gdf)
-            assert data.num_edges == len(sample_edges_gdf)
+            # Edges are symmetrized by default (directed=False), so doubled
+            assert data.num_edges == len(sample_edges_gdf) * 2
             assert not data.graph_metadata.is_hetero
         else:
             data = gdf_to_pyg(sample_hetero_nodes_dict, sample_hetero_edges_dict)
@@ -216,9 +217,10 @@ class TestGraphConversion:
         data = nx_to_pyg(sample_nx_graph)
         assert isinstance(data, Data)
         assert data.num_nodes == sample_nx_graph.number_of_nodes()
-        assert data.num_edges == sample_nx_graph.number_of_edges()
+        # Edges are symmetrized by default (directed=False), so doubled
+        assert data.num_edges == sample_nx_graph.number_of_edges() * 2
 
-        # PyG -> NX (round trip)
+        # PyG -> NX (round trip) — pyg_to_nx uses pyg_to_gdf which deduplicates
         nx_restored = pyg_to_nx(data)
         assert isinstance(nx_restored, nx.Graph)
         assert nx_restored.graph.get("is_hetero") is False
@@ -1091,3 +1093,148 @@ class TestOptionalTensorConversion:
                 graph_module._get_device(None)
         else:
             pytest.skip("_get_device not accessible")
+
+
+class TestUndirectedEdgeHandling:
+    """Test undirected edge symmetrization and deduplication."""
+
+    @pytest.fixture
+    def simple_nodes(self) -> gpd.GeoDataFrame:
+        """Create simple nodes for testing."""
+        data = {
+            "node_id": [1, 2, 3],
+            "feature": [10.0, 20.0, 30.0],
+            "geometry": [Point(0, 0), Point(1, 0), Point(1, 1)],
+        }
+        return gpd.GeoDataFrame(data, crs="EPSG:27700").set_index("node_id")
+
+    @pytest.fixture
+    def simple_edges(self) -> gpd.GeoDataFrame:
+        """Create simple undirected edges (each pair once)."""
+        source_ids = [1, 2]
+        target_ids = [2, 3]
+        data = {
+            "source_id": source_ids,
+            "target_id": target_ids,
+            "weight": [0.5, 1.5],
+            "geometry": [
+                LineString([(0, 0), (1, 0)]),
+                LineString([(1, 0), (1, 1)]),
+            ],
+        }
+        idx = pd.MultiIndex.from_arrays([source_ids, target_ids], names=["source_id", "target_id"])
+        return gpd.GeoDataFrame(data, index=idx, crs="EPSG:27700")
+
+    def test_default_symmetrizes_edges(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Default (directed=False) doubles edges via symmetrization."""
+        data = gdf_to_pyg(simple_nodes, simple_edges)
+        # 2 original edges → 4 after symmetrization
+        assert data.num_edges == 4
+
+    def test_every_edge_has_reverse(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Every (u,v) should have a matching (v,u)."""
+        data = gdf_to_pyg(simple_nodes, simple_edges)
+        edge_set = set()
+        ei = data.edge_index
+        for i in range(ei.size(1)):
+            edge_set.add((ei[0, i].item(), ei[1, i].item()))
+        for u, v in list(edge_set):
+            assert (v, u) in edge_set, f"Missing reverse edge ({v}, {u})"
+
+    def test_directed_true_no_symmetrization(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """directed=True keeps edges as-is (no doubling)."""
+        data = gdf_to_pyg(simple_nodes, simple_edges, directed=True)
+        assert data.num_edges == 2
+
+    def test_round_trip_restores_original_edges(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """gdf_to_pyg → pyg_to_gdf round trip restores original edge count."""
+        data = gdf_to_pyg(simple_nodes, simple_edges)
+        assert data.num_edges == 4  # symmetrized
+
+        _, edges_restored = pyg_to_gdf(data)
+        assert isinstance(edges_restored, gpd.GeoDataFrame)
+        # Should be deduplicated back to original count
+        assert len(edges_restored) == 2
+
+    def test_edge_features_duplicated(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Edge features are correctly duplicated for reverse edges."""
+        data = gdf_to_pyg(simple_nodes, simple_edges, edge_feature_cols=["weight"])
+        assert data.edge_attr.shape == (4, 1)
+        # Original: [0.5, 1.5], Reverse: [0.5, 1.5]
+        weights = data.edge_attr[:, 0].tolist()
+        assert weights == [0.5, 1.5, 0.5, 1.5]
+
+    def test_self_loops_not_duplicated(self) -> None:
+        """Self-loops should not be duplicated during symmetrization."""
+        nodes = gpd.GeoDataFrame(
+            {"node_id": [1, 2], "geometry": [Point(0, 0), Point(1, 0)]},
+            crs="EPSG:27700",
+        ).set_index("node_id")
+
+        source_ids = [1, 1]
+        target_ids = [2, 1]
+        edges_data = {
+            "source_id": source_ids,
+            "target_id": target_ids,  # 1→2 and 1→1 (self-loop)
+            "geometry": [LineString([(0, 0), (1, 0)]), LineString([(0, 0), (0, 0)])],
+        }
+        idx = pd.MultiIndex.from_arrays(
+            [source_ids, target_ids],
+            names=["source_id", "target_id"],
+        )
+        edges = gpd.GeoDataFrame(edges_data, index=idx, crs="EPSG:27700")
+
+        data = gdf_to_pyg(nodes, edges)
+        # 1→2 gets reversed (adds 2→1), 1→1 stays as is: total 3
+        assert data.num_edges == 3
+
+    def test_hetero_same_type_symmetrized(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Same-type hetero edges (road→road) are symmetrized."""
+        # Create edges with road→road only having one direction
+        road_links = gpd.GeoDataFrame(
+            {
+                "source_road_id": ["r1"],
+                "target_road_id": ["r2"],
+                "feat": [1.0],
+                "geometry": [LineString([(10, 12), (12, 12)])],
+            },
+            crs="EPSG:27700",
+        )
+        road_links = road_links.set_index(
+            pd.MultiIndex.from_arrays(
+                [road_links["source_road_id"], road_links["target_road_id"]],
+                names=["source_road_id", "target_road_id"],
+            )
+        )
+
+        edges_dict = {("road", "links_to", "road"): road_links}
+        data = gdf_to_pyg(sample_hetero_nodes_dict, edges_dict)
+
+        # 1 edge → 2 after symmetrization
+        et = ("road", "links_to", "road")
+        assert data[et].edge_index.size(1) == 2
+
+    def test_hetero_cross_type_not_symmetrized(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+        sample_hetero_edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
+    ) -> None:
+        """Cross-type hetero edges (building→road) are NOT symmetrized."""
+        data = gdf_to_pyg(sample_hetero_nodes_dict, sample_hetero_edges_dict)
+
+        # building→road: 3 edges, NOT symmetrized (different types)
+        et_cross = ("building", "connects_to", "road")
+        assert data[et_cross].edge_index.size(1) == 3

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -146,7 +146,9 @@ class TestGraphConversion:
             assert isinstance(data, HeteroData)
             assert data.graph_metadata.is_hetero
             assert set(data.node_types) == set(sample_hetero_nodes_dict.keys())
-            assert set(data.edge_types) == set(sample_hetero_edges_dict.keys())
+            # Original edge types should be present; generated reverse stores
+            # for cross-type undirected edges add extra edge types.
+            assert set(sample_hetero_edges_dict.keys()).issubset(set(data.edge_types))
 
     @pytest.mark.parametrize("graph_type", ["homogeneous", "heterogeneous"])
     def test_gdf_to_pyg_with_features(
@@ -1238,3 +1240,606 @@ class TestUndirectedEdgeHandling:
         # building→road: 3 edges, NOT symmetrized (different types)
         et_cross = ("building", "connects_to", "road")
         assert data[et_cross].edge_index.size(1) == 3
+
+    # ------------------------------------------------------------------
+    # NEW: Graph-semantics tests from Implementation Plan v2 Step 7
+    # ------------------------------------------------------------------
+
+    def test_nx_digraph_stays_directed(self) -> None:
+        """nx.DiGraph edges are not symmetrized in PyG."""
+        G = nx.DiGraph()
+        G.add_node(1, pos=(0, 0), geometry=Point(0, 0))
+        G.add_node(2, pos=(1, 0), geometry=Point(1, 0))
+        G.add_edge(1, 2, geometry=LineString([(0, 0), (1, 0)]))
+        G.graph["crs"] = "EPSG:27700"
+        G.graph["is_hetero"] = False
+
+        data = nx_to_pyg(G)
+        # Directed: edges should NOT be doubled
+        assert data.num_edges == 1, f"Expected 1 directed edge, got {data.num_edges}"
+        assert data.graph_metadata.is_directed is True
+
+    def test_nx_multidigraph_stays_directed(self) -> None:
+        """nx.MultiDiGraph edges are not symmetrized in PyG."""
+        G = nx.MultiDiGraph()
+        G.add_node(1, pos=(0, 0), geometry=Point(0, 0))
+        G.add_node(2, pos=(1, 0), geometry=Point(1, 0))
+        G.add_edge(1, 2, key=0, geometry=LineString([(0, 0), (1, 0)]))
+        G.graph["crs"] = "EPSG:27700"
+        G.graph["is_hetero"] = False
+
+        data = nx_to_pyg(G)
+        assert data.num_edges == 1, f"Expected 1 directed edge, got {data.num_edges}"
+        assert data.graph_metadata.is_directed is True
+
+    def test_nx_graph_symmetrized(self) -> None:
+        """nx.Graph edges are symmetrized in PyG (bidirectional)."""
+        G = nx.Graph()
+        G.add_node(1, pos=(0, 0), geometry=Point(0, 0))
+        G.add_node(2, pos=(1, 0), geometry=Point(1, 0))
+        G.add_edge(1, 2, geometry=LineString([(0, 0), (1, 0)]))
+        G.graph["crs"] = "EPSG:27700"
+        G.graph["is_hetero"] = False
+
+        data = nx_to_pyg(G)
+        # Undirected: edges should be doubled
+        assert data.num_edges == 2, f"Expected 2 edges after symmetrization, got {data.num_edges}"
+        assert data.graph_metadata.is_directed is False
+
+    def test_already_bidirectional_gdf_rejected(self, simple_nodes: gpd.GeoDataFrame) -> None:
+        """GDF with both (u,v) and (v,u) raises ValueError when directed=False."""
+        source_ids = [1, 2]
+        target_ids = [2, 1]
+        edges_data = {
+            "source_id": source_ids,
+            "target_id": target_ids,
+            "geometry": [
+                LineString([(0, 0), (1, 0)]),
+                LineString([(1, 0), (0, 0)]),
+            ],
+        }
+        idx = pd.MultiIndex.from_arrays(
+            [source_ids, target_ids],
+            names=["source_id", "target_id"],
+        )
+        edges = gpd.GeoDataFrame(edges_data, index=idx, crs="EPSG:27700")
+
+        with pytest.raises(ValueError, match="Ambiguous undirected input"):
+            gdf_to_pyg(simple_nodes, edges, directed=False)
+
+    def test_already_bidirectional_ok_when_directed(self, simple_nodes: gpd.GeoDataFrame) -> None:
+        """Already-bidirectional GDF is fine when directed=True."""
+        source_ids = [1, 2]
+        target_ids = [2, 1]
+        edges_data = {
+            "source_id": source_ids,
+            "target_id": target_ids,
+            "geometry": [
+                LineString([(0, 0), (1, 0)]),
+                LineString([(1, 0), (0, 0)]),
+            ],
+        }
+        idx = pd.MultiIndex.from_arrays(
+            [source_ids, target_ids],
+            names=["source_id", "target_id"],
+        )
+        edges = gpd.GeoDataFrame(edges_data, index=idx, crs="EPSG:27700")
+
+        data = gdf_to_pyg(simple_nodes, edges, directed=True)
+        assert data.num_edges == 2
+
+    def test_parallel_undirected_rows_rejected(self, simple_nodes: gpd.GeoDataFrame) -> None:
+        """Duplicate unordered keys (parallel undirected) raise ValueError."""
+        source_ids = [1, 1]
+        target_ids = [2, 2]
+        edges_data = {
+            "source_id": source_ids,
+            "target_id": target_ids,
+            "geometry": [
+                LineString([(0, 0), (1, 0)]),
+                LineString([(0, 0), (1, 0)]),
+            ],
+        }
+        idx = pd.MultiIndex.from_arrays(
+            [source_ids, target_ids],
+            names=["source_id", "target_id"],
+        )
+        edges = gpd.GeoDataFrame(edges_data, index=idx, crs="EPSG:27700")
+
+        with pytest.raises(ValueError, match="Parallel undirected edges"):
+            gdf_to_pyg(simple_nodes, edges, directed=False)
+
+    def test_cross_type_auto_reverse_store(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Cross-type undirected edges generate auto reverse stores."""
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "connects_to", "road"): conn_gdf}
+
+        data = gdf_to_pyg(sample_hetero_nodes_dict, edges_dict)
+
+        # Original edge type still has 1 edge
+        et = ("building", "connects_to", "road")
+        assert data[et].edge_index.size(1) == 1
+
+        # Generated reverse store should exist
+        rev_et = ("road", "rev_connects_to", "building")
+        assert rev_et in data.edge_types
+        assert data[rev_et].edge_index.size(1) == 1
+
+        # Reverse should flip source/target
+        assert data[rev_et].edge_index[0].tolist() == data[et].edge_index[1].tolist()
+        assert data[rev_et].edge_index[1].tolist() == data[et].edge_index[0].tolist()
+
+    def test_cross_type_explicit_reverse_mapping(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Explicit reverse_edge_types mapping is used for cross-type edges."""
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "connects_to", "road"): conn_gdf}
+
+        custom_rev = ("road", "served_by", "building")
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            edges_dict,
+            reverse_edge_types={("building", "connects_to", "road"): custom_rev},
+        )
+
+        assert custom_rev in data.edge_types
+        # Auto-generated name should NOT exist
+        assert ("road", "rev_connects_to", "building") not in data.edge_types
+
+    def test_cross_type_strict_mode_raises(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """reverse_edge_types=None (strict mode) raises for undirected cross-type."""
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "connects_to", "road"): conn_gdf}
+
+        with pytest.raises(ValueError, match="strict mode"):
+            gdf_to_pyg(
+                sample_hetero_nodes_dict,
+                edges_dict,
+                reverse_edge_types=None,
+            )
+
+    def test_cross_type_directed_no_reverse_store(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Cross-type directed edges don't generate reverse stores."""
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "connects_to", "road"): conn_gdf}
+
+        data = gdf_to_pyg(sample_hetero_nodes_dict, edges_dict, directed=True)
+        assert ("road", "rev_connects_to", "building") not in data.edge_types
+        assert data[("building", "connects_to", "road")].edge_index.size(1) == 1
+
+    def test_directed_dict_complete(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Complete directed dict: road→road directed, building→road undirected."""
+        road_data = {
+            "source_road_id": ["r1"],
+            "target_road_id": ["r2"],
+            "geometry": [LineString([(10, 12), (12, 12)])],
+        }
+        road_gdf = gpd.GeoDataFrame(
+            road_data,
+            index=pd.MultiIndex.from_arrays(
+                [road_data["source_road_id"], road_data["target_road_id"]],
+                names=["source_road_id", "target_road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        edges_dict = {
+            ("road", "links_to", "road"): road_gdf,
+            ("building", "connects_to", "road"): conn_gdf,
+        }
+
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            edges_dict,
+            directed={
+                ("road", "links_to", "road"): True,
+                ("building", "connects_to", "road"): False,
+            },
+        )
+
+        # road→road is directed: no symmetrization, 1 edge
+        assert data[("road", "links_to", "road")].edge_index.size(1) == 1
+        # building→road is undirected: has reverse store
+        assert data[("building", "connects_to", "road")].edge_index.size(1) == 1
+        assert ("road", "rev_connects_to", "building") in data.edge_types
+
+    def test_directed_dict_missing_keys_raises(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Incomplete directed dict raises ValueError."""
+        road_data = {
+            "source_road_id": ["r1"],
+            "target_road_id": ["r2"],
+            "geometry": [LineString([(10, 12), (12, 12)])],
+        }
+        road_gdf = gpd.GeoDataFrame(
+            road_data,
+            index=pd.MultiIndex.from_arrays(
+                [road_data["source_road_id"], road_data["target_road_id"]],
+                names=["source_road_id", "target_road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        edges_dict = {
+            ("road", "links_to", "road"): road_gdf,
+            ("building", "connects_to", "road"): conn_gdf,
+        }
+
+        with pytest.raises(ValueError, match="directed dict is missing keys"):
+            gdf_to_pyg(
+                sample_hetero_nodes_dict,
+                edges_dict,
+                directed={("road", "links_to", "road"): True},  # missing building→road
+            )
+
+    def test_directed_dict_extra_keys_raises(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Extra keys in directed dict raises ValueError."""
+        road_data = {
+            "source_road_id": ["r1"],
+            "target_road_id": ["r2"],
+            "geometry": [LineString([(10, 12), (12, 12)])],
+        }
+        road_gdf = gpd.GeoDataFrame(
+            road_data,
+            index=pd.MultiIndex.from_arrays(
+                [road_data["source_road_id"], road_data["target_road_id"]],
+                names=["source_road_id", "target_road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("road", "links_to", "road"): road_gdf}
+
+        with pytest.raises(ValueError, match="directed dict has extra keys"):
+            gdf_to_pyg(
+                sample_hetero_nodes_dict,
+                edges_dict,
+                directed={
+                    ("road", "links_to", "road"): True,
+                    ("building", "fake_rel", "road"): False,
+                },
+            )
+
+    def test_pyg_to_gdf_skips_generated_reverse_stores(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """pyg_to_gdf skips generated reverse edge stores during reconstruction."""
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "connects_to", "road"): conn_gdf}
+
+        data = gdf_to_pyg(sample_hetero_nodes_dict, edges_dict)
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert isinstance(edges_restored, dict)
+        # Only the original edge type should be returned
+        assert ("building", "connects_to", "road") in edges_restored
+        assert ("road", "rev_connects_to", "building") not in edges_restored
+
+    def test_reverse_type_collision_raises(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Auto-generated reverse type colliding with user type raises ValueError."""
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        # Provide a user edge type that would collide with auto-generated reverse
+        rev_data = {
+            "road_id": ["r1"],
+            "building_id": ["b1"],
+            "geometry": [LineString([(10, 12), (10, 10)])],
+        }
+        rev_gdf = gpd.GeoDataFrame(
+            rev_data,
+            index=pd.MultiIndex.from_arrays(
+                [rev_data["road_id"], rev_data["building_id"]],
+                names=["road_id", "building_id"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        edges_dict = {
+            ("building", "connects_to", "road"): conn_gdf,
+            ("road", "rev_connects_to", "building"): rev_gdf,
+        }
+
+        with pytest.raises(ValueError, match="collides with an existing"):
+            gdf_to_pyg(sample_hetero_nodes_dict, edges_dict)
+
+    def test_round_trip_with_cross_type_undirected(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Round trip preserves original edge count for cross-type undirected edges."""
+        conn_data = {
+            "building_id": ["b1", "b2"],
+            "road_id": ["r1", "r2"],
+            "feat": [1.0, 2.0],
+            "geometry": [
+                LineString([(10, 10), (10, 12)]),
+                LineString([(11, 11), (12, 12)]),
+            ],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [["b1", "b2"], ["r1", "r2"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "connects_to", "road"): conn_gdf}
+
+        data = gdf_to_pyg(sample_hetero_nodes_dict, edges_dict)
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert isinstance(edges_restored, dict)
+        et = ("building", "connects_to", "road")
+        assert len(edges_restored[et]) == 2
+
+    def test_metadata_edge_was_symmetrized_homo(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Homogeneous edge_was_symmetrized is True when directed=False."""
+        data = gdf_to_pyg(simple_nodes, simple_edges, directed=False)
+        assert data.graph_metadata.edge_was_symmetrized is True
+
+        data_dir = gdf_to_pyg(simple_nodes, simple_edges, directed=True)
+        assert data_dir.graph_metadata.edge_was_symmetrized is False
+
+    def test_metadata_edge_was_symmetrized_hetero(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Hetero edge_was_symmetrized is per-edge-type dict."""
+        road_data = {
+            "source_road_id": ["r1"],
+            "target_road_id": ["r2"],
+            "geometry": [LineString([(10, 12), (12, 12)])],
+        }
+        road_gdf = gpd.GeoDataFrame(
+            road_data,
+            index=pd.MultiIndex.from_arrays(
+                [road_data["source_road_id"], road_data["target_road_id"]],
+                names=["source_road_id", "target_road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("road", "links_to", "road"): road_gdf}
+
+        data = gdf_to_pyg(sample_hetero_nodes_dict, edges_dict)
+        ews = data.graph_metadata.edge_was_symmetrized
+        assert isinstance(ews, dict)
+        assert ews[("road", "links_to", "road")] is True
+
+    def test_directed_dict_for_homogeneous_raises(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Homogeneous graphs reject directed dict."""
+        with pytest.raises(TypeError, match="directed must be a bool for homogeneous"):
+            gdf_to_pyg(
+                simple_nodes,
+                simple_edges,
+                directed={("n", "r", "n"): True},
+            )
+
+    def test_explicit_reverse_inconsistent_endpoints_raises(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Explicit reverse with wrong endpoints raises ValueError."""
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "connects_to", "road"): conn_gdf}
+
+        with pytest.raises(ValueError, match="inconsistent endpoints"):
+            gdf_to_pyg(
+                sample_hetero_nodes_dict,
+                edges_dict,
+                reverse_edge_types={
+                    ("building", "connects_to", "road"): ("building", "wrong_rev", "road"),
+                },
+            )
+
+    def test_explicit_reverse_missing_mapping_raises(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Explicit reverse dict missing a mapping raises ValueError."""
+        conn_data = {
+            "building_id": ["b1"],
+            "road_id": ["r1"],
+            "geometry": [LineString([(10, 10), (10, 12)])],
+        }
+        conn_gdf = gpd.GeoDataFrame(
+            conn_data,
+            index=pd.MultiIndex.from_arrays(
+                [conn_data["building_id"], conn_data["road_id"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "connects_to", "road"): conn_gdf}
+
+        with pytest.raises(ValueError, match="missing a mapping"):
+            gdf_to_pyg(
+                sample_hetero_nodes_dict,
+                edges_dict,
+                reverse_edge_types={},  # empty dict, missing the required mapping
+            )
+
+    def test_original_edge_types_metadata(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+        sample_hetero_edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
+    ) -> None:
+        """original_edge_types records only user-supplied edge types."""
+        data = gdf_to_pyg(sample_hetero_nodes_dict, sample_hetero_edges_dict)
+        oets = data.graph_metadata.original_edge_types
+        assert set(oets) == set(sample_hetero_edges_dict.keys())
+        # Should NOT include generated reverse stores
+        gen = data.graph_metadata.generated_reverse_edge_types
+        for gen_et in gen:
+            assert gen_et not in oets
+
+    def test_backward_compat_old_metadata_no_dedup(self) -> None:
+        """Old metadata without edge_was_symmetrized defaults to no dedup."""
+        nodes = gpd.GeoDataFrame(
+            {"node_id": [1, 2], "geometry": [Point(0, 0), Point(1, 0)]},
+            crs="EPSG:27700",
+        ).set_index("node_id")
+
+        source_ids = [1, 2]
+        target_ids = [2, 1]
+        edges = gpd.GeoDataFrame(
+            {
+                "source_id": source_ids,
+                "target_id": target_ids,
+                "geometry": [
+                    LineString([(0, 0), (1, 0)]),
+                    LineString([(1, 0), (0, 0)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [source_ids, target_ids], names=["source_id", "target_id"]
+            ),
+            crs="EPSG:27700",
+        )
+
+        # Build PyG data directly (simulating old metadata)
+        data = gdf_to_pyg(nodes, edges, directed=True)
+        # Remove edge_was_symmetrized to simulate old metadata
+        if hasattr(data.graph_metadata, "edge_was_symmetrized"):
+            delattr(data.graph_metadata, "edge_was_symmetrized")
+        # Ensure is_directed is True (old default) so backward compat path won't dedup
+        data.graph_metadata.is_directed = True
+
+        _, edges_restored = pyg_to_gdf(data)
+        assert isinstance(edges_restored, gpd.GeoDataFrame)
+        assert len(edges_restored) == 2

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1808,6 +1808,395 @@ class TestUndirectedEdgeHandling:
         for gen_et in gen:
             assert gen_et not in oets
 
+    def test_non_multiindex_edges_rejected(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Plain edge indexes are rejected by the public converter."""
+        edges = simple_edges.reset_index(drop=True)
+
+        with pytest.raises(ValueError, match="MultiIndex with at least two levels"):
+            gdf_to_pyg(simple_nodes, edges)
+
+    def test_empty_non_multiindex_edges_accepted(self, simple_nodes: gpd.GeoDataFrame) -> None:
+        """Empty edge tables can omit a MultiIndex."""
+        edges = gpd.GeoDataFrame(
+            {"geometry": gpd.GeoSeries([], crs="EPSG:27700")},
+            geometry="geometry",
+            crs="EPSG:27700",
+        )
+
+        data = gdf_to_pyg(simple_nodes, edges)
+
+        assert data.num_edges == 0
+
+    def test_three_level_multiindex_accepted(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Three-level MultiGraph edge indexes are accepted."""
+        edges = simple_edges.copy()
+        edges.index = pd.MultiIndex.from_arrays(
+            [
+                edges.index.get_level_values(0),
+                edges.index.get_level_values(1),
+                [0, 0],
+            ],
+            names=["source_id", "target_id", "edge_key"],
+        )
+
+        data = gdf_to_pyg(simple_nodes, edges, directed=True)
+
+        assert data.num_edges == len(edges)
+
+    def test_empty_edge_features_resized_on_symmetrization(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Empty edge feature matrices resize during symmetrisation."""
+        data = gdf_to_pyg(simple_nodes, simple_edges, edge_feature_cols=[])
+
+        assert data.edge_attr.shape == (4, 0)
+
+    def test_cross_type_reverse_store_clones_edge_attr(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Generated cross-type reverse stores clone edge attributes."""
+        edge_type = ("building", "connects_to", "road")
+        reverse_type = ("road", "rev_connects_to", "building")
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "building_id": ["b1", "b2"],
+                "road_id": ["r1", "r2"],
+                "score": [1.25, 2.5],
+                "geometry": [
+                    LineString([(10, 10), (10, 12)]),
+                    LineString([(11, 11), (12, 12)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1", "b2"], ["r1", "r2"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            {edge_type: conn_gdf},
+            edge_feature_cols={edge_type: ["score"]},
+        )
+
+        assert data[reverse_type].edge_attr.shape == data[edge_type].edge_attr.shape
+        assert torch.equal(data[reverse_type].edge_attr, data[edge_type].edge_attr)
+        assert data[reverse_type].edge_attr is not data[edge_type].edge_attr
+
+    def test_nx_multigraph_symmetrized(self) -> None:
+        """nx.MultiGraph edges are symmetrised in PyG."""
+        graph = nx.MultiGraph()
+        graph.add_node(1, pos=(0, 0), geometry=Point(0, 0))
+        graph.add_node(2, pos=(1, 0), geometry=Point(1, 0))
+        graph.add_edge(1, 2, key=0, geometry=LineString([(0, 0), (1, 0)]))
+        graph.graph["crs"] = "EPSG:27700"
+        graph.graph["is_hetero"] = False
+
+        data = nx_to_pyg(graph)
+
+        assert data.num_edges == 2
+        assert data.graph_metadata.is_directed is False
+
+    def test_nx_to_pyg_directed_override(self) -> None:
+        """The directed override takes precedence over nx.Graph semantics."""
+        graph = nx.Graph()
+        graph.add_node(1, pos=(0, 0), geometry=Point(0, 0))
+        graph.add_node(2, pos=(1, 0), geometry=Point(1, 0))
+        graph.add_edge(1, 2, geometry=LineString([(0, 0), (1, 0)]))
+        graph.graph["crs"] = "EPSG:27700"
+        graph.graph["is_hetero"] = False
+
+        data = nx_to_pyg(graph, directed=True)
+
+        assert data.num_edges == 1
+        assert data.graph_metadata.is_directed is True
+
+    def test_nx_round_trip_undirected_preserves_edges(self) -> None:
+        """nx.Graph round trips as undirected with the same edge set."""
+        graph = nx.Graph()
+        for node_id, coords in [(1, (0, 0)), (2, (1, 0)), (3, (1, 1))]:
+            graph.add_node(node_id, pos=coords, geometry=Point(*coords))
+        graph.add_edge(1, 2, geometry=LineString([(0, 0), (1, 0)]))
+        graph.add_edge(2, 3, geometry=LineString([(1, 0), (1, 1)]))
+        graph.graph["crs"] = "EPSG:27700"
+        graph.graph["is_hetero"] = False
+
+        restored = pyg_to_nx(nx_to_pyg(graph))
+
+        assert restored.is_directed() is False
+        assert restored.number_of_edges() == graph.number_of_edges()
+        assert {frozenset(edge) for edge in restored.edges()} == {
+            frozenset(edge) for edge in graph.edges()
+        }
+
+    def test_nx_round_trip_digraph_preserves_direction(self) -> None:
+        """nx.DiGraph round trips as directed with the same edge set."""
+        graph = nx.DiGraph()
+        for node_id, coords in [(1, (0, 0)), (2, (1, 0)), (3, (1, 1))]:
+            graph.add_node(node_id, pos=coords, geometry=Point(*coords))
+        graph.add_edge(1, 2, geometry=LineString([(0, 0), (1, 0)]))
+        graph.add_edge(3, 2, geometry=LineString([(1, 1), (1, 0)]))
+        graph.graph["crs"] = "EPSG:27700"
+        graph.graph["is_hetero"] = False
+
+        restored = pyg_to_nx(nx_to_pyg(graph))
+
+        assert restored.is_directed() is True
+        assert set(restored.edges()) == set(graph.edges())
+
+    def test_hetero_mixed_directionality_round_trip(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Mixed same-type and cross-type undirected relations round trip."""
+        road_type = ("road", "links_to", "road")
+        conn_type = ("building", "connects_to", "road")
+        road_gdf = gpd.GeoDataFrame(
+            {
+                "source_road_id": ["r1"],
+                "target_road_id": ["r2"],
+                "geometry": [LineString([(10, 12), (12, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["r1"], ["r2"]],
+                names=["source_road_id", "target_road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "building_id": ["b1"],
+                "road_id": ["r1"],
+                "geometry": [LineString([(10, 10), (10, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1"], ["r1"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {road_type: road_gdf, conn_type: conn_gdf}
+
+        _, edges_restored = pyg_to_gdf(gdf_to_pyg(sample_hetero_nodes_dict, edges_dict))
+
+        assert isinstance(edges_restored, dict)
+        assert set(edges_restored) == set(edges_dict)
+        assert len(edges_restored[road_type]) == len(road_gdf)
+        assert len(edges_restored[conn_type]) == len(conn_gdf)
+
+    def test_hetero_directed_dict_round_trip(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Per-type directionality round trips without reverse artefacts."""
+        road_type = ("road", "links_to", "road")
+        conn_type = ("building", "connects_to", "road")
+        road_gdf = gpd.GeoDataFrame(
+            {
+                "source_road_id": ["r1"],
+                "target_road_id": ["r2"],
+                "geometry": [LineString([(10, 12), (12, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["r1"], ["r2"]],
+                names=["source_road_id", "target_road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "building_id": ["b1", "b2"],
+                "road_id": ["r1", "r2"],
+                "geometry": [
+                    LineString([(10, 10), (10, 12)]),
+                    LineString([(11, 11), (12, 12)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1", "b2"], ["r1", "r2"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {road_type: road_gdf, conn_type: conn_gdf}
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            edges_dict,
+            directed={road_type: False, conn_type: True},
+        )
+
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert isinstance(edges_restored, dict)
+        assert set(edges_restored) == set(edges_dict)
+        assert len(edges_restored[conn_type]) == len(conn_gdf)
+        assert ("road", "rev_connects_to", "building") not in edges_restored
+
+    def test_metadata_reverse_edge_types_populated(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Reverse edge metadata records generated cross-type stores."""
+        edge_type = ("building", "connects_to", "road")
+        reverse_type = ("road", "rev_connects_to", "building")
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "building_id": ["b1"],
+                "road_id": ["r1"],
+                "geometry": [LineString([(10, 10), (10, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1"], ["r1"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        data = gdf_to_pyg(sample_hetero_nodes_dict, {edge_type: conn_gdf})
+        metadata = data.graph_metadata
+
+        assert metadata.reverse_edge_types == {edge_type: reverse_type}
+        assert metadata.generated_reverse_edge_types == {reverse_type: edge_type}
+        assert metadata.original_edge_types == [edge_type]
+
+    def test_explicit_reverse_dict_round_trip(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Custom generated reverse stores do not leak into reconstructed GDFs."""
+        edge_type = ("building", "connects_to", "road")
+        reverse_type = ("road", "served_by", "building")
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "building_id": ["b1"],
+                "road_id": ["r1"],
+                "geometry": [LineString([(10, 10), (10, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1"], ["r1"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            {edge_type: conn_gdf},
+            reverse_edge_types={edge_type: reverse_type},
+        )
+
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert isinstance(edges_restored, dict)
+        assert edge_type in edges_restored
+        assert reverse_type not in edges_restored
+
+    def test_old_metadata_generated_reverse_edge_types_skipped(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Old metadata that lists generated stores still skips them."""
+        edge_type = ("building", "connects_to", "road")
+        reverse_type = ("road", "rev_connects_to", "building")
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "building_id": ["b1"],
+                "road_id": ["r1"],
+                "geometry": [LineString([(10, 10), (10, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1"], ["r1"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        data = gdf_to_pyg(sample_hetero_nodes_dict, {edge_type: conn_gdf})
+        data.graph_metadata.original_edge_types = None
+        data.graph_metadata.edge_types = list(data.edge_types)
+
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert isinstance(edges_restored, dict)
+        assert edge_type in edges_restored
+        assert reverse_type not in edges_restored
+
+    def test_hetero_additional_edge_cols_by_relation_name(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Hetero edge columns can be requested by relation name."""
+        edge_type = ("building", "connects_to", "road")
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "building_id": ["b1", "b2"],
+                "road_id": ["r1", "r2"],
+                "geometry": [
+                    LineString([(10, 10), (10, 12)]),
+                    LineString([(11, 11), (12, 12)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1", "b2"], ["r1", "r2"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        data = gdf_to_pyg(sample_hetero_nodes_dict, {edge_type: conn_gdf})
+        data[edge_type].capacity = torch.tensor([[4.0], [8.0]])
+
+        _, edges_restored = pyg_to_gdf(
+            data,
+            additional_edge_cols=cast("Any", {"connects_to": ["capacity"]}),
+        )
+
+        assert isinstance(edges_restored, dict)
+        assert edges_restored[edge_type]["capacity"].tolist() == [4.0, 8.0]
+
+    def test_invalid_edge_was_symmetrized_metadata_no_dedup(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """Unexpected symmetrisation metadata values do not deduplicate."""
+        data = gdf_to_pyg(simple_nodes, simple_edges)
+        data.graph_metadata.edge_was_symmetrized = None
+
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert isinstance(edges_restored, gpd.GeoDataFrame)
+        assert len(edges_restored) == data.edge_index.size(1)
+
+    def test_backward_compat_is_directed_dict_no_dedup(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Old hetero directed metadata dicts avoid accidental deduplication."""
+        edge_type = ("road", "links_to", "road")
+        road_gdf = gpd.GeoDataFrame(
+            {
+                "source_road_id": ["r1"],
+                "target_road_id": ["r2"],
+                "geometry": [LineString([(10, 12), (12, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["r1"], ["r2"]],
+                names=["source_road_id", "target_road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        data = gdf_to_pyg(sample_hetero_nodes_dict, {edge_type: road_gdf})
+        if hasattr(data.graph_metadata, "edge_was_symmetrized"):
+            delattr(data.graph_metadata, "edge_was_symmetrized")
+        data.graph_metadata.is_directed = {edge_type: True}
+
+        _, edges_restored = pyg_to_gdf(data)
+
+        assert isinstance(edges_restored, dict)
+        assert len(edges_restored[edge_type]) == data[edge_type].edge_index.size(1)
+
     def test_backward_compat_old_metadata_no_dedup(self) -> None:
         """Old metadata without edge_was_symmetrized defaults to no dedup."""
         nodes = gpd.GeoDataFrame(

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 from typing import cast
 
@@ -12,11 +13,13 @@ import pytest
 import torch
 from shapely.geometry import LineString
 from shapely.geometry import Point
+from shapely.geometry import Polygon
 from torch_geometric.data import Data
 from torch_geometric.data import HeteroData
 
 from city2graph import graph as graph_module
 from city2graph.base import GraphMetadata
+from city2graph.proximity import contiguity_graph
 
 # Import torch-related modules conditionally
 try:
@@ -1148,6 +1151,42 @@ class TestUndirectedEdgeHandling:
         """directed=True keeps edges as-is (no doubling)."""
         data = gdf_to_pyg(simple_nodes, simple_edges, directed=True)
         assert data.num_edges == 2
+        assert data.graph_metadata.is_directed is True
+        assert data.graph_metadata.edge_was_symmetrized is False
+
+    def test_issue_156_queen_grid_neighbors_are_bidirectional(self) -> None:
+        """4x4 queen contiguity around id22 has every neighbor in both directions."""
+        records = [
+            {
+                "node_id": f"id{row}{col}",
+                "geometry": Polygon(
+                    [
+                        (col, row),
+                        (col + 1, row),
+                        (col + 1, row + 1),
+                        (col, row + 1),
+                    ]
+                ),
+            }
+            for row in range(4)
+            for col in range(4)
+        ]
+        polygons = gpd.GeoDataFrame(records, crs="EPSG:27700").set_index("node_id")
+        nodes, edges = contiguity_graph(polygons, contiguity="queen")
+
+        data = gdf_to_pyg(nodes, edges)
+        mapping = data.graph_metadata.node_mappings["default"]["mapping"]
+        focal = mapping["id22"]
+        expected_neighbors = {"id11", "id12", "id13", "id21", "id23", "id31", "id32", "id33"}
+        expected_edges = {(focal, mapping[neighbor]) for neighbor in expected_neighbors} | {
+            (mapping[neighbor], focal) for neighbor in expected_neighbors
+        }
+        observed_edges = {
+            (int(data.edge_index[0, i]), int(data.edge_index[1, i]))
+            for i in range(data.edge_index.size(1))
+        }
+
+        assert expected_edges <= observed_edges
 
     def test_round_trip_restores_original_edges(
         self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
@@ -1194,6 +1233,22 @@ class TestUndirectedEdgeHandling:
         data = gdf_to_pyg(nodes, edges)
         # 1→2 gets reversed (adds 2→1), 1→1 stays as is: total 3
         assert data.num_edges == 3
+
+    def test_only_self_loops_do_not_trigger_parallel_validation(self) -> None:
+        """Self-loop-only undirected tables skip unordered-pair validation."""
+        nodes = gpd.GeoDataFrame(
+            {"node_id": [1], "geometry": [Point(0, 0)]},
+            crs="EPSG:27700",
+        ).set_index("node_id")
+        edges = gpd.GeoDataFrame(
+            {"geometry": [LineString([(0, 0), (0, 0)])]},
+            index=pd.MultiIndex.from_arrays([[1], [1]], names=["source_id", "target_id"]),
+            crs="EPSG:27700",
+        )
+
+        data = gdf_to_pyg(nodes, edges)
+
+        assert data.num_edges == 1
 
     def test_hetero_same_type_symmetrized(
         self,
@@ -1842,6 +1897,27 @@ class TestUndirectedEdgeHandling:
 
         assert data.num_edges == len(edges)
 
+    def test_three_level_parallel_undirected_edges_rejected(
+        self, simple_nodes: gpd.GeoDataFrame
+    ) -> None:
+        """Three-level MultiGraph-style parallel rows still need directed=True."""
+        edges = gpd.GeoDataFrame(
+            {
+                "geometry": [
+                    LineString([(0, 0), (1, 0)]),
+                    LineString([(0, 0), (1, 0)]),
+                ],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [[1, 1], [2, 2], [0, 1]],
+                names=["source_id", "target_id", "edge_key"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        with pytest.raises(ValueError, match="Parallel undirected edges"):
+            gdf_to_pyg(simple_nodes, edges)
+
     def test_empty_edge_features_resized_on_symmetrization(
         self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
     ) -> None:
@@ -1883,6 +1959,86 @@ class TestUndirectedEdgeHandling:
         assert data[reverse_type].edge_attr.shape == data[edge_type].edge_attr.shape
         assert torch.equal(data[reverse_type].edge_attr, data[edge_type].edge_attr)
         assert data[reverse_type].edge_attr is not data[edge_type].edge_attr
+
+    def test_large_undirected_validation_smoke(self) -> None:
+        """Large unique undirected edge tables validate and round-trip."""
+        edge_count = 10_000
+        node_ids = list(range(edge_count + 1))
+        nodes = gpd.GeoDataFrame(
+            {"geometry": [Point(float(i), 0.0) for i in node_ids]},
+            index=pd.Index(node_ids, name="node_id"),
+            crs="EPSG:27700",
+        )
+        src = list(range(edge_count))
+        dst = list(range(1, edge_count + 1))
+        edges = gpd.GeoDataFrame(
+            {
+                "geometry": [LineString([(float(i), 0.0), (float(i + 1), 0.0)]) for i in src],
+            },
+            index=pd.MultiIndex.from_arrays([src, dst], names=["source_id", "target_id"]),
+            crs="EPSG:27700",
+        )
+
+        start = time.perf_counter()
+        data = gdf_to_pyg(nodes, edges)
+        _, restored_edges = pyg_to_gdf(data)
+        elapsed = time.perf_counter() - start
+
+        assert data.num_edges == edge_count * 2
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        assert len(restored_edges) == edge_count
+        assert elapsed < 20.0
+
+    def test_categorical_node_ids_round_trip_undirected(self) -> None:
+        """Categorical node IDs do not require ordering for deduplication."""
+        node_ids = pd.CategoricalIndex(["b", "a", "c"], name="node_id")
+        nodes = gpd.GeoDataFrame(
+            {"geometry": [Point(0, 0), Point(1, 0), Point(2, 0)]},
+            index=node_ids,
+            crs="EPSG:27700",
+        )
+        edges = gpd.GeoDataFrame(
+            {"geometry": [LineString([(0, 0), (1, 0)]), LineString([(1, 0), (2, 0)])]},
+            index=pd.MultiIndex.from_arrays(
+                [
+                    pd.Categorical(["b", "a"]),
+                    pd.Categorical(["a", "c"]),
+                ],
+                names=["source_id", "target_id"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        _, restored_edges = pyg_to_gdf(gdf_to_pyg(nodes, edges))
+
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        assert len(restored_edges) == len(edges)
+
+    def test_uuid_string_node_ids_round_trip_undirected(self) -> None:
+        """UUID string node IDs round-trip after undirected symmetrization."""
+        ids = [
+            "7f4e2c0e-d9d7-4a90-b9f2-5a03e2d86a01",
+            "3103f18b-3552-46be-a6d0-763f25de52c4",
+            "f24207d2-c43c-419a-a37a-b602094a8eb2",
+        ]
+        nodes = gpd.GeoDataFrame(
+            {"geometry": [Point(0, 0), Point(1, 0), Point(2, 0)]},
+            index=pd.Index(ids, name="node_id"),
+            crs="EPSG:27700",
+        )
+        edges = gpd.GeoDataFrame(
+            {"geometry": [LineString([(0, 0), (1, 0)]), LineString([(1, 0), (2, 0)])]},
+            index=pd.MultiIndex.from_arrays(
+                [[ids[1], ids[2]], [ids[0], ids[1]]],
+                names=["source_id", "target_id"],
+            ),
+            crs="EPSG:27700",
+        )
+
+        _, restored_edges = pyg_to_gdf(gdf_to_pyg(nodes, edges))
+
+        assert isinstance(restored_edges, gpd.GeoDataFrame)
+        assert len(restored_edges) == len(edges)
 
     def test_nx_multigraph_symmetrized(self) -> None:
         """nx.MultiGraph edges are symmetrised in PyG."""
@@ -2032,6 +2188,48 @@ class TestUndirectedEdgeHandling:
         assert set(edges_restored) == set(edges_dict)
         assert len(edges_restored[conn_type]) == len(conn_gdf)
         assert ("road", "rev_connects_to", "building") not in edges_restored
+
+    def test_pyg_to_nx_warns_on_mixed_hetero_directedness(
+        self,
+        sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
+    ) -> None:
+        """Mixed hetero direction metadata warns before collapsing to one NX graph."""
+        road_type = ("road", "links_to", "road")
+        conn_type = ("building", "connects_to", "road")
+        road_gdf = gpd.GeoDataFrame(
+            {
+                "source_road_id": ["r1"],
+                "target_road_id": ["r2"],
+                "geometry": [LineString([(10, 12), (12, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["r1"], ["r2"]],
+                names=["source_road_id", "target_road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        conn_gdf = gpd.GeoDataFrame(
+            {
+                "building_id": ["b1"],
+                "road_id": ["r1"],
+                "geometry": [LineString([(10, 10), (10, 12)])],
+            },
+            index=pd.MultiIndex.from_arrays(
+                [["b1"], ["r1"]],
+                names=["building_id", "road_id"],
+            ),
+            crs="EPSG:27700",
+        )
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            {road_type: road_gdf, conn_type: conn_gdf},
+            directed={road_type: False, conn_type: True},
+        )
+
+        with pytest.warns(UserWarning, match="collapses mixed heterogeneous edge directedness"):
+            graph = pyg_to_nx(data)
+
+        assert graph.is_directed() is False
 
     def test_metadata_reverse_edge_types_populated(
         self,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,16 +1,4 @@
-"""
-Streamlined tests for the graph module.
-
-This module provides comprehensive test coverage for city2graph.graph with improved
-maintainability and clear organization. Tests are organized by core functionality
-with minimal redundancy.
-
-Key improvements:
-- Simplified test structure focused on core functionality
-- Reduced redundancy through better parameterization
-- Clear separation of concerns
-- Easier to maintain and extend
-"""
+"""Scenario-focused tests for the public graph conversion API."""
 
 from __future__ import annotations
 
@@ -124,94 +112,94 @@ class TestGraphConversion:
 
         return nodes, edges
 
-    @pytest.mark.parametrize("graph_type", ["homogeneous", "heterogeneous"])
-    def test_gdf_to_pyg_basic(
+    def test_homogeneous_gdf_to_pyg_basic(
         self,
-        graph_type: str,
         sample_nodes_gdf: gpd.GeoDataFrame,
         sample_edges_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """Homogeneous GeoDataFrames convert into a symmetrized Data graph."""
+        data = gdf_to_pyg(sample_nodes_gdf, sample_edges_gdf)
+        assert isinstance(data, Data)
+        assert data.num_nodes == len(sample_nodes_gdf)
+        assert data.num_edges == len(sample_edges_gdf) * 2
+        assert not data.graph_metadata.is_hetero
+
+    def test_heterogeneous_gdf_to_pyg_basic(
+        self,
         sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
         sample_hetero_edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
     ) -> None:
-        """Test basic conversion from GeoDataFrames to PyG objects."""
-        if graph_type == "homogeneous":
-            data = gdf_to_pyg(sample_nodes_gdf, sample_edges_gdf)
-            assert isinstance(data, Data)
-            assert data.num_nodes == len(sample_nodes_gdf)
-            # Edges are symmetrized by default (directed=False), so doubled
-            assert data.num_edges == len(sample_edges_gdf) * 2
-            assert not data.graph_metadata.is_hetero
-        else:
-            data = gdf_to_pyg(sample_hetero_nodes_dict, sample_hetero_edges_dict)
-            assert isinstance(data, HeteroData)
-            assert data.graph_metadata.is_hetero
-            assert set(data.node_types) == set(sample_hetero_nodes_dict.keys())
-            # Original edge types should be present; generated reverse stores
-            # for cross-type undirected edges add extra edge types.
-            assert set(sample_hetero_edges_dict.keys()).issubset(set(data.edge_types))
+        """Heterogeneous GeoDataFrames retain original and generated edge stores."""
+        data = gdf_to_pyg(sample_hetero_nodes_dict, sample_hetero_edges_dict)
+        assert isinstance(data, HeteroData)
+        assert data.graph_metadata.is_hetero
+        assert set(data.node_types) == set(sample_hetero_nodes_dict.keys())
+        assert set(sample_hetero_edges_dict.keys()).issubset(set(data.edge_types))
 
-    @pytest.mark.parametrize("graph_type", ["homogeneous", "heterogeneous"])
-    def test_gdf_to_pyg_with_features(
+    def test_homogeneous_gdf_to_pyg_with_features(
         self,
-        graph_type: str,
         sample_nodes_gdf: gpd.GeoDataFrame,
         sample_edges_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """Homogeneous feature, label, and edge tensors are column-driven."""
+        data = gdf_to_pyg(
+            sample_nodes_gdf,
+            sample_edges_gdf,
+            node_feature_cols=["feature1"],
+            node_label_cols=["label1"],
+            edge_feature_cols=["edge_feature1"],
+        )
+        assert data.x.shape[1] == 1
+        assert data.y.shape[1] == 1
+        assert data.edge_attr.shape[1] == 1
+
+    def test_heterogeneous_gdf_to_pyg_with_features(
+        self,
         sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
         sample_hetero_edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
     ) -> None:
-        """Test conversion with node and edge features."""
-        if graph_type == "homogeneous":
-            data = gdf_to_pyg(
-                sample_nodes_gdf,
-                sample_edges_gdf,
-                node_feature_cols=["feature1"],
-                node_label_cols=["label1"],
-                edge_feature_cols=["edge_feature1"],
-            )
-            assert data.x.shape[1] == 1
-            assert data.y.shape[1] == 1
-            assert data.edge_attr.shape[1] == 1
-        else:
-            data = gdf_to_pyg(
-                sample_hetero_nodes_dict,
-                sample_hetero_edges_dict,
-                node_feature_cols={"building": ["b_feat1"], "road": ["length"]},
-                node_label_cols={"building": ["b_label"]},
-                edge_feature_cols={
-                    ("building", "connects_to", "road"): ["conn_feat1"],
-                    ("road", "links_to", "road"): ["link_feat1"],
-                },
-            )
-            assert data["building"].x.shape[1] == 1
-            assert data["road"].x.shape[1] == 1
-            assert data["building"].y.shape[1] == 1
+        """Heterogeneous feature and label tensors use per-type column specs."""
+        data = gdf_to_pyg(
+            sample_hetero_nodes_dict,
+            sample_hetero_edges_dict,
+            node_feature_cols={"building": ["b_feat1"], "road": ["length"]},
+            node_label_cols={"building": ["b_label"]},
+            edge_feature_cols={
+                ("building", "connects_to", "road"): ["conn_feat1"],
+                ("road", "links_to", "road"): ["link_feat1"],
+            },
+        )
+        assert data["building"].x.shape[1] == 1
+        assert data["road"].x.shape[1] == 1
+        assert data["building"].y.shape[1] == 1
 
-    @pytest.mark.parametrize("graph_type", ["homogeneous", "heterogeneous"])
-    def test_round_trip_conversion(
+    def test_homogeneous_round_trip_conversion(
         self,
-        graph_type: str,
         sample_nodes_gdf: gpd.GeoDataFrame,
         sample_edges_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """Homogeneous GDF data survives GDF -> PyG -> GDF conversion."""
+        data = gdf_to_pyg(sample_nodes_gdf, sample_edges_gdf)
+        nodes_restored, edges_restored = pyg_to_gdf(data)
+
+        assert isinstance(nodes_restored, gpd.GeoDataFrame)
+        assert isinstance(edges_restored, gpd.GeoDataFrame)
+        assert len(nodes_restored) == len(sample_nodes_gdf)
+        assert len(edges_restored) == len(sample_edges_gdf)
+
+    def test_heterogeneous_round_trip_conversion(
+        self,
         sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
         sample_hetero_edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
     ) -> None:
-        """Test that data survives round-trip conversion (GDF -> PyG -> GDF)."""
-        if graph_type == "homogeneous":
-            data = gdf_to_pyg(sample_nodes_gdf, sample_edges_gdf)
-            nodes_restored, edges_restored = pyg_to_gdf(data)
+        """Heterogeneous GDF data survives GDF -> PyG -> GDF conversion."""
+        data = gdf_to_pyg(sample_hetero_nodes_dict, sample_hetero_edges_dict)
+        nodes_restored, edges_restored = pyg_to_gdf(data)
 
-            assert isinstance(nodes_restored, gpd.GeoDataFrame)
-            assert isinstance(edges_restored, gpd.GeoDataFrame)
-            assert len(nodes_restored) == len(sample_nodes_gdf)
-            assert len(edges_restored) == len(sample_edges_gdf)
-        else:
-            data = gdf_to_pyg(sample_hetero_nodes_dict, sample_hetero_edges_dict)
-            nodes_restored, edges_restored = pyg_to_gdf(data)
-
-            assert isinstance(nodes_restored, dict)
-            assert isinstance(edges_restored, dict)
-            assert set(nodes_restored.keys()) == set(sample_hetero_nodes_dict.keys())
-            assert set(edges_restored.keys()) == set(sample_hetero_edges_dict.keys())
+        assert isinstance(nodes_restored, dict)
+        assert isinstance(edges_restored, dict)
+        assert set(nodes_restored.keys()) == set(sample_hetero_nodes_dict.keys())
+        assert set(edges_restored.keys()) == set(sample_hetero_edges_dict.keys())
 
     def test_nx_conversions(self, sample_nx_graph: nx.Graph) -> None:
         """Test NetworkX conversions."""
@@ -309,35 +297,33 @@ class TestGraphConversion:
         with pytest.raises(ValueError, match="Graph has no nodes"):
             nx_to_pyg(empty_graph)
 
-    @pytest.mark.parametrize(
-        ("feature_type", "graph_type"),
-        [
-            ("node_feature_cols", "homogeneous"),
-            ("node_label_cols", "homogeneous"),
-            ("edge_feature_cols", "homogeneous"),
-            ("node_feature_cols", "heterogeneous"),
-            ("node_label_cols", "heterogeneous"),
-            ("edge_feature_cols", "heterogeneous"),
-        ],
-    )
-    def test_invalid_feature_types(
+    def test_homogeneous_feature_specs_must_be_lists(
         self,
-        feature_type: str,
-        graph_type: str,
         sample_nodes_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """Homogeneous conversion rejects dictionary column specs."""
+        with pytest.raises(TypeError, match="node_feature_cols must be a list"):
+            gdf_to_pyg(sample_nodes_gdf, node_feature_cols={"invalid": ["cols"]})
+
+        with pytest.raises(TypeError, match="node_label_cols must be a list"):
+            gdf_to_pyg(sample_nodes_gdf, node_label_cols={"invalid": ["cols"]})
+
+        with pytest.raises(TypeError, match="edge_feature_cols must be a list"):
+            gdf_to_pyg(sample_nodes_gdf, edge_feature_cols={("a", "b", "c"): ["cols"]})
+
+    def test_heterogeneous_feature_specs_must_be_dicts(
+        self,
         sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
     ) -> None:
-        """Test invalid feature column types."""
-        if graph_type == "homogeneous":
-            kwargs: dict[str, Any] = {feature_type: {"invalid": "cols"}}
-            expected_msg = f"{feature_type} must be a list"
-            with pytest.raises(TypeError, match=expected_msg):
-                gdf_to_pyg(sample_nodes_gdf, **kwargs)
-        else:
-            kwargs = {feature_type: ["invalid"]}
-            expected_msg = f"{feature_type} must be a dict"
-            with pytest.raises(TypeError, match=expected_msg):
-                gdf_to_pyg(sample_hetero_nodes_dict, **kwargs)
+        """Heterogeneous conversion rejects list column specs."""
+        with pytest.raises(TypeError, match="node_feature_cols must be a dict"):
+            gdf_to_pyg(sample_hetero_nodes_dict, node_feature_cols=["invalid"])
+
+        with pytest.raises(TypeError, match="node_label_cols must be a dict"):
+            gdf_to_pyg(sample_hetero_nodes_dict, node_label_cols=["invalid"])
+
+        with pytest.raises(TypeError, match="edge_feature_cols must be a dict"):
+            gdf_to_pyg(sample_hetero_nodes_dict, edge_feature_cols=["invalid"])
 
     def test_geometry_handling(self, sample_nodes_gdf: gpd.GeoDataFrame) -> None:
         """Test geometry handling edge cases."""
@@ -498,16 +484,18 @@ class TestGraphConversion:
             gdf_to_pyg("invalid_nodes")
 
     def test_convert_none_nodes(self) -> None:
-        """Test None nodes in conversion methods."""
+        """Public converter dispatch reports missing homogeneous and hetero nodes."""
         converter = graph_module.PyGConverter()
+        edges = gpd.GeoDataFrame(
+            {"geometry": [LineString([(0, 0), (1, 1)])]},
+            index=pd.MultiIndex.from_tuples([(1, 2)], names=["source_id", "target_id"]),
+        )
 
-        # Homogeneous
         with pytest.raises(ValueError, match="Nodes GeoDataFrame is required"):
-            converter._convert_homogeneous(None, None)
+            converter.convert(None, edges)
 
-        # Heterogeneous
         with pytest.raises(ValueError, match="Nodes dictionary is required"):
-            converter._convert_heterogeneous(None, None)
+            converter.convert(None, {("node", "to", "node"): edges})
 
     def test_reconstruct_missing_geometry_data(self, sample_nodes_gdf: gpd.GeoDataFrame) -> None:
         """Test reconstruction when features exist but geometry/pos is missing."""
@@ -530,26 +518,28 @@ class TestGraphConversion:
         # Remove pos to prevent reconstruction from pos
         data.pos = None
 
-        # This will trigger the fallback to empty geometry in _reconstruct_edge_gdf
         _, edges_rec = pyg_to_gdf(data)
         assert isinstance(edges_rec, gpd.GeoDataFrame)
         assert edges_rec.geometry.isna().all()
 
     def test_reconstruct_hetero_edge_errors(self, sample_pyg_hetero_data: HeteroData) -> None:
-        """Test heterogeneous edge reconstruction errors."""
-        converter = graph_module.PyGConverter()
-        metadata = sample_pyg_hetero_data.graph_metadata
+        """Invalid hetero edge metadata is rejected during public reconstruction."""
+        sample_pyg_hetero_data.graph_metadata.original_edge_types = ["invalid"]
 
         with pytest.raises(TypeError, match="Edge type must be a tuple"):
-            converter._reconstruct_edge_gdf(sample_pyg_hetero_data, metadata, edge_type="invalid")  # type: ignore[arg-type]
+            pyg_to_gdf(sample_pyg_hetero_data)
 
-    def test_create_geometry_missing_pos(self, sample_pyg_data: Data) -> None:
-        """Test geometry creation with missing pos."""
-        converter = graph_module.PyGConverter()
+    def test_nodes_reconstruct_with_null_geometry_when_positions_removed(
+        self, sample_pyg_data: Data
+    ) -> None:
+        """Node reconstruction falls back to null geometries when positions are missing."""
         sample_pyg_data.pos = None
-        assert converter._create_geometry_from_positions(sample_pyg_data) is None
+        sample_pyg_data.graph_metadata.node_geometries = None
+        nodes_restored, _ = pyg_to_gdf(sample_pyg_data)
+        assert isinstance(nodes_restored, gpd.GeoDataFrame)
+        assert nodes_restored.geometry.isna().all()
 
-    def test_create_edge_geometries_hetero_no_stored(
+    def test_heterogeneous_edges_rebuild_straight_geometry_without_stored_wkb(
         self,
         sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
         sample_hetero_edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
@@ -567,34 +557,37 @@ class TestGraphConversion:
             assert not gdf.geometry.isna().all()
             assert all(isinstance(g, LineString) for g in gdf.geometry)
 
-    def test_create_features_no_numeric(self, sample_nodes_gdf: gpd.GeoDataFrame) -> None:
-        """Test feature creation with no numeric columns."""
-        # Create GDF with only string columns
+    def test_non_numeric_requested_features_are_ignored(
+        self, sample_nodes_gdf: gpd.GeoDataFrame
+    ) -> None:
+        """Non-numeric requested feature columns produce an empty tensor."""
         gdf = sample_nodes_gdf.copy()
         gdf["str_col"] = "a"
         gdf = gdf[["str_col", "geometry"]]
 
-        converter = graph_module.PyGConverter()
-        features = converter._create_features(gdf, feature_cols=None)
-        assert features.shape[1] == 0
+        data = gdf_to_pyg(gdf, node_feature_cols=["str_col"])
+        assert data.x.shape[1] == 0
 
-    def test_create_node_positions_no_geom(self, sample_nodes_gdf: gpd.GeoDataFrame) -> None:
-        """Test node position creation with no geometry."""
-        gdf = sample_nodes_gdf.copy()
-        # Remove geometry column to trigger the None return
-        del gdf["geometry"]
+    def test_geometryless_nodes_have_no_position_tensor(
+        self, sample_nodes_gdf: gpd.GeoDataFrame
+    ) -> None:
+        """GeoDataFrames without an active geometry column create no positions."""
+        gdf = gpd.GeoDataFrame(sample_nodes_gdf.drop(columns="geometry"))
 
-        converter = graph_module.PyGConverter()
-        assert converter._create_node_positions(gdf) is None
+        data = gdf_to_pyg(gdf)
+        assert data.pos is None
 
-    def test_serialize_geometries_no_geom(self, sample_nodes_gdf: gpd.GeoDataFrame) -> None:
-        """Test geometry serialization with no geometry."""
-        gdf = sample_nodes_gdf.copy()
-        # Remove geometry column to trigger the None return
-        del gdf["geometry"]
+    def test_geometryless_nodes_store_no_wkb_and_reconstruct_null_geometry(
+        self, sample_nodes_gdf: gpd.GeoDataFrame
+    ) -> None:
+        """Geometry-less inputs reconstruct with null geometry under keep_geom."""
+        gdf = gpd.GeoDataFrame(sample_nodes_gdf.drop(columns="geometry"))
 
-        converter = graph_module.PyGConverter()
-        assert converter._serialize_geometries(gdf) is None
+        data = gdf_to_pyg(gdf, keep_geom=True)
+        assert data.graph_metadata.node_geometries is None
+        nodes_restored, _ = pyg_to_gdf(data)
+        assert isinstance(nodes_restored, gpd.GeoDataFrame)
+        assert nodes_restored.geometry.isna().all()
 
 
 class TestGraphValidation:
@@ -630,29 +623,32 @@ class TestGraphValidation:
         with pytest.raises(TypeError, match="PyG object has 'graph_metadata' of incorrect type"):
             validate_pyg(data)
 
-    @pytest.mark.parametrize(
-        ("graph_type", "inconsistency"),
-        [
-            ("homo_marked_as_hetero", "is Data but metadata.is_hetero is True"),
-            ("hetero_marked_as_homo", "HeteroData but metadata.is_hetero is False"),
-        ],
-    )
-    def test_inconsistent_metadata(
+    def test_homogeneous_data_marked_as_heterogeneous_is_rejected(
         self,
-        graph_type: str,
-        inconsistency: str,
         sample_nodes_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """Data objects cannot claim heterogeneous metadata."""
+        data = gdf_to_pyg(sample_nodes_gdf)
+        data.graph_metadata.is_hetero = True
+
+        with pytest.raises(
+            ValueError,
+            match=r"Inconsistency detected.*is Data but metadata.is_hetero is True",
+        ):
+            validate_pyg(data)
+
+    def test_heterogeneous_data_marked_as_homogeneous_is_rejected(
+        self,
         sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame],
     ) -> None:
-        """Test validation with inconsistent metadata."""
-        if graph_type == "homo_marked_as_hetero":
-            data = gdf_to_pyg(sample_nodes_gdf)
-            data.graph_metadata.is_hetero = True
-        else:
-            data = gdf_to_pyg(sample_hetero_nodes_dict)
-            data.graph_metadata.is_hetero = False
+        """HeteroData objects cannot claim homogeneous metadata."""
+        data = gdf_to_pyg(sample_hetero_nodes_dict)
+        data.graph_metadata.is_hetero = False
 
-        with pytest.raises(ValueError, match=f"Inconsistency detected.*{inconsistency}"):
+        with pytest.raises(
+            ValueError,
+            match=r"Inconsistency detected.*HeteroData but metadata.is_hetero is False",
+        ):
             validate_pyg(data)
 
     def test_tensor_validation_errors(self, sample_nodes_gdf: gpd.GeoDataFrame) -> None:
@@ -822,8 +818,6 @@ class TestGraphFeatures:
             node_label_cols=["label1"],
         )
 
-        # Test the homogeneous branch in _extract_node_features_and_labels
-        # by calling pyg_to_gdf which uses this function
         nodes_restored, _ = pyg_to_gdf(data)
 
         # Verify features and labels are extracted correctly
@@ -1086,15 +1080,16 @@ class TestOptionalTensorConversion:
         assert isinstance(edges_dict, dict)
         assert "w" in edges_dict[edge_type].columns
 
-    def test_get_device_no_torch(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test _get_device raises ImportError when torch is not available."""
-        # Check if _get_device is available in graph_module
-        if hasattr(graph_module, "_get_device"):
-            monkeypatch.setattr(graph_module, "TORCH_AVAILABLE", False)
-            with pytest.raises(ImportError, match="PyTorch and PyTorch Geometric required"):
-                graph_module._get_device(None)
-        else:
-            pytest.skip("_get_device not accessible")
+    def test_converter_reports_missing_torch_during_device_resolution(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Converter device resolution reports missing torch through the public method."""
+        monkeypatch.setattr(graph_module, "TORCH_AVAILABLE", False)
+        nodes = gpd.GeoDataFrame({"geometry": [Point(0, 0)]}, index=[1])
+        converter = graph_module.PyGConverter()
+
+        with pytest.raises(ImportError, match="PyTorch and PyTorch Geometric required"):
+            converter.gdf_to_pyg(nodes)
 
 
 class TestUndirectedEdgeHandling:

--- a/tests/test_metapath.py
+++ b/tests/test_metapath.py
@@ -121,9 +121,13 @@ class TestMetapaths:
         sample_hetero_edges_dict: dict[tuple[str, str, str], gpd.GeoDataFrame],
     ) -> None:
         """Exercise aggregation choices: sum, mean, callable, and all-NaN callable path."""
+        # NOTE: travel_time arrays must match the row count of the corresponding
+        # fixture GeoDataFrames. The road->road edge fixture only has a single
+        # row because the new undirected-edge validation in gdf_to_pyg rejects
+        # bidirectional pairs like (r1, r2) + (r2, r1).
         travel_time_values = {
             ("building", "connects_to", "road"): [10.0, 20.0, 30.0],
-            ("road", "links_to", "road"): [5.0, 15.0],
+            ("road", "links_to", "road"): [5.0],
         }
         edges_with_attr = {k: v.copy() for k, v in sample_hetero_edges_dict.items()}
         for ek, vals in travel_time_values.items():
@@ -459,9 +463,10 @@ class TestMetapaths:
         elif join_case == "disjoint":
             edges_disjoint = {k: v.copy() for k, v in sample_hetero_edges_dict.items()}
             rl = edges_disjoint[("road", "links_to", "road")].copy()
-            rl.index = pd.MultiIndex.from_tuples(
-                [("r10", "r11"), ("r11", "r10")], names=rl.index.names
-            )
+            # The road->road fixture has a single row; replace its index with a
+            # disjoint pair whose endpoints do not appear in the road nodes
+            # fixture so the metapath join produces an empty result.
+            rl.index = pd.MultiIndex.from_tuples([("r10", "r11")], names=rl.index.names)
             edges_disjoint[("road", "links_to", "road")] = rl
             _, edges_out = add_metapaths(
                 (sample_hetero_nodes_dict, edges_disjoint), sequence=METAPATH


### PR DESCRIPTION
## Description

Fixes incorrect edge handling in `gdf_to_pyg` and `pyg_to_gdf` for undirected graphs. Previously, when an edges GeoDataFrame produced by `contiguity_graph(..., as_nx=False)` (or any undirected source) listed each edge once, `gdf_to_pyg` passed the edges to PyTorch Geometric as directed, so message passing only saw half of the expected edges.

The fix aligns conversion with `BaseGraphConverter.directed` (default `False`):

- **`gdf_to_pyg`** now accepts a `directed: bool = False` parameter. When `directed=False`, edges are symmetrized: for every `(u, v)` with `u != v`, the reverse `(v, u)` is appended to `edge_index`, edge attributes are duplicated, and the stored `edge_index_values` and `edge_geometries` metadata are extended in lockstep. Self-loops are not duplicated.
- **`pyg_to_gdf`** uses the new `metadata.is_directed` flag (no new public parameter) to deduplicate symmetrized edges back to canonical undirected pairs (`level_0 <= level_1`).
- For heterogeneous graphs, symmetrization is applied **only to same-type edges** (`src_type == dst_type`); cross-type edge tables cannot be reversed within a single edge type and are left as-is.

Implementation details:

- `GraphMetadata.__init__` gains an `is_directed: bool | dict[tuple[str, str, str], bool]` field (default `False`).
- `PyGConverter.__init__` accepts and forwards `directed` to `BaseGraphConverter`.
- New helpers: `_symmetrize_edges`, `_symmetrize_edge_index_values`, `_symmetrize_edge_geometries`, `_deduplicate_undirected_edges`.
- `_convert_homogeneous`, `_create_homogeneous_metadata`, `_process_hetero_edges`, `_store_hetero_metadata`, and `_reconstruct_edge_gdf` updated accordingly.

This restores correct semantics for undirected GNN training while preserving existing behaviour for callers that explicitly opt in with `directed=True`.

## Related Issues

[#156](https://github.com/c2g-dev/city2graph/issues/156)

## Checklist

- [x]  I have read the [[Contributing Guide](https://city2graph.net/contributing.html)](https://city2graph.net/contributing.html).
- [x]  I have updated the documentation, if necessary.
- [x]  I have added tests to cover my changes.
- [x]  All new and existing tests passed.
- [x]  Pre-commit checks passed locally.