### PR TITLE
Fix/fix tessellations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ docs/examples/*.geojson
 dev/
 documents/
 temp_installation.html
+
+30daymapchallenge_data
+thumbnail.png
+generate_thumbnail.py
+gtfs_old.ipynb
+city2graph_overture.ipynb

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -14,6 +14,8 @@ The module specializes in three types of spatial relationships:
 3. Private-to-public: Interface relationships between private and public spaces
 """
 
+from __future__ import annotations
+
 # Standard library imports
 import logging
 import math
@@ -25,10 +27,10 @@ import geopandas as gpd
 import networkx as nx
 import numpy as np
 import pandas as pd
+from shapely import STRtree
 from shapely.creation import linestrings as sh_linestrings
 from shapely.geometry import LineString
 from shapely.geometry import Point
-from shapely.geometry.base import BaseGeometry
 
 # Local imports
 from .base import GeoDataProcessor
@@ -38,6 +40,9 @@ from .utils import dual_graph
 from .utils import filter_graph_by_distance
 from .utils import gdf_to_nx
 from .utils import nx_to_gdf
+
+if typing.TYPE_CHECKING:
+    from shapely.geometry.base import BaseGeometry
 
 # Public API definition
 __all__ = [
@@ -225,11 +230,19 @@ def morphological_graph(  # noqa: PLR0913
     segments_gdf = segments_gdf.copy()
     segments_gdf[public_id_col] = segments_gdf.index
 
+    # Compute the single-source reachability cost field once on the full network so that
+    # streets, buildings and cells are all judged against the same metric on the same network.
+    reachability_field: _ReachabilityField | None = None
+    if center_point is not None and distance is not None and not segments_gdf.empty:
+        _, full_segment_edges = segments_to_graph(segments_gdf)
+        reachability_field = _network_reachability_field(full_segment_edges, center_point)
+
     segments_filtered, segments_buffer = _process_segments(
         segments_gdf,
         center_point,
         distance,
         clipping_buffer,
+        field=reachability_field,
     )
 
     tessellation = _create_and_filter_tessellation(
@@ -245,6 +258,7 @@ def morphological_graph(  # noqa: PLR0913
         include_unenclosed_buildings,
         extent_buffer,
         limit=limit,
+        field=reachability_field,
     )
 
     # When a reachability budget is applied, prune private cells that face no
@@ -1010,6 +1024,10 @@ def _ensure_crs_consistency(
     -----
     RuntimeWarning
         If a CRS mismatch is detected and reprojection is performed.
+    UserWarning
+        If the resolved CRS is geographic (degrees). Distance parameters
+        (``distance``, ``extent_buffer``, ``tolerance``) are interpreted as
+        metric and ``.centroid`` results are unreliable on such a CRS.
     """
     if source_gdf.crs != target_gdf.crs:
         warnings.warn(
@@ -1017,7 +1035,17 @@ def _ensure_crs_consistency(
             RuntimeWarning,
             stacklevel=3,
         )  # Warn user
-        return source_gdf.to_crs(target_gdf.crs)
+        source_gdf = source_gdf.to_crs(target_gdf.crs)
+
+    if target_gdf.crs is not None and target_gdf.crs.is_geographic:
+        warnings.warn(
+            "Geometry is in a geographic CRS. Distance parameters "
+            "(distance, extent_buffer, tolerance) are treated as metric and "
+            "'.centroid' results are unreliable. Re-project to a projected CRS "
+            "with 'GeoSeries.to_crs()' before building the morphological graph.",
+            UserWarning,
+            stacklevel=3,
+        )
     return source_gdf
 
 
@@ -1031,6 +1059,7 @@ def _process_segments(
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | None,
     distance: float | None,
     clipping_buffer: float,
+    field: _ReachabilityField | None = None,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
     """
     Process segments: create graph, filter by distance, and create buffer context.
@@ -1049,6 +1078,10 @@ def _process_segments(
         Maximum distance from ``center_point`` for spatial filtering.
     clipping_buffer : float
         Buffer distance to ensure adequate context for generating tessellation.
+    field : _ReachabilityField or None, optional
+        A precomputed cost field shared across node types. When supplied it is
+        reused for the segment filter so the field is computed only once on the
+        full network; when ``None`` the field is computed here from the segments.
 
     Returns
     -------
@@ -1066,13 +1099,17 @@ def _process_segments(
         segments_graph = nx.Graph()
 
     # Filter segments by network distance for the final graph if center_point and distance are
-    # provided. Street acceptance is derived from the same reachability cost field used for
-    # tessellation cells, so every node type is judged against a single distance metric.
+    # provided. The same reachability cost field is reused for tessellation cells and buildings,
+    # so every node type is judged against a single distance metric on the same network.
     if center_point is not None and distance is not None and not segments_gdf.empty:
+        seg_field = (
+            field if field is not None else _network_reachability_field(segment_edges, center_point)
+        )
         segments_filtered = _segments_within_network_distance(
             segment_edges,
             center_point,
             distance,
+            field=seg_field,
         )
     else:
         segments_filtered = segment_edges
@@ -1115,6 +1152,7 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
     include_unenclosed_buildings: bool = False,
     extent_buffer: float = math.inf,
     limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None = None,
+    field: _ReachabilityField | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Create tessellation and apply spatial filters.
@@ -1155,6 +1193,11 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
         centroid for it to be retained by the network-distance filters.
     limit : geopandas.GeoDataFrame, geopandas.GeoSeries, shapely geometry, or None, optional
         Boundary passed to `create_tessellation` for enclosed tessellation.
+    field : _ReachabilityField or None, optional
+        Shared reachability cost field computed once on the full network. When
+        provided it is reused for both the building and tessellation network
+        filters so they share a single metric; when ``None`` each filter computes
+        its own field from the segments it is given.
 
     Returns
     -------
@@ -1188,6 +1231,7 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
         center_point,
         distance,
         extent_buffer,
+        field=field,
     )
 
     if include_unenclosed_buildings and not barriers.empty:
@@ -1214,6 +1258,7 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
             center_point,
             distance,  # Max network distance
             extent_buffer,
+            field=field,
         )
 
     # Optionally preserve building information by joining tessellation with buildings
@@ -1280,6 +1325,7 @@ def _filter_buildings_by_network_distance(
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point | None,
     max_distance: float | None,
     extent_buffer: float = math.inf,
+    field: _ReachabilityField | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Filter buildings by network distance from a centre point.
@@ -1301,6 +1347,9 @@ def _filter_buildings_by_network_distance(
         Maximum network distance for a building to be retained.
     extent_buffer : float, default ``math.inf``
         Maximum perpendicular access distance from a street to the building.
+    field : _ReachabilityField or None, optional
+        A precomputed cost field shared across node types. When ``None`` the field
+        is computed from ``segments`` and ``center_point``.
 
     Returns
     -------
@@ -1316,6 +1365,7 @@ def _filter_buildings_by_network_distance(
         center_point,
         max_distance,
         extent_buffer,
+        field=field,
     )
     return buildings_gdf.iloc[keep_ilocs].copy()
 
@@ -1661,18 +1711,23 @@ def _filter_adjacent_tessellation(
         tessellation.groupby(enclosure_col) if enclosure_col is not None else [(None, tessellation)]
     )
 
+    # Build the segment spatial index once so each enclosure only examines its
+    # candidate segments instead of scanning the whole network.
+    segments_sindex = segments.sindex
+    all_segments_union = segments.union_all()
+
     # Iterate over each enclosure group
     for _, group in groups:
         # Geometry of the current enclosure
         enclosure_geom = group.union_all()
 
-        # Segments intersecting this enclosure
-        segments_in_enclosure = segments[segments.intersects(enclosure_geom)]
-        if segments_in_enclosure.empty:
-            segments_in_enclosure = segments
-
-        # Union of segments within this enclosure
-        segment_union_in_enclosure = segments_in_enclosure.union_all()
+        # Segments intersecting this enclosure, found via the spatial index.
+        candidate_pos = segments_sindex.query(enclosure_geom, predicate="intersects")
+        segment_union_in_enclosure = (
+            all_segments_union
+            if len(candidate_pos) == 0
+            else segments.iloc[candidate_pos].union_all()
+        )
 
         # Centroids of cells in this group
         centroids_in_group = group.geometry.centroid
@@ -1700,6 +1755,7 @@ def _filter_tessellation_by_network_distance(
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
     max_distance: float,
     extent_buffer: float = math.inf,
+    field: _ReachabilityField | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Filter tessellation by network distance from a center point.
@@ -1722,6 +1778,9 @@ def _filter_tessellation_by_network_distance(
         The maximum network distance (e.g., in meters) for a tessellation cell to be included.
     extent_buffer : float, default ``math.inf``
         Maximum perpendicular access distance from a street to a cell centroid.
+    field : _ReachabilityField or None, optional
+        A precomputed cost field shared across node types. When ``None`` the field
+        is computed from ``segments`` and ``center_point``.
 
     Returns
     -------
@@ -1739,6 +1798,7 @@ def _filter_tessellation_by_network_distance(
         center_point,
         max_distance,
         extent_buffer,
+        field=field,
     )
 
     # Return the subset of the original tessellation corresponding to the kept ilocs
@@ -1776,8 +1836,16 @@ class _ReachabilityField(typing.NamedTuple):
     Single-source reachability cost field shared across all node types.
 
     The field is computed once from a centre snapped onto the street network and
-    is reused to derive the acceptance of both street segments and tessellation
-    cells, so every node type is judged against the same reachability metric.
+    is reused to derive the acceptance of street segments, buildings and
+    tessellation cells alike, so every node type is judged against the same
+    reachability metric on the same network.
+
+    The node identities of ``endpoint_lengths`` and ``edge_records`` are the exact
+    endpoint coordinate tuples assigned by :func:`gdf_to_nx` (which keys implicit
+    nodes by their coordinate), so segment endpoints can be matched directly
+    against the cost field without a separate rounding scheme. ``edge_tree`` is an
+    STRtree over ``edge_records`` geometries (aligned by position) used to prune
+    the edges that need examining for a given destination geometry.
     """
 
     endpoint_lengths: dict[typing.Hashable, float]
@@ -1785,7 +1853,7 @@ class _ReachabilityField(typing.NamedTuple):
     source_edge: tuple[typing.Hashable, typing.Hashable, LineString, float]
     source_along: float
     source_access: float
-    node_positions: dict[typing.Hashable, tuple[float, float]]
+    edge_tree: STRtree
 
 
 def _network_reachability_field(
@@ -1843,7 +1911,7 @@ def _network_reachability_field(
         source_edge=source_edge,
         source_along=source_along,
         source_access=source_access,
-        node_positions=nx.get_node_attributes(graph, "pos"),
+        edge_tree=STRtree([record[2] for record in edge_records]),
     )
 
 
@@ -1853,6 +1921,7 @@ def _geometry_ilocs_within_network_distance(
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
     max_distance: float,
     extent_buffer: float = math.inf,
+    field: _ReachabilityField | None = None,
 ) -> list[int]:
     """
     Return the integer positions of geometries reachable within the budget caps.
@@ -1866,25 +1935,35 @@ def _geometry_ilocs_within_network_distance(
     disconnected (forcing a long straight-line access leg across barriers) is not
     retained on the strength of a distant reachable street.
 
+    Only edges whose perpendicular access is within ``extent_buffer`` can satisfy
+    the access cap, so the field's STRtree restricts the per-geometry scan to that
+    neighbourhood instead of every network edge.
+
     Parameters
     ----------
     geometries : geopandas.GeoSeries
         Geometries whose reachability is evaluated, in their original order.
     segments : geopandas.GeoDataFrame
-        Street segments used to build the reachability network.
+        Street segments used to build the reachability network. Ignored when a
+        precomputed ``field`` is supplied.
     center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point
         Origin point(s) for the reachability computation.
     max_distance : float
         Maximum network distance from the centre to the projection foot.
     extent_buffer : float, default ``math.inf``
         Maximum perpendicular access distance from a street to the geometry.
+    field : _ReachabilityField or None, optional
+        A precomputed cost field shared across node types. When ``None`` the
+        field is computed from ``segments`` and ``center_point``, reproducing the
+        standalone behaviour.
 
     Returns
     -------
     list[int]
         Integer positions (``iloc``) of the reachable geometries.
     """
-    field = _network_reachability_field(segments, center_point)
+    if field is None:
+        field = _network_reachability_field(segments, center_point)
     if field is None:
         return []
 
@@ -1894,7 +1973,7 @@ def _geometry_ilocs_within_network_distance(
         if _reachable_within_caps(
             geometry,
             field.endpoint_lengths,
-            field.edge_records,
+            _candidate_edge_records(geometry, field, extent_buffer),
             field.source_edge,
             field.source_along,
             field.source_access,
@@ -1902,6 +1981,39 @@ def _geometry_ilocs_within_network_distance(
             extent_buffer,
         )
     ]
+
+
+def _candidate_edge_records(
+    point: Point,
+    field: _ReachabilityField,
+    extent_buffer: float,
+) -> list[tuple[typing.Hashable, typing.Hashable, LineString, float]]:
+    """
+    Restrict the network edges worth testing for a single destination point.
+
+    Only edges whose perpendicular access distance is within ``extent_buffer`` can
+    satisfy the access cap, so the field's STRtree returns just the edges in that
+    neighbourhood. When ``extent_buffer`` is infinite no spatial restriction is
+    possible and every edge is returned, preserving the exhaustive behaviour.
+
+    Parameters
+    ----------
+    point : shapely.geometry.Point
+        The destination point being tested.
+    field : _ReachabilityField
+        The shared cost field whose STRtree indexes the edge geometries.
+    extent_buffer : float
+        Maximum perpendicular access distance from a street to the point.
+
+    Returns
+    -------
+    list[tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float]]
+        The subset of ``field.edge_records`` near ``point``.
+    """
+    if math.isinf(extent_buffer):
+        return field.edge_records
+    candidate_ilocs = field.edge_tree.query(point, predicate="dwithin", distance=extent_buffer)
+    return [field.edge_records[iloc] for iloc in candidate_ilocs]
 
 
 def _ensure_graph_edge_lengths(graph: nx.Graph) -> None:
@@ -2044,7 +2156,8 @@ def _reachable_within_caps(
     endpoint_lengths : dict[typing.Hashable, float]
         Shortest-path cost from the centre to each reachable network node.
     edge_records : list[tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float]]
-        Candidate edges produced by :func:`_network_edge_records`.
+        Candidate edges to examine, typically the subset near ``point`` returned
+        by :func:`_candidate_edge_records`.
     source_edge : tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float]
         The edge onto which the centre was snapped.
     source_along : float
@@ -2108,48 +2221,39 @@ def _projected_edge_access(point: Point, line: LineString) -> tuple[float, float
     return along, point.distance(projected)
 
 
-def _coordinate_key(coordinate: tuple[float, float]) -> tuple[float, float]:
-    """
-    Round a coordinate to a stable lookup key.
-
-    Rounding tolerates floating-point noise so segment endpoints can be matched
-    against network node positions in a dictionary.
-
-    Parameters
-    ----------
-    coordinate : tuple[float, float]
-        The ``(x, y)`` coordinate to normalise.
-
-    Returns
-    -------
-    tuple[float, float]
-        The coordinate rounded to six decimal places.
-    """
-    return (round(coordinate[0], 6), round(coordinate[1], 6))
-
-
 def _segments_within_network_distance(
     segments: gpd.GeoDataFrame,
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
     max_distance: float,
+    field: _ReachabilityField | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Filter street segments by the shared network reachability cost field.
 
     A segment is retained when its nearest reachable endpoint lies within
-    ``max_distance`` on the same cost field used for tessellation cells. This
-    keeps segments that straddle the budget boundary (their reachable portion is
-    within budget) instead of dropping them on a binary wholly-in/out test, and
-    ensures street and cell acceptance derive from a single reachability metric.
+    ``max_distance`` on the same cost field used for buildings and tessellation
+    cells. This keeps segments that straddle the budget boundary (their reachable
+    portion is within budget) instead of dropping them on a binary wholly-in/out
+    test, and ensures street and cell acceptance derive from a single
+    reachability metric.
+
+    Segment endpoints are looked up directly against ``field.endpoint_lengths``,
+    whose keys are the exact endpoint coordinate tuples assigned by
+    :func:`gdf_to_nx`. This is the same identity scheme :func:`segments_to_graph`
+    uses, so no separate coordinate-rounding strategy is needed.
 
     Parameters
     ----------
     segments : geopandas.GeoDataFrame
         Street segments to filter. All columns are preserved on the kept rows.
+        Ignored when a precomputed ``field`` is supplied.
     center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point
         Origin point(s) for the reachability computation.
     max_distance : float
         Maximum network distance for a segment to be retained.
+    field : _ReachabilityField or None, optional
+        A precomputed cost field shared across node types. When ``None`` the field
+        is computed from ``segments`` and ``center_point``.
 
     Returns
     -------
@@ -2159,47 +2263,38 @@ def _segments_within_network_distance(
     if segments.empty:
         return segments.copy()
 
-    field = _network_reachability_field(segments, center_point)
+    if field is None:
+        field = _network_reachability_field(segments, center_point)
     if field is None:
         return segments.iloc[0:0].copy()
-
-    # Map each network node position to its cheapest reachable cost so segment
-    # endpoints can be looked up directly against the shared cost field.
-    cost_by_coordinate: dict[tuple[float, float], float] = {}
-    for node, cost in field.endpoint_lengths.items():
-        position = field.node_positions.get(node)
-        if position is None:
-            continue
-        key = _coordinate_key(position)
-        existing = cost_by_coordinate.get(key)
-        if existing is None or cost < existing:
-            cost_by_coordinate[key] = cost
 
     keep_ilocs = [
         iloc
         for iloc, geometry in enumerate(segments.geometry)
-        if _segment_min_reachable_cost(geometry, cost_by_coordinate) <= max_distance
+        if _segment_min_reachable_cost(geometry, field.endpoint_lengths) <= max_distance
     ]
     return segments.iloc[keep_ilocs].copy()
 
 
 def _segment_min_reachable_cost(
     geometry: LineString,
-    cost_by_coordinate: dict[tuple[float, float], float],
+    endpoint_lengths: dict[typing.Hashable, float],
 ) -> float:
     """
     Return the cheapest reachable cost among a segment's endpoints.
 
     The reachable portion of a segment is bounded by its cheaper endpoint, so the
     minimum endpoint cost determines whether any part of the segment falls within
-    the reachability budget.
+    the reachability budget. Endpoints are matched by their exact coordinate
+    tuple, the node identity used by the reachability graph.
 
     Parameters
     ----------
     geometry : shapely.geometry.LineString
         The segment geometry to evaluate.
-    cost_by_coordinate : dict[tuple[float, float], float]
-        Reachability cost keyed by rounded network node position.
+    endpoint_lengths : dict[typing.Hashable, float]
+        Shortest-path cost from the centre to each reachable network node, keyed
+        by the node's exact ``(x, y)`` coordinate tuple.
 
     Returns
     -------
@@ -2210,8 +2305,8 @@ def _segment_min_reachable_cost(
     coordinates = list(geometry.coords)
     if not coordinates:
         return math.inf
-    start = cost_by_coordinate.get(_coordinate_key(coordinates[0]), math.inf)
-    end = cost_by_coordinate.get(_coordinate_key(coordinates[-1]), math.inf)
+    start = endpoint_lengths.get(coordinates[0], math.inf)
+    end = endpoint_lengths.get(coordinates[-1], math.inf)
     return min(start, end)
 
 

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -69,6 +69,7 @@ def morphological_graph(  # noqa: PLR0913
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | None = None,
     distance: float | None = None,
     clipping_buffer: float = math.inf,
+    extent_buffer: float = 50.0,
     limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None = None,
     primary_barrier_col: str | None = "barrier_geometry",
     contiguity: str = "queen",
@@ -106,7 +107,15 @@ def morphological_graph(  # noqa: PLR0913
         these segments does not exceed this value.
     clipping_buffer : float, default=math.inf
         Buffer distance to ensure adequate context for generating tessellation.
-        Must be non-negative.
+        Must be non-negative and not smaller than ``extent_buffer``.
+    extent_buffer : float, default=50.0
+        Maximum perpendicular access distance (a bounded catchment cap) from a
+        street to a building/cell for it to be retained, and the maximum length
+        of a ``faced_to`` connection. Unlike ``distance`` this access term is
+        never added to the walking-network budget, so a building whose only
+        nearby street is disconnected from the reachable network is not retained
+        on the strength of a long straight-line access leg across barriers. Must
+        be non-negative and not larger than ``clipping_buffer``.
     limit : geopandas.GeoDataFrame, geopandas.GeoSeries, shapely geometry, or None, optional
         Boundary passed to `momepy.enclosures` when creating enclosed
         tessellation. When None, `create_tessellation` computes one from the
@@ -195,9 +204,15 @@ def morphological_graph(  # noqa: PLR0913
         msg = "contiguity must be 'queen' or 'rook'"
         raise ValueError(msg)
 
-    # Validate clipping_buffer
+    # Validate clipping_buffer and extent_buffer
     if clipping_buffer < 0:
         msg = "clipping_buffer cannot be negative."
+        raise ValueError(msg)
+    if extent_buffer < 0:
+        msg = "extent_buffer cannot be negative."
+        raise ValueError(msg)
+    if clipping_buffer < extent_buffer:
+        msg = "clipping_buffer must be greater than or equal to extent_buffer."
         raise ValueError(msg)
 
     if isinstance(buildings_gdf.index, pd.MultiIndex):
@@ -228,7 +243,7 @@ def morphological_graph(  # noqa: PLR0913
         keep_buildings,
         private_id_col,
         include_unenclosed_buildings,
-        segments_buffer,
+        extent_buffer,
         limit=limit,
     )
 
@@ -246,6 +261,7 @@ def morphological_graph(  # noqa: PLR0913
         public_id_col,
         keep_segments,
         drop_isolated_private=drop_isolated_private,
+        extent_buffer=extent_buffer,
     )
 
     return (nodes, edges) if not as_nx else gdf_to_nx(nodes, edges)
@@ -404,6 +420,7 @@ def private_to_public_graph(
     primary_barrier_col: str | None = None,
     tolerance: float = 1e-6,
     as_nx: bool = False,
+    max_connection_distance: float = math.inf,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     """
     Create edges between private polygons and nearby public geometries.
@@ -427,6 +444,12 @@ def private_to_public_graph(
         Buffer distance for public geometries to detect proximity to private spaces.
     as_nx : bool, default=False
         If True, convert the output to a NetworkX graph.
+    max_connection_distance : float, default=``math.inf``
+        Maximum distance for the nearest-public fallback connection. Private
+        cells matched by the ``tolerance`` proximity query are unaffected; cells
+        connected only by the fallback are dropped when their nearest public
+        geometry lies farther than this distance, preventing long star-shaped
+        edges to distant streets.
 
     Returns
     -------
@@ -526,6 +549,7 @@ def private_to_public_graph(
         query_geometry,
         private_id_col,
         public_id_col,
+        max_connection_distance,
     )
 
     edges_gdf = _create_private_public_edges(
@@ -548,6 +572,7 @@ def _connect_unmatched_private_to_nearest_public(
     query_geometry: gpd.GeoSeries,
     private_id_col: str,
     public_id_col: str,
+    max_distance: float = math.inf,
 ) -> pd.DataFrame:
     """
     Add one nearest public edge for private polygons missed by the proximity query.
@@ -555,7 +580,10 @@ def _connect_unmatched_private_to_nearest_public(
     The regular ``dwithin`` query captures true face relationships. Fallback
     tessellation cells can be raw building footprints, so they may not touch a
     street barrier. Those otherwise isolated cells are connected to their nearest
-    public segment to keep them integrated in the morphology graph.
+    public segment to keep them integrated in the morphology graph, but only when
+    that segment lies within ``max_distance``. Cells whose nearest segment is
+    farther are left unconnected so a caller's isolated-node pruning can remove
+    them instead of forcing a long star-shaped edge.
 
     Parameters
     ----------
@@ -571,6 +599,8 @@ def _connect_unmatched_private_to_nearest_public(
         Column name identifying private geometries.
     public_id_col : str
         Column name identifying public geometries.
+    max_distance : float, default ``math.inf``
+        Maximum private-to-public distance for a fallback connection to be added.
 
     Returns
     -------
@@ -594,6 +624,21 @@ def _connect_unmatched_private_to_nearest_public(
     )
     if len(private_nearest_indices) == 0:
         return joined
+
+    # Drop fallback pairs whose nearest public segment is beyond the cap so that
+    # only genuinely street-facing cells receive a fallback faced_to edge.
+    if not math.isinf(max_distance):
+        matched_private = unmatched_private.geometry.to_numpy()[private_nearest_indices]
+        matched_public = public_query.to_numpy()[public_nearest_indices]
+        gaps = gpd.GeoSeries(matched_private, crs=public_gdf.crs).distance(
+            gpd.GeoSeries(matched_public, crs=public_gdf.crs),
+            align=False,
+        )
+        within = (gaps <= max_distance).to_numpy()
+        private_nearest_indices = private_nearest_indices[within]
+        public_nearest_indices = public_nearest_indices[within]
+        if len(private_nearest_indices) == 0:
+            return joined
 
     nearest = pd.DataFrame(
         {
@@ -1068,7 +1113,7 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
     keep_buildings: bool,
     private_id_col: str,
     include_unenclosed_buildings: bool = False,
-    network_segments: gpd.GeoDataFrame | None = None,
+    extent_buffer: float = math.inf,
     limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None = None,
 ) -> gpd.GeoDataFrame:
     """
@@ -1077,14 +1122,19 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
     This function creates a tessellation from buildings and barriers, renames the ID column,
     and filters the tessellation based on adjacency to segments and network distance.
 
+    The wider ``segments_buffer`` only provides tessellation context (barriers and
+    a coarse adjacency gate); building and cell retention are judged solely
+    against ``segments_filtered`` (the reachable isochrone streets) so that
+    retention and the ``faced_to`` edges that follow share a single street set.
+
     Parameters
     ----------
     buildings_gdf : geopandas.GeoDataFrame
         GeoDataFrame containing building polygons.
     segments_buffer : geopandas.GeoDataFrame
-        Buffered segments used for tessellation context.
+        Buffered segments used for tessellation context (barriers and adjacency).
     segments_filtered : geopandas.GeoDataFrame
-        Filtered segments used for adjacency checks.
+        Reachable isochrone segments used for adjacency and all retention checks.
     primary_barrier_col : str or None
         Column name containing alternative geometry for public spaces.
     distance : float or None
@@ -1100,9 +1150,9 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
     include_unenclosed_buildings : bool, default=False
         If True, buildings excluded by enclosed tessellation are added using
         barrier-free tessellation before distance filters are applied.
-    network_segments : geopandas.GeoDataFrame or None, default=None
-        Segments used for the network distance computations. When None, the
-        filtered segments are used; otherwise these segments define the network.
+    extent_buffer : float, default ``math.inf``
+        Maximum perpendicular access distance from a street to a building/cell
+        centroid for it to be retained by the network-distance filters.
     limit : geopandas.GeoDataFrame, geopandas.GeoSeries, shapely geometry, or None, optional
         Boundary passed to `create_tessellation` for enclosed tessellation.
 
@@ -1128,13 +1178,16 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
     if private_id_col not in tessellation.columns:
         tessellation[private_id_col] = range(len(tessellation))  # Assign sequential private IDs
 
-    distance_segments = segments_filtered if network_segments is None else network_segments
+    # Retention is judged solely against the reachable isochrone streets so that
+    # cell/building acceptance and the faced_to edges share a single street set.
+    distance_segments = segments_filtered
 
     eligible_buildings = _filter_buildings_by_network_distance(
         buildings_gdf,
         distance_segments,
         center_point,
         distance,
+        extent_buffer,
     )
 
     if include_unenclosed_buildings and not barriers.empty:
@@ -1160,6 +1213,7 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
             distance_segments,
             center_point,
             distance,  # Max network distance
+            extent_buffer,
         )
 
     # Optionally preserve building information by joining tessellation with buildings
@@ -1225,11 +1279,13 @@ def _filter_buildings_by_network_distance(
     segments: gpd.GeoDataFrame,
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point | None,
     max_distance: float | None,
+    extent_buffer: float = math.inf,
 ) -> gpd.GeoDataFrame:
     """
     Filter buildings by network distance from a centre point.
 
     Buildings are kept when their centroid is reachable within ``max_distance``
+    network distance *and* within ``extent_buffer`` access distance of a street
     on the shared reachability cost field. Filtering is skipped when no centre or
     distance budget is supplied, returning the buildings unchanged.
 
@@ -1243,6 +1299,8 @@ def _filter_buildings_by_network_distance(
         Origin point(s) for the reachability computation.
     max_distance : float or None
         Maximum network distance for a building to be retained.
+    extent_buffer : float, default ``math.inf``
+        Maximum perpendicular access distance from a street to the building.
 
     Returns
     -------
@@ -1257,6 +1315,7 @@ def _filter_buildings_by_network_distance(
         segments,
         center_point,
         max_distance,
+        extent_buffer,
     )
     return buildings_gdf.iloc[keep_ilocs].copy()
 
@@ -1307,6 +1366,7 @@ def _build_morphological_layers(
     public_id_col: str,
     keep_segments: bool = True,
     drop_isolated_private: bool = False,
+    extent_buffer: float = math.inf,
 ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]]:
     """
     Build the node and edge layers for the morphological graph.
@@ -1339,6 +1399,12 @@ def _build_morphological_layers(
         This guarantees an induced subgraph free of isolated private nodes and is
         enabled when a reachability budget (``center_point`` and ``distance``) is
         applied.
+    extent_buffer : float, default ``math.inf``
+        Maximum length of a nearest-public fallback ``faced_to`` connection. A
+        private cell that touches no street within ``tolerance`` and whose
+        nearest street lies farther than ``extent_buffer`` receives no fallback
+        edge, so ``drop_isolated_private`` can remove it instead of forcing a
+        long star-shaped connection to a distant street.
 
     Returns
     -------
@@ -1373,6 +1439,7 @@ def _build_morphological_layers(
         segments_filtered,
         primary_barrier_col=primary_barrier_col,
         tolerance=tolerance,
+        max_connection_distance=extent_buffer,
     )
 
     # Log warning if no private-public connections found
@@ -1632,14 +1699,16 @@ def _filter_tessellation_by_network_distance(
     segments: gpd.GeoDataFrame,
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
     max_distance: float,
+    extent_buffer: float = math.inf,
 ) -> gpd.GeoDataFrame:
     """
     Filter tessellation by network distance from a center point.
 
     This function filters a tessellation GeoDataFrame to include only those cells
-    that are within a specified network distance from a given `center_point`.
-    It constructs a spatial graph combining street segments and tessellation
-    centroids, then uses shortest-path calculations to determine reachability.
+    that are within a specified network distance from a given `center_point` and
+    within ``extent_buffer`` access distance of a street. It constructs a spatial
+    graph from the street segments and tests each cell centroid against the
+    shared reachability cost field with two independent caps.
 
     Parameters
     ----------
@@ -1651,6 +1720,8 @@ def _filter_tessellation_by_network_distance(
         The geographic center point(s) from which to calculate network distances.
     max_distance : float
         The maximum network distance (e.g., in meters) for a tessellation cell to be included.
+    extent_buffer : float, default ``math.inf``
+        Maximum perpendicular access distance from a street to a cell centroid.
 
     Returns
     -------
@@ -1667,6 +1738,7 @@ def _filter_tessellation_by_network_distance(
         segments,
         center_point,
         max_distance,
+        extent_buffer,
     )
 
     # Return the subset of the original tessellation corresponding to the kept ilocs
@@ -1780,13 +1852,19 @@ def _geometry_ilocs_within_network_distance(
     segments: gpd.GeoDataFrame,
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
     max_distance: float,
+    extent_buffer: float = math.inf,
 ) -> list[int]:
     """
-    Return the integer positions of geometries reachable within a network budget.
+    Return the integer positions of geometries reachable within the budget caps.
 
-    Each geometry (typically a cell or building centroid) is scored against the
-    shared reachability cost field, adding the last-leg access from the geometry
-    to the network, and kept when that cost is within ``max_distance``.
+    Each geometry (typically a cell or building centroid) is tested against the
+    shared reachability cost field with two independent caps: the network
+    distance from the centre to the projection foot must be within
+    ``max_distance`` and the perpendicular access distance from the foot to the
+    geometry must be within ``extent_buffer``. The access term is never folded
+    into the network budget, so a geometry whose only nearby street is
+    disconnected (forcing a long straight-line access leg across barriers) is not
+    retained on the strength of a distant reachable street.
 
     Parameters
     ----------
@@ -1797,7 +1875,9 @@ def _geometry_ilocs_within_network_distance(
     center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point
         Origin point(s) for the reachability computation.
     max_distance : float
-        Maximum network distance for a geometry to be retained.
+        Maximum network distance from the centre to the projection foot.
+    extent_buffer : float, default ``math.inf``
+        Maximum perpendicular access distance from a street to the geometry.
 
     Returns
     -------
@@ -1811,15 +1891,16 @@ def _geometry_ilocs_within_network_distance(
     return [
         iloc
         for iloc, geometry in enumerate(geometries)
-        if _distance_from_network_edges(
+        if _reachable_within_caps(
             geometry,
             field.endpoint_lengths,
             field.edge_records,
             field.source_edge,
             field.source_along,
             field.source_access,
+            max_distance,
+            extent_buffer,
         )
-        <= max_distance
     ]
 
 
@@ -1934,26 +2015,32 @@ def _connect_point_to_nearest_edge(
     return edge_record, along, access_distance
 
 
-def _distance_from_network_edges(
+def _reachable_within_caps(
     point: Point,
     endpoint_lengths: dict[typing.Hashable, float],
     edge_records: list[tuple[typing.Hashable, typing.Hashable, LineString, float]],
     source_edge: tuple[typing.Hashable, typing.Hashable, LineString, float],
     source_along: float,
     source_access: float,
-) -> float:
+    max_distance: float,
+    extent_buffer: float,
+) -> bool:
     """
-    Compute the network distance from the centre to a point.
+    Decide whether a point is reachable within both the network and access caps.
 
-    The point is projected onto every reachable edge and the cheapest path is
-    taken across the endpoint costs (plus along-edge and access terms), with the
-    centre-bearing edge handled explicitly so points sharing that edge are not
-    forced to detour through an endpoint.
+    For every reachable edge the point is projected onto its foot, splitting the
+    last leg into two independently-bounded terms: the network cost to reach the
+    foot (the centre endpoint costs plus the along-edge distance) and the
+    perpendicular access distance from the foot to the point. The point is kept
+    when some edge holds the network cost within ``max_distance`` *and* the
+    access distance within ``extent_buffer``. Keeping the access term out of the
+    network budget prevents a straight-line access leg that crosses barriers from
+    being mistaken for walkable network distance.
 
     Parameters
     ----------
     point : shapely.geometry.Point
-        The destination point to score.
+        The destination point to test.
     endpoint_lengths : dict[typing.Hashable, float]
         Shortest-path cost from the centre to each reachable network node.
     edge_records : list[tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float]]
@@ -1964,13 +2051,16 @@ def _distance_from_network_edges(
         Along-edge distance of the centre projection on ``source_edge``.
     source_access : float
         Access distance from the centre to ``source_edge``.
+    max_distance : float
+        Maximum network distance from the centre to the projection foot.
+    extent_buffer : float
+        Maximum perpendicular access distance from the foot to ``point``.
 
     Returns
     -------
-    float
-        The minimum network distance, or ``math.inf`` when unreachable.
+    bool
+        ``True`` when at least one edge satisfies both caps, ``False`` otherwise.
     """
-    best = math.inf
     for edge_record in edge_records:
         from_node, to_node, geometry, length = edge_record
         from_length = endpoint_lengths.get(from_node)
@@ -1979,13 +2069,19 @@ def _distance_from_network_edges(
             continue
 
         along, access_distance = _projected_edge_access(point, geometry)
+        if access_distance > extent_buffer:
+            continue
+
+        network_cost = math.inf
         if edge_record is source_edge:
-            best = min(best, source_access + abs(along - source_along) + access_distance)
+            network_cost = min(network_cost, source_access + abs(along - source_along))
         if from_length is not None:
-            best = min(best, from_length + along + access_distance)
+            network_cost = min(network_cost, from_length + along)
         if to_length is not None:
-            best = min(best, to_length + max(length - along, 0.0) + access_distance)
-    return best
+            network_cost = min(network_cost, to_length + max(length - along, 0.0))
+        if network_cost <= max_distance:
+            return True
+    return False
 
 
 def _projected_edge_access(point: Point, line: LineString) -> tuple[float, float]:

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -15,7 +15,6 @@ The module specializes in three types of spatial relationships:
 """
 
 # Standard library imports
-import itertools
 import logging
 import math
 import typing
@@ -26,10 +25,10 @@ import geopandas as gpd
 import networkx as nx
 import numpy as np
 import pandas as pd
-from scipy.spatial import KDTree
-from scipy.spatial.distance import pdist
 from shapely.creation import linestrings as sh_linestrings
+from shapely.geometry import LineString
 from shapely.geometry import Point
+from shapely.geometry.base import BaseGeometry
 
 # Local imports
 from .base import GeoDataProcessor
@@ -51,6 +50,7 @@ __all__ = [
 
 # Module logger configuration
 logger = logging.getLogger(__name__)
+_SOURCE_BUILDING_INDEX_COL = "_source_building_index"
 
 
 # ============================================================================
@@ -63,17 +63,19 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 
 
-def morphological_graph(
+def morphological_graph(  # noqa: PLR0913
     buildings_gdf: gpd.GeoDataFrame,
     segments_gdf: gpd.GeoDataFrame,
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | None = None,
     distance: float | None = None,
     clipping_buffer: float = math.inf,
+    limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None = None,
     primary_barrier_col: str | None = "barrier_geometry",
     contiguity: str = "queen",
     keep_buildings: bool = False,
     keep_segments: bool = True,
     tolerance: float = 1e-6,
+    include_unenclosed_buildings: bool = False,
     as_nx: bool = False,
 ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]] | nx.Graph:
     """
@@ -105,6 +107,10 @@ def morphological_graph(
     clipping_buffer : float, default=math.inf
         Buffer distance to ensure adequate context for generating tessellation.
         Must be non-negative.
+    limit : geopandas.GeoDataFrame, geopandas.GeoSeries, shapely geometry, or None, optional
+        Boundary passed to `momepy.enclosures` when creating enclosed
+        tessellation. When None, `create_tessellation` computes one from the
+        buildings and barriers.
     primary_barrier_col : str, optional
         Column name containing alternative geometry for public spaces. If specified and exists,
         this geometry will be used instead of the main geometry column for tessellation barriers.
@@ -120,6 +126,9 @@ def morphological_graph(
         Buffer distance for public geometries when creating private-to-public connections.
         This parameter controls how close private spaces need to be to public spaces
         to establish a connection.
+    include_unenclosed_buildings : bool, default=False
+        If True, buildings excluded by enclosed tessellation are added using
+        barrier-free tessellation before distance filters are applied.
     as_nx : bool, default=False
         If True, convert the output to a NetworkX graph.
 
@@ -218,7 +227,14 @@ def morphological_graph(
         center_point,
         keep_buildings,
         private_id_col,
+        include_unenclosed_buildings,
+        segments_buffer,
+        limit=limit,
     )
+
+    # When a reachability budget is applied, prune private cells that face no
+    # retained street so the induced subgraph contains no isolated private nodes.
+    drop_isolated_private = center_point is not None and distance is not None
 
     nodes, edges = _build_morphological_layers(
         tessellation,
@@ -229,6 +245,7 @@ def morphological_graph(
         private_id_col,
         public_id_col,
         keep_segments,
+        drop_isolated_private=drop_isolated_private,
     )
 
     return (nodes, edges) if not as_nx else gdf_to_nx(nodes, edges)
@@ -502,6 +519,14 @@ def private_to_public_graph(
 
     # Drop duplicate pairs of (private_id, public_id)
     joined = joined.drop_duplicates()
+    joined = _connect_unmatched_private_to_nearest_public(
+        joined,
+        private_gdf,
+        public_gdf,
+        query_geometry,
+        private_id_col,
+        public_id_col,
+    )
 
     edges_gdf = _create_private_public_edges(
         joined,
@@ -514,6 +539,71 @@ def private_to_public_graph(
     nodes_gdf = pd.concat([private_gdf, public_gdf], ignore_index=True)
 
     return (nodes_gdf, edges_gdf) if not as_nx else gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf)
+
+
+def _connect_unmatched_private_to_nearest_public(
+    joined: pd.DataFrame,
+    private_gdf: gpd.GeoDataFrame,
+    public_gdf: gpd.GeoDataFrame,
+    query_geometry: gpd.GeoSeries,
+    private_id_col: str,
+    public_id_col: str,
+) -> pd.DataFrame:
+    """
+    Add one nearest public edge for private polygons missed by the proximity query.
+
+    The regular ``dwithin`` query captures true face relationships. Fallback
+    tessellation cells can be raw building footprints, so they may not touch a
+    street barrier. Those otherwise isolated cells are connected to their nearest
+    public segment to keep them integrated in the morphology graph.
+
+    Parameters
+    ----------
+    joined : pd.DataFrame
+        DataFrame of proximity query results linking private and public geometries.
+    private_gdf : gpd.GeoDataFrame
+        GeoDataFrame of private geometries (tessellation cells or building footprints).
+    public_gdf : gpd.GeoDataFrame
+        GeoDataFrame of public geometries (street segments).
+    query_geometry : gpd.GeoSeries
+        GeoSeries used to find nearest public segments for missing private geometries.
+    private_id_col : str
+        Column name identifying private geometries.
+    public_id_col : str
+        Column name identifying public geometries.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame containing augmented connections for isolated private geometries.
+    """
+    connected_private_ids = set(joined[private_id_col]) if not joined.empty else set()
+    unmatched_private = private_gdf.loc[
+        ~private_gdf[private_id_col].isin(connected_private_ids),
+    ].drop_duplicates(subset=[private_id_col])
+    if unmatched_private.empty:
+        return joined
+
+    public_query = gpd.GeoSeries(query_geometry.to_numpy(), crs=public_gdf.crs)
+    if public_query.empty:
+        return joined
+
+    private_nearest_indices, public_nearest_indices = public_query.sindex.nearest(
+        unmatched_private.geometry,
+        return_all=False,
+    )
+    if len(private_nearest_indices) == 0:
+        return joined
+
+    nearest = pd.DataFrame(
+        {
+            private_id_col: unmatched_private.iloc[private_nearest_indices][
+                private_id_col
+            ].to_numpy(),
+            public_id_col: public_gdf.iloc[public_nearest_indices][public_id_col].to_numpy(),
+        },
+    )
+    return pd.concat([joined, nearest], ignore_index=True).drop_duplicates()
 
 
 # ============================================================================
@@ -930,10 +1020,15 @@ def _process_segments(
         segment_nodes, segment_edges = segments_to_graph(segments_gdf)
         segments_graph = nx.Graph()
 
-    # Filter segments by network distance for the final graph if center_point and distance are provided
+    # Filter segments by network distance for the final graph if center_point and distance are
+    # provided. Street acceptance is derived from the same reachability cost field used for
+    # tessellation cells, so every node type is judged against a single distance metric.
     if center_point is not None and distance is not None and not segments_gdf.empty:
-        filtered_segments_graph = filter_graph_by_distance(segments_graph, center_point, distance)
-        segments_filtered = nx_to_gdf(filtered_segments_graph, nodes=False, edges=True)
+        segments_filtered = _segments_within_network_distance(
+            segment_edges,
+            center_point,
+            distance,
+        )
     else:
         segments_filtered = segment_edges
 
@@ -962,7 +1057,7 @@ def _process_segments(
     return segments_filtered, segments_buffer
 
 
-def _create_and_filter_tessellation(
+def _create_and_filter_tessellation(  # noqa: PLR0913
     buildings_gdf: gpd.GeoDataFrame,
     segments_buffer: gpd.GeoDataFrame,
     segments_filtered: gpd.GeoDataFrame,
@@ -972,6 +1067,9 @@ def _create_and_filter_tessellation(
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | None,
     keep_buildings: bool,
     private_id_col: str,
+    include_unenclosed_buildings: bool = False,
+    network_segments: gpd.GeoDataFrame | None = None,
+    limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Create tessellation and apply spatial filters.
@@ -999,6 +1097,14 @@ def _create_and_filter_tessellation(
         If True, preserves building information in the tessellation output.
     private_id_col : str
         Name of the private ID column.
+    include_unenclosed_buildings : bool, default=False
+        If True, buildings excluded by enclosed tessellation are added using
+        barrier-free tessellation before distance filters are applied.
+    network_segments : geopandas.GeoDataFrame or None, default=None
+        Segments used for the network distance computations. When None, the
+        filtered segments are used; otherwise these segments define the network.
+    limit : geopandas.GeoDataFrame, geopandas.GeoSeries, shapely geometry, or None, optional
+        Boundary passed to `create_tessellation` for enclosed tessellation.
 
     Returns
     -------
@@ -1007,9 +1113,13 @@ def _create_and_filter_tessellation(
     """
     barriers = _prepare_barriers(segments_buffer, primary_barrier_col)
     # Create tessellation based on buildings and prepared barriers
+    tessellation_kwargs = {}
+    if limit is not None:
+        tessellation_kwargs["limit"] = limit
     tessellation = create_tessellation(
         buildings_gdf,
         primary_barriers=None if barriers.empty else barriers,  # Use barriers if available
+        **tessellation_kwargs,
     )
 
     tessellation = tessellation.rename(columns={"tess_id": private_id_col})
@@ -1017,6 +1127,22 @@ def _create_and_filter_tessellation(
     # Ensure the fixed private ID column exists, creating a sequential ID if necessary
     if private_id_col not in tessellation.columns:
         tessellation[private_id_col] = range(len(tessellation))  # Assign sequential private IDs
+
+    distance_segments = segments_filtered if network_segments is None else network_segments
+
+    eligible_buildings = _filter_buildings_by_network_distance(
+        buildings_gdf,
+        distance_segments,
+        center_point,
+        distance,
+    )
+
+    if include_unenclosed_buildings and not barriers.empty:
+        tessellation = _include_unenclosed_building_tessellation(
+            tessellation,
+            eligible_buildings,
+            private_id_col,
+        )
 
     # Determine max_distance for filtering tessellation adjacent to segments
     max_distance_for_adj_filter = distance + clipping_buffer if distance is not None else math.inf
@@ -1031,16 +1157,144 @@ def _create_and_filter_tessellation(
     if center_point is not None and distance is not None:
         tessellation = _filter_tessellation_by_network_distance(
             tessellation,
-            segments_filtered,  # Use 'segments_filtered' for network distance calculation
+            distance_segments,
             center_point,
             distance,  # Max network distance
         )
 
     # Optionally preserve building information by joining tessellation with buildings
     if keep_buildings:
-        tessellation = _add_building_info(tessellation, buildings_gdf)
+        tessellation = _add_building_info(tessellation, eligible_buildings)
 
     return tessellation
+
+
+def _include_unenclosed_building_tessellation(
+    tessellation: gpd.GeoDataFrame,
+    buildings_gdf: gpd.GeoDataFrame,
+    private_id_col: str,
+) -> gpd.GeoDataFrame:
+    """
+    Append fallback cells for buildings missed by the enclosed tessellation.
+
+    Buildings that fall outside every enclosed tessellation cell are represented
+    by their own footprint as a fallback cell, tagged with a synthetic private id
+    and a source-building reference so they can still join the morphological graph.
+
+    Parameters
+    ----------
+    tessellation : geopandas.GeoDataFrame
+        The enclosed tessellation to augment.
+    buildings_gdf : geopandas.GeoDataFrame
+        Buildings eligible for inclusion, used to find the unenclosed ones.
+    private_id_col : str
+        Name of the private ID column.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The tessellation with fallback cells appended, or the original when none
+        are missing.
+    """
+    missing_buildings = _buildings_without_tessellation(tessellation, buildings_gdf)
+    if missing_buildings.empty:
+        return tessellation
+
+    tessellation = tessellation.copy()
+    if "enclosure_index" in tessellation.columns:
+        tessellation["enclosure_index"] = tessellation["enclosure_index"].astype(str)
+
+    fallback = gpd.GeoDataFrame(
+        {private_id_col: missing_buildings.index.astype(str)},
+        geometry=missing_buildings.geometry.to_numpy(),
+        crs=missing_buildings.crs,
+    )
+    fallback[_SOURCE_BUILDING_INDEX_COL] = missing_buildings.index.to_numpy()
+    fallback[private_id_col] = "fallback_" + fallback[private_id_col].astype(str)
+    fallback["enclosure_index"] = "fallback"
+
+    return gpd.GeoDataFrame(
+        pd.concat([tessellation, fallback], ignore_index=True, sort=False),
+        geometry=tessellation.geometry.name,
+        crs=tessellation.crs,
+    )
+
+
+def _filter_buildings_by_network_distance(
+    buildings_gdf: gpd.GeoDataFrame,
+    segments: gpd.GeoDataFrame,
+    center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point | None,
+    max_distance: float | None,
+) -> gpd.GeoDataFrame:
+    """
+    Filter buildings by network distance from a centre point.
+
+    Buildings are kept when their centroid is reachable within ``max_distance``
+    on the shared reachability cost field. Filtering is skipped when no centre or
+    distance budget is supplied, returning the buildings unchanged.
+
+    Parameters
+    ----------
+    buildings_gdf : geopandas.GeoDataFrame
+        Buildings to filter.
+    segments : geopandas.GeoDataFrame
+        Street segments used to build the reachability network.
+    center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point or None
+        Origin point(s) for the reachability computation.
+    max_distance : float or None
+        Maximum network distance for a building to be retained.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The reachable subset of ``buildings_gdf``.
+    """
+    if buildings_gdf.empty or segments.empty or center_point is None or max_distance is None:
+        return buildings_gdf.copy()
+
+    keep_ilocs = _geometry_ilocs_within_network_distance(
+        buildings_gdf.geometry.centroid,
+        segments,
+        center_point,
+        max_distance,
+    )
+    return buildings_gdf.iloc[keep_ilocs].copy()
+
+
+def _buildings_without_tessellation(
+    tessellation: gpd.GeoDataFrame,
+    buildings_gdf: gpd.GeoDataFrame,
+) -> gpd.GeoDataFrame:
+    """
+    Identify buildings not covered by any tessellation cell.
+
+    A spatial join flags buildings whose footprint intersects a tessellation
+    cell; those that intersect none are returned as the unenclosed buildings.
+
+    Parameters
+    ----------
+    tessellation : geopandas.GeoDataFrame
+        The tessellation whose coverage is tested.
+    buildings_gdf : geopandas.GeoDataFrame
+        Buildings to test against the tessellation.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The subset of buildings that intersect no tessellation cell.
+    """
+    if buildings_gdf.empty:
+        return buildings_gdf.copy()
+    if tessellation.empty:
+        return buildings_gdf.copy()
+
+    covered = gpd.sjoin(
+        buildings_gdf[[buildings_gdf.geometry.name]],
+        tessellation[[tessellation.geometry.name]],
+        how="inner",
+        predicate="intersects",
+    )
+    return buildings_gdf.loc[~buildings_gdf.index.isin(covered.index.unique())].copy()
 
 
 def _build_morphological_layers(
@@ -1052,6 +1306,7 @@ def _build_morphological_layers(
     private_id_col: str,
     public_id_col: str,
     keep_segments: bool = True,
+    drop_isolated_private: bool = False,
 ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]]:
     """
     Build the node and edge layers for the morphological graph.
@@ -1078,6 +1333,12 @@ def _build_morphological_layers(
     keep_segments : bool, default True
         If True, preserves the original segment LineString geometry in a column
         named 'segment_geometry' in the public nodes GeoDataFrame.
+    drop_isolated_private : bool, default False
+        If True, private cells with no private-to-public (faced_to) connection
+        are removed, along with the private-to-private edges that reference them.
+        This guarantees an induced subgraph free of isolated private nodes and is
+        enabled when a reachability budget (``center_point`` and ``distance``) is
+        applied.
 
     Returns
     -------
@@ -1117,6 +1378,24 @@ def _build_morphological_layers(
     # Log warning if no private-public connections found
     if private_to_public_edges.empty:
         logger.warning("No private to public connections found")
+
+    # Drop private cells that face no retained street so the induced subgraph
+    # contains no isolated private nodes. Adjacency (touched_to) edges that
+    # reference removed cells are pruned to keep the layers consistent.
+    if drop_isolated_private and not tessellation.empty:
+        connected_private_ids = (
+            set(private_to_public_edges[private_id_col].unique())
+            if not private_to_public_edges.empty
+            else set()
+        )
+        keep_mask = tessellation[private_id_col].isin(connected_private_ids)
+        if not keep_mask.all():
+            tessellation = tessellation.loc[keep_mask].copy()
+            if not private_to_private_edges.empty:
+                private_to_private_edges = private_to_private_edges.loc[
+                    private_to_private_edges["from_private_id"].isin(connected_private_ids)
+                    & private_to_private_edges["to_private_id"].isin(connected_private_ids)
+                ].copy()
 
     # Prepare private nodes with Point geometry (centroids)
     # Preserve original tessellation geometry in tessellation_geometry column
@@ -1205,11 +1484,11 @@ def _add_building_info(
     """
     Add building information to tessellation.
 
-    This function performs a spatial join between the tessellation GeoDataFrame
-    and the buildings GeoDataFrame to associate each tessellation cell with
-    the building(s) it contains or intersects. It adds a new column
+    This function associates each tessellation cell with buildings whose
+    representative points fall inside the cell. Fallback cells with a recorded
+    source building index are matched exactly. It adds a new column
     `building_geometry` to the tessellation, containing the geometry of the
-    intersecting building.
+    matched building.
 
     Parameters
     ----------
@@ -1223,29 +1502,45 @@ def _add_building_info(
     geopandas.GeoDataFrame
         The tessellation GeoDataFrame with an added `building_geometry` column.
     """
-    joined = gpd.sjoin(tessellation, buildings, how="left", predicate="intersects")
-
-    # If 'index_right' exists (meaning some joins occurred), map building geometries
-    if "index_right" in joined.columns:
-        # Create a mapping from building index to building geometry
-        building_geom_map = buildings.geometry.to_dict()
-
-        # Use the 'index_right' (building indices) to look up geometries from the map
-        # This creates a pandas Series of Shapely geometries.
-        building_geometries_series = joined["index_right"].map(building_geom_map)
-
-        # Convert this pandas Series to a GeoSeries, assigning the CRS from the source 'buildings' GDF
-        joined["building_geometry"] = gpd.GeoSeries(building_geometries_series, crs=buildings.crs)
-
-        # Remove the temporary 'index_right' column
-        joined = joined.drop(columns=["index_right"])
-    else:
-        # Always allocate the "building_geometry" column even if sjoin yields 0 matches
+    if tessellation.empty or buildings.empty:
+        joined = tessellation.copy()
         joined["building_geometry"] = gpd.GeoSeries(
             [None] * len(joined), index=joined.index, crs=buildings.crs
         )
+        return joined.drop(columns=[_SOURCE_BUILDING_INDEX_COL], errors="ignore")
 
-    return joined  # Return tessellation with added building geometry (if any)
+    building_columns = [col for col in buildings.columns if col != buildings.geometry.name]
+    points = gpd.GeoDataFrame(
+        buildings[building_columns].copy(),
+        geometry=buildings.geometry.representative_point(),
+        crs=buildings.crs,
+    )
+    joined = gpd.sjoin(tessellation, points, how="left", predicate="contains")
+
+    if "index_right" not in joined.columns:
+        joined["index_right"] = None
+
+    if _SOURCE_BUILDING_INDEX_COL in joined.columns:
+        source_index = joined[_SOURCE_BUILDING_INDEX_COL]
+        joined["index_right"] = source_index.combine_first(joined["index_right"])
+        source_mask = source_index.notna()
+        for column in building_columns:
+            joined.loc[source_mask, column] = (
+                source_index.loc[source_mask]
+                .map(
+                    buildings[column],
+                )
+                .to_numpy()
+            )
+
+    building_geom_map = buildings.geometry.to_dict()
+    joined["building_geometry"] = gpd.GeoSeries(
+        joined["index_right"].map(building_geom_map),
+        index=joined.index,
+        crs=buildings.crs,
+    )
+
+    return joined.drop(columns=["index_right", _SOURCE_BUILDING_INDEX_COL], errors="ignore")
 
 
 # ============================================================================
@@ -1295,13 +1590,19 @@ def _filter_adjacent_tessellation(
     # List to store filtered parts of tessellation
     filtered_parts: list[gpd.GeoDataFrame] = []
 
+    groups = (
+        tessellation.groupby(enclosure_col) if enclosure_col is not None else [(None, tessellation)]
+    )
+
     # Iterate over each enclosure group
-    for _, group in tessellation.groupby(enclosure_col):
+    for _, group in groups:
         # Geometry of the current enclosure
         enclosure_geom = group.union_all()
 
         # Segments intersecting this enclosure
         segments_in_enclosure = segments[segments.intersects(enclosure_geom)]
+        if segments_in_enclosure.empty:
+            segments_in_enclosure = segments
 
         # Union of segments within this enclosure
         segment_union_in_enclosure = segments_in_enclosure.union_all()
@@ -1318,6 +1619,9 @@ def _filter_adjacent_tessellation(
         # Add filtered group to list
         if not filtered_group.empty:
             filtered_parts.append(filtered_group)
+
+    if not filtered_parts:
+        return tessellation.iloc[0:0].copy()
 
     # Concatenate all filtered parts into a single GeoDataFrame
     return gpd.GeoDataFrame(pd.concat(filtered_parts), crs=tessellation.crs)
@@ -1358,278 +1662,461 @@ def _filter_tessellation_by_network_distance(
     if tessellation.empty or segments.empty:
         return tessellation.copy()
 
-    # Get centroids of tessellation cells
-    tessellation_centroids = tessellation.geometry.centroid
-
-    # Build a spatial graph including segment endpoints and tessellation centroids as nodes
-    graph, centroid_iloc_to_node_id, segment_node_positions = _build_spatial_graph(
+    keep_ilocs = _geometry_ilocs_within_network_distance(
+        tessellation.geometry.centroid,
         segments,
-        tessellation_centroids,
-    )
-
-    # Connect tessellation centroid nodes to the nearest segment graph nodes
-    _connect_centroids_to_segment_graph(
-        graph,
-        tessellation_centroids,
-        centroid_iloc_to_node_id,
-        segment_node_positions,
-    )
-
-    _connect_centroids_to_centroids(graph, tessellation_centroids, centroid_iloc_to_node_id)
-
-    # Normalize center_point input to a single Shapely Point geometry
-    center_geom = center_point.iloc[0] if isinstance(center_point, gpd.GeoSeries) else center_point
-
-    # Find the graph node closest to the geographic center_geom
-    center_node_id_in_graph = _find_closest_node_to_center(graph, center_geom)
-
-    # Filter centroid ilocs based on network path length from the center_node_id_in_graph
-    keep_ilocs = _filter_nodes_by_path_length(
-        graph,
-        center_node_id_in_graph,
+        center_point,
         max_distance,
-        centroid_iloc_to_node_id,
     )
 
     # Return the subset of the original tessellation corresponding to the kept ilocs
-    return tessellation.iloc[sorted(keep_ilocs)].copy()
+    return tessellation.iloc[keep_ilocs].copy()
 
 
-def _filter_nodes_by_path_length(
-    graph: nx.Graph,
-    source_node_id: typing.Hashable,
-    max_distance: float,
-    centroid_iloc_to_node_id: dict[int, str],
-) -> list[int]:
+def _extract_center_geometry(
+    center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
+) -> Point:
     """
-    Filter nodes by their shortest path length from a source node.
+    Extract a single representative Point from a centre input.
 
-    This function calculates the shortest path distance from a given source node to
-    all other nodes in the graph using Dijkstra's algorithm. It then returns a list
-    of the integer locations (ilocs) of the tessellation centroids whose corresponding
-    nodes are within the specified maximum distance.
+    Accepts the several centre representations used across the module and
+    returns the first geometry as a plain Point for downstream snapping.
 
     Parameters
     ----------
-    graph : networkx.Graph
-        The graph to perform the search on.
-    source_node_id : typing.Hashable
-        The ID of the source node for the path length calculation.
-    max_distance : float
-        The maximum path length for a node to be included.
-    centroid_iloc_to_node_id : dict[int, str]
-        A mapping from centroid integer location to its graph node ID.
+    center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point
+        The centre input to normalise.
 
     Returns
     -------
-    list[int]
-        A list of integer locations of the centroids that are within the distance.
+    shapely.geometry.Point
+        The first point geometry of the input.
     """
-    if source_node_id not in graph:
-        # This can happen if the center point is very far from any graph node
-        logger.warning("Source node for distance filtering not found in graph.")
-        return []
-
-    lengths = nx.single_source_dijkstra_path_length(
-        graph,
-        source_node_id,
-        weight="length",
-    )
-
-    # Get the ilocs of tessellation centroids that are within the max_distance
-    keep_ilocs = []
-    for iloc, node_id in centroid_iloc_to_node_id.items():
-        if node_id in lengths and lengths[node_id] <= max_distance:
-            keep_ilocs.append(iloc)
-    return keep_ilocs
+    if isinstance(center_point, gpd.GeoDataFrame):
+        return typing.cast("Point", center_point.geometry.iloc[0])
+    if isinstance(center_point, gpd.GeoSeries):
+        return typing.cast("Point", center_point.iloc[0])
+    return center_point
 
 
-# ============================================================================
-# SPATIAL GRAPH CONSTRUCTION HELPERS
-# ============================================================================
+class _ReachabilityField(typing.NamedTuple):
+    """
+    Single-source reachability cost field shared across all node types.
+
+    The field is computed once from a centre snapped onto the street network and
+    is reused to derive the acceptance of both street segments and tessellation
+    cells, so every node type is judged against the same reachability metric.
+    """
+
+    endpoint_lengths: dict[typing.Hashable, float]
+    edge_records: list[tuple[typing.Hashable, typing.Hashable, LineString, float]]
+    source_edge: tuple[typing.Hashable, typing.Hashable, LineString, float]
+    source_along: float
+    source_access: float
+    node_positions: dict[typing.Hashable, tuple[float, float]]
 
 
-def _build_spatial_graph(
+def _network_reachability_field(
     segments: gpd.GeoDataFrame,
-    tessellation_centroids: gpd.GeoSeries,
-) -> tuple[nx.Graph, dict[int, str], dict[str, tuple[float, float]]]:
+    center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
+) -> _ReachabilityField | None:
     """
-    Build a spatial graph from segments and tessellation centroids.
+    Compute the single-source reachability cost field for a street network.
 
-    This function creates a unified NetworkX graph that combines the street segment
-    network with the tessellation centroids. The segment endpoints and the centroids
-    are all treated as nodes in this temporary graph, which is used for calculating
-    network distances.
+    The centre point is snapped onto its nearest network edge (capturing the
+    last leg as an along-edge plus access projection), and a single shortest
+    path computation yields the cumulative cost to reach every network node.
+    This cost field is the common basis from which both street and cell
+    acceptance are derived.
 
     Parameters
     ----------
     segments : geopandas.GeoDataFrame
-        The street segments GeoDataFrame.
-    tessellation_centroids : geopandas.GeoSeries
-        A GeoSeries of tessellation centroid points.
+        Street segments used to build the network.
+    center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point
+        Origin point(s) for the reachability computation.
 
     Returns
     -------
-    tuple[networkx.Graph, dict[int, str], dict[str, tuple[float, float]]]
-        A tuple containing the combined graph, a mapping from centroid integer
-        location to node ID, and a dictionary of segment node positions.
+    _ReachabilityField or None
+        The computed cost field, or None when the network has no usable edges
+        or the centre cannot be snapped onto it.
     """
     graph = gdf_to_nx(edges=segments)
+    _ensure_graph_edge_lengths(graph)
+    edge_records = _network_edge_records(graph)
+    if not edge_records:
+        return None
 
-    # Get positions (coordinates) of segment graph nodes
-    segment_node_positions = nx.get_node_attributes(graph, "pos")
+    source_id = "__city2graph_center__"
+    graph = graph.copy()
+    source_edge, source_along, source_access = _connect_point_to_nearest_edge(
+        graph,
+        source_id,
+        _extract_center_geometry(center_point),
+        edge_records,
+    )
+    if source_id not in graph:
+        logger.warning("Source node for distance filtering not found in graph.")
+        return None
 
-    centroid_iloc_to_node_id = {
-        i: f"tess_centroid_{i}" for i, _ in enumerate(tessellation_centroids)
-    }
+    endpoint_lengths = nx.single_source_dijkstra_path_length(
+        graph,
+        source_id,
+        weight="length",
+    )
+    return _ReachabilityField(
+        endpoint_lengths=endpoint_lengths,
+        edge_records=edge_records,
+        source_edge=source_edge,
+        source_along=source_along,
+        source_access=source_access,
+        node_positions=nx.get_node_attributes(graph, "pos"),
+    )
 
-    centroid_nodes = [
-        (f"tess_centroid_{i}", {"pos": (point.x, point.y), "type": "centroid_node"})
-        for i, point in enumerate(tessellation_centroids)
-    ]
 
-    # Add tessellation centroid nodes to the graph
-    graph.add_nodes_from(centroid_nodes)
-    return graph, centroid_iloc_to_node_id, segment_node_positions
-
-
-def _connect_centroids_to_segment_graph(
-    graph: nx.Graph,
-    tessellation_centroids: gpd.GeoSeries,
-    centroid_iloc_to_node_id: dict[int, str],
-    segment_node_positions: dict[str, tuple[float, float]],
-) -> None:
+def _geometry_ilocs_within_network_distance(
+    geometries: gpd.GeoSeries,
+    segments: gpd.GeoDataFrame,
+    center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
+    max_distance: float,
+) -> list[int]:
     """
-    Connect centroid nodes to their nearest segment graph nodes.
+    Return the integer positions of geometries reachable within a network budget.
 
-    This function uses a KDTree for efficient nearest neighbor search to find the
-    closest segment node for each tessellation centroid. It then adds edges to the
-    graph connecting each centroid to its nearest segment node, with the edge
-    length representing the Euclidean distance.
+    Each geometry (typically a cell or building centroid) is scored against the
+    shared reachability cost field, adding the last-leg access from the geometry
+    to the network, and kept when that cost is within ``max_distance``.
 
     Parameters
     ----------
-    graph : networkx.Graph
-        The graph to which the new edges will be added.
-    tessellation_centroids : geopandas.GeoSeries
-        The GeoSeries of tessellation centroid points.
-    centroid_iloc_to_node_id : dict[int, str]
-        A mapping from centroid integer location to its graph node ID.
-    segment_node_positions : dict[str, tuple[float, float]]
-        A dictionary of segment node positions.
-    """
-    # Prepare segment node IDs and their coordinates for KDTree
-    segment_node_ids = list(segment_node_positions.keys())
-    segment_node_coords = [list(coord) for coord in segment_node_positions.values()]
-    segment_coords_array = np.array(segment_node_coords)
-
-    # Build KDTree from segment graph node coordinates for efficient nearest neighbor search
-    kdtree = KDTree(segment_coords_array)
-
-    # Prepare centroid coordinates for querying the KDTree
-    centroid_coords = [(point.x, point.y) for point in tessellation_centroids.tolist()]
-    centroid_coords_array = np.array(centroid_coords)
-
-    # Query KDTree: for each centroid, find the nearest segment graph node and distance to it
-    distances_to_segments, segment_indices = kdtree.query(centroid_coords_array)
-
-    # Prepare edges to connect centroids to their nearest segment graph nodes
-    edges_to_add = [
-        (
-            centroid_iloc_to_node_id[i],
-            segment_node_ids[segment_indices[i]],
-            {"length": distances_to_segments[i]},
-        )
-        for i in range(len(tessellation_centroids))
-        if 0 <= segment_indices[i] < len(segment_node_ids)
-    ]
-    # Add the new edges to the graph
-    if edges_to_add:
-        graph.add_edges_from(edges_to_add)
-
-
-def _connect_centroids_to_centroids(
-    graph: nx.Graph,
-    tessellation_centroids: gpd.GeoSeries,
-    centroid_iloc_to_node_id: dict[int, str],
-) -> None:
-    """
-    Connect centroid nodes to each other based on Euclidean distance.
-
-    This function creates a complete graph between all the tessellation centroid
-    nodes, where the weight of each edge is the Euclidean distance between the
-    centroids. This allows for pathfinding between centroids that may not be
-    directly connected to the street network.
-
-    Parameters
-    ----------
-    graph : networkx.Graph
-        The graph to which the new edges will be added.
-    tessellation_centroids : geopandas.GeoSeries
-        The GeoSeries of tessellation centroid points.
-    centroid_iloc_to_node_id : dict[int, str]
-        A mapping from centroid integer location to its graph node ID.
-    """
-    relevant_ilocs = sorted(centroid_iloc_to_node_id.keys())
-
-    # Extract centroid Point geometries and their graph node IDs in a consistent, sorted order
-    points_to_connect = tessellation_centroids.iloc[relevant_ilocs]
-    node_ids_ordered = [centroid_iloc_to_node_id[iloc] for iloc in relevant_ilocs]
-
-    coords_array = np.array([(point.x, point.y) for point in points_to_connect])
-
-    pairwise_distances = pdist(coords_array, metric="euclidean")
-
-    # List to store edges to be added to the graph
-    edges_to_add = []
-
-    # Generate all unique pairs of ordered node IDs using itertools.combinations
-    # The order of pairs matches the order of distances in pairwise_distances
-    for idx, (node_id1, node_id2) in enumerate(itertools.combinations(node_ids_ordered, 2)):
-        distance = pairwise_distances[idx]
-        edges_to_add.append((node_id1, node_id2, {"length": distance}))
-
-    # Add all new centroid-to-centroid edges to the graph
-    if edges_to_add:
-        graph.add_edges_from(edges_to_add)
-
-
-def _find_closest_node_to_center(
-    graph: nx.Graph,
-    center_point_geom: Point,
-) -> typing.Hashable:
-    """
-    Find the graph node ID closest to a geometric center point.
-
-    This function uses a KDTree to efficiently find the nearest node in the graph
-    to a given geometric point. This is used to identify the starting node for
-    network distance calculations when filtering by distance from a center point.
-
-    Parameters
-    ----------
-    graph : networkx.Graph
-        The graph to search within.
-    center_point_geom : shapely.geometry.Point
-        The geometric point to find the closest node to.
+    geometries : geopandas.GeoSeries
+        Geometries whose reachability is evaluated, in their original order.
+    segments : geopandas.GeoDataFrame
+        Street segments used to build the reachability network.
+    center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point
+        Origin point(s) for the reachability computation.
+    max_distance : float
+        Maximum network distance for a geometry to be retained.
 
     Returns
     -------
-    str
-        The ID of the closest node in the graph.
+    list[int]
+        Integer positions (``iloc``) of the reachable geometries.
     """
-    pos = nx.get_node_attributes(graph, "pos")
+    field = _network_reachability_field(segments, center_point)
+    if field is None:
+        return []
 
-    node_ids = list(pos.keys())
-    node_coords = np.array(list(pos.values()))
+    return [
+        iloc
+        for iloc, geometry in enumerate(geometries)
+        if _distance_from_network_edges(
+            geometry,
+            field.endpoint_lengths,
+            field.edge_records,
+            field.source_edge,
+            field.source_along,
+            field.source_access,
+        )
+        <= max_distance
+    ]
 
-    # Create a KDTree for efficient nearest neighbor search
-    kdtree = KDTree(node_coords)
 
-    # Query for the closest node to the center point
-    _, idx = kdtree.query([center_point_geom.x, center_point_geom.y])
+def _ensure_graph_edge_lengths(graph: nx.Graph) -> None:
+    """
+    Populate a ``length`` weight on every graph edge in place.
 
-    # Return the exact native ID of the closest node
-    return typing.cast("typing.Hashable", node_ids[int(idx)])
+    Edges that already carry a valid ``length`` are left untouched; otherwise the
+    length is taken from the edge geometry, or from the straight-line distance
+    between the endpoint positions when no geometry is available.
+
+    Parameters
+    ----------
+    graph : networkx.Graph
+        Graph whose edges are annotated with a ``length`` weight in place.
+    """
+    positions = nx.get_node_attributes(graph, "pos")
+    for from_node, to_node, data in graph.edges(data=True):
+        length = data.get("length")
+        if length is not None and not pd.isna(length):
+            continue
+
+        geometry = data.get("geometry")
+        if geometry is not None:
+            data["length"] = geometry.length
+            continue
+
+        from_pos = positions.get(from_node)
+        to_pos = positions.get(to_node)
+        if from_pos is not None and to_pos is not None:
+            data["length"] = Point(from_pos).distance(Point(to_pos))
+
+
+def _network_edge_records(
+    graph: nx.Graph,
+) -> list[tuple[typing.Hashable, typing.Hashable, LineString, float]]:
+    """
+    Collect the traversable edges of a network as reusable records.
+
+    Each record bundles the endpoint node ids, the edge geometry and its length;
+    zero-length edges and edges with undetermined geometry are skipped so the
+    records can drive both snapping and distance evaluation.
+
+    Parameters
+    ----------
+    graph : networkx.Graph
+        The street network graph to enumerate.
+
+    Returns
+    -------
+    list[tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float]]
+        One ``(from_node, to_node, geometry, length)`` tuple per usable edge.
+    """
+    records = []
+    positions = nx.get_node_attributes(graph, "pos")
+    for from_node, to_node, data in graph.edges(data=True):
+        geometry = data.get("geometry")
+        if geometry is None:
+            from_pos = positions.get(from_node)
+            to_pos = positions.get(to_node)
+            if from_pos is None or to_pos is None:
+                continue
+            geometry = LineString([from_pos, to_pos])
+
+        length = data.get("length")
+        if length is None or pd.isna(length):
+            length = geometry.length
+        if length <= 0:
+            continue
+        records.append((from_node, to_node, geometry, float(length)))
+    return records
+
+
+def _connect_point_to_nearest_edge(
+    graph: nx.Graph,
+    point_node_id: typing.Hashable,
+    point: Point,
+    edge_records: list[tuple[typing.Hashable, typing.Hashable, LineString, float]],
+) -> tuple[tuple[typing.Hashable, typing.Hashable, LineString, float], float, float]:
+    """
+    Attach a point to the network through its nearest edge.
+
+    A temporary node is added for the point and connected to both endpoints of
+    the nearest edge, weighting each connection by the perpendicular access plus
+    the along-edge distance so the last leg is reflected in the cost field.
+
+    Parameters
+    ----------
+    graph : networkx.Graph
+        Graph that the point node is added to in place.
+    point_node_id : typing.Hashable
+        Identifier used for the temporary point node.
+    point : shapely.geometry.Point
+        The point to connect to the network.
+    edge_records : list[tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float]]
+        Candidate edges produced by :func:`_network_edge_records`.
+
+    Returns
+    -------
+    tuple[tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float], float, float]
+        The chosen edge record, the along-edge distance and the access distance.
+    """
+    edge_record = min(
+        edge_records,
+        key=lambda record: point.distance(record[2]),
+    )
+    from_node, to_node, geometry, length = edge_record
+    along, access_distance = _projected_edge_access(point, geometry)
+    graph.add_node(point_node_id, pos=(point.x, point.y))
+    graph.add_edge(point_node_id, from_node, length=access_distance + along)
+    graph.add_edge(point_node_id, to_node, length=access_distance + max(length - along, 0.0))
+    return edge_record, along, access_distance
+
+
+def _distance_from_network_edges(
+    point: Point,
+    endpoint_lengths: dict[typing.Hashable, float],
+    edge_records: list[tuple[typing.Hashable, typing.Hashable, LineString, float]],
+    source_edge: tuple[typing.Hashable, typing.Hashable, LineString, float],
+    source_along: float,
+    source_access: float,
+) -> float:
+    """
+    Compute the network distance from the centre to a point.
+
+    The point is projected onto every reachable edge and the cheapest path is
+    taken across the endpoint costs (plus along-edge and access terms), with the
+    centre-bearing edge handled explicitly so points sharing that edge are not
+    forced to detour through an endpoint.
+
+    Parameters
+    ----------
+    point : shapely.geometry.Point
+        The destination point to score.
+    endpoint_lengths : dict[typing.Hashable, float]
+        Shortest-path cost from the centre to each reachable network node.
+    edge_records : list[tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float]]
+        Candidate edges produced by :func:`_network_edge_records`.
+    source_edge : tuple[typing.Hashable, typing.Hashable, shapely.geometry.LineString, float]
+        The edge onto which the centre was snapped.
+    source_along : float
+        Along-edge distance of the centre projection on ``source_edge``.
+    source_access : float
+        Access distance from the centre to ``source_edge``.
+
+    Returns
+    -------
+    float
+        The minimum network distance, or ``math.inf`` when unreachable.
+    """
+    best = math.inf
+    for edge_record in edge_records:
+        from_node, to_node, geometry, length = edge_record
+        from_length = endpoint_lengths.get(from_node)
+        to_length = endpoint_lengths.get(to_node)
+        if from_length is None and to_length is None:
+            continue
+
+        along, access_distance = _projected_edge_access(point, geometry)
+        if edge_record is source_edge:
+            best = min(best, source_access + abs(along - source_along) + access_distance)
+        if from_length is not None:
+            best = min(best, from_length + along + access_distance)
+        if to_length is not None:
+            best = min(best, to_length + max(length - along, 0.0) + access_distance)
+    return best
+
+
+def _projected_edge_access(point: Point, line: LineString) -> tuple[float, float]:
+    """
+    Project a point onto a line and measure the access geometry.
+
+    The projection captures how far along the line the nearest point lies and how
+    far the point sits from the line, which together form the last-leg access.
+
+    Parameters
+    ----------
+    point : shapely.geometry.Point
+        The point to project.
+    line : shapely.geometry.LineString
+        The line to project onto.
+
+    Returns
+    -------
+    tuple[float, float]
+        The along-edge distance and the perpendicular access distance.
+    """
+    along = float(line.project(point))
+    projected = line.interpolate(along)
+    return along, point.distance(projected)
+
+
+def _coordinate_key(coordinate: tuple[float, float]) -> tuple[float, float]:
+    """
+    Round a coordinate to a stable lookup key.
+
+    Rounding tolerates floating-point noise so segment endpoints can be matched
+    against network node positions in a dictionary.
+
+    Parameters
+    ----------
+    coordinate : tuple[float, float]
+        The ``(x, y)`` coordinate to normalise.
+
+    Returns
+    -------
+    tuple[float, float]
+        The coordinate rounded to six decimal places.
+    """
+    return (round(coordinate[0], 6), round(coordinate[1], 6))
+
+
+def _segments_within_network_distance(
+    segments: gpd.GeoDataFrame,
+    center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point,
+    max_distance: float,
+) -> gpd.GeoDataFrame:
+    """
+    Filter street segments by the shared network reachability cost field.
+
+    A segment is retained when its nearest reachable endpoint lies within
+    ``max_distance`` on the same cost field used for tessellation cells. This
+    keeps segments that straddle the budget boundary (their reachable portion is
+    within budget) instead of dropping them on a binary wholly-in/out test, and
+    ensures street and cell acceptance derive from a single reachability metric.
+
+    Parameters
+    ----------
+    segments : geopandas.GeoDataFrame
+        Street segments to filter. All columns are preserved on the kept rows.
+    center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point
+        Origin point(s) for the reachability computation.
+    max_distance : float
+        Maximum network distance for a segment to be retained.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The subset of ``segments`` reachable within ``max_distance``.
+    """
+    if segments.empty:
+        return segments.copy()
+
+    field = _network_reachability_field(segments, center_point)
+    if field is None:
+        return segments.iloc[0:0].copy()
+
+    # Map each network node position to its cheapest reachable cost so segment
+    # endpoints can be looked up directly against the shared cost field.
+    cost_by_coordinate: dict[tuple[float, float], float] = {}
+    for node, cost in field.endpoint_lengths.items():
+        position = field.node_positions.get(node)
+        if position is None:
+            continue
+        key = _coordinate_key(position)
+        existing = cost_by_coordinate.get(key)
+        if existing is None or cost < existing:
+            cost_by_coordinate[key] = cost
+
+    keep_ilocs = [
+        iloc
+        for iloc, geometry in enumerate(segments.geometry)
+        if _segment_min_reachable_cost(geometry, cost_by_coordinate) <= max_distance
+    ]
+    return segments.iloc[keep_ilocs].copy()
+
+
+def _segment_min_reachable_cost(
+    geometry: LineString,
+    cost_by_coordinate: dict[tuple[float, float], float],
+) -> float:
+    """
+    Return the cheapest reachable cost among a segment's endpoints.
+
+    The reachable portion of a segment is bounded by its cheaper endpoint, so the
+    minimum endpoint cost determines whether any part of the segment falls within
+    the reachability budget.
+
+    Parameters
+    ----------
+    geometry : shapely.geometry.LineString
+        The segment geometry to evaluate.
+    cost_by_coordinate : dict[tuple[float, float], float]
+        Reachability cost keyed by rounded network node position.
+
+    Returns
+    -------
+    float
+        The minimum endpoint cost, or ``math.inf`` when neither endpoint is
+        reachable.
+    """
+    coordinates = list(geometry.coords)
+    if not coordinates:
+        return math.inf
+    start = cost_by_coordinate.get(_coordinate_key(coordinates[0]), math.inf)
+    end = cost_by_coordinate.get(_coordinate_key(coordinates[-1]), math.inf)
+    return min(start, end)
 
 
 # ============================================================================

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -38,6 +38,7 @@ from shapely.geometry import MultiPoint
 from shapely.geometry import MultiPolygon
 from shapely.geometry import Point
 from shapely.geometry import Polygon
+from shapely.geometry.base import BaseGeometry
 
 try:
     import matplotlib.pyplot as plt
@@ -3923,6 +3924,7 @@ def create_tessellation(
     segment: float = 0.5,
     threshold: float = 0.05,
     n_jobs: int = -1,
+    limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None = None,
     **kwargs: object,
 ) -> gpd.GeoDataFrame:
     """
@@ -3952,6 +3954,9 @@ def create_tessellation(
     n_jobs : int, default -1
         The number of jobs to use for parallel processing. -1 means using all
         available processors. Only used for enclosed tessellation.
+    limit : geopandas.GeoDataFrame, geopandas.GeoSeries, shapely geometry, or None, optional
+        Boundary passed to `momepy.enclosures` for enclosed tessellation. When
+        None, a buffered convex hull of input geometry and barriers is computed.
     **kwargs : object, optional
         Additional keyword arguments passed to the underlying `momepy`
         tessellation function.
@@ -4015,6 +4020,7 @@ def create_tessellation(
         return _create_enclosed_tessellation(
             geometry,
             primary_barriers,
+            limit,
             shrink,
             segment,
             threshold,
@@ -4032,6 +4038,7 @@ def create_tessellation(
 def _create_enclosed_tessellation(
     geometry: gpd.GeoDataFrame | gpd.GeoSeries,
     primary_barriers: gpd.GeoDataFrame | gpd.GeoSeries,
+    limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None,
     shrink: float,
     segment: float,
     threshold: float,
@@ -4051,6 +4058,9 @@ def _create_enclosed_tessellation(
         The geometries to tessellate around.
     primary_barriers : geopandas.GeoDataFrame or geopandas.GeoSeries
         Geometries to use as barriers.
+    limit : geopandas.GeoDataFrame, geopandas.GeoSeries, shapely geometry, or None
+        Boundary passed to `momepy.enclosures`. If None, one is derived from
+        geometry and barriers.
     shrink : float
         The distance to shrink the geometry.
     segment : float
@@ -4067,9 +4077,12 @@ def _create_enclosed_tessellation(
     geopandas.GeoDataFrame
         The enclosed tessellation.
     """
+    if limit is None:
+        limit = _compute_enclosure_limit(geometry, primary_barriers)
+
     enclosures = momepy.enclosures(
         primary_barriers=primary_barriers,
-        limit=None,
+        limit=limit,
         additional_barriers=None,
         enclosure_id="eID",
         clip=False,
@@ -4104,6 +4117,44 @@ def _create_enclosed_tessellation(
         for i, j in zip(tessellation["enclosure_index"], tessellation.index, strict=False)
     ]
     return tessellation.reset_index(drop=True)
+
+
+def _compute_enclosure_limit(
+    geometry: gpd.GeoDataFrame | gpd.GeoSeries,
+    primary_barriers: gpd.GeoDataFrame | gpd.GeoSeries,
+    buffer: float = 500,
+) -> BaseGeometry | None:
+    """
+    Compute a buffered hull limit for momepy enclosures.
+
+    The limit needs to include both buildings and street barriers so buildings
+    near the outer street loops are not excluded from enclosed tessellation.
+
+    Parameters
+    ----------
+    geometry : gpd.GeoDataFrame | gpd.GeoSeries
+        Building geometries used to compute boundaries.
+    primary_barriers : gpd.GeoDataFrame | gpd.GeoSeries
+        Street geometries forming enclosures.
+    buffer : float, default 500
+        Distance in map units to buffer the combined convex hull.
+
+    Returns
+    -------
+    BaseGeometry | None
+        A single geometry representing the enclosure limit, or None if no valid
+        geometries exist.
+    """
+    geometries = [
+        geom
+        for source in (geometry.geometry, primary_barriers.geometry)
+        for geom in source
+        if geom is not None and not geom.is_empty
+    ]
+    if not geometries:
+        return None
+
+    return gpd.GeoSeries(geometries, crs=geometry.crs).union_all().convex_hull.buffer(buffer)
 
 
 def _create_empty_tessellation(

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -4089,16 +4089,22 @@ def _create_enclosed_tessellation(
     )
 
     if not enclosures.empty:
-        try:
-            tessellation = momepy.enclosed_tessellation(
+
+        def _run_enclosed_tessellation(**extra_kwargs: object) -> gpd.GeoDataFrame:
+            # ``extra_kwargs`` (e.g. ``simplify`` or a coarser ``grid_size``) are
+            # applied as retry overrides on top of the caller-supplied ``kwargs``.
+            return momepy.enclosed_tessellation(
                 geometry=geometry,
                 enclosures=enclosures,
                 shrink=shrink,
                 segment=segment,
                 threshold=threshold,
                 n_jobs=n_jobs,
-                **kwargs,
+                **{**kwargs, **extra_kwargs},
             )
+
+        try:
+            tessellation = _run_enclosed_tessellation()
         except ValueError as e:
             if "No objects to concatenate" in str(e):
                 logger.warning(
@@ -4106,6 +4112,41 @@ def _create_enclosed_tessellation(
                 )
                 return _create_empty_tessellation(geometry.crs)
             raise
+        except TypeError as e:
+            # shapely.coverage_simplify rejects non-polygonal cells produced by
+            # degenerate/overlapping footprints in a single enclosure, which
+            # aborts the whole parallel run. Retry once without boundary
+            # simplification (the un-simplified result is still a valid
+            # tessellation) unless the caller explicitly chose ``simplify``.
+            if "incorrect geometry type" not in str(e) or "simplify" in kwargs:
+                raise
+            logger.warning(
+                "Tessellation boundary simplification failed (%s); retrying with simplify=False.",
+                e,
+            )
+            tessellation = _run_enclosed_tessellation(simplify=False)
+        except shapely.errors.GEOSException as e:
+            # ``shapely.voronoi_polygons`` can raise ``TopologyException: side
+            # location conflict`` on numerically fragile / near-degenerate
+            # footprints. ``voronoi_frames`` snaps coordinates at ``grid_size``
+            # (default 1e-5); a single failing enclosure aborts the whole parallel
+            # run. Retry once with a coarser precision to resolve the conflict,
+            # unless the caller already pinned ``grid_size``.
+            if "grid_size" in kwargs:
+                raise
+            logger.warning(
+                "Tessellation hit a GEOS topology error (%s); retrying with coarser "
+                "grid_size=1e-3.",
+                e,
+            )
+            try:
+                tessellation = _run_enclosed_tessellation(grid_size=1e-3)
+            except shapely.errors.GEOSException:
+                logger.warning(
+                    "Tessellation still failed at coarser precision; returning empty "
+                    "tessellation for this unit.",
+                )
+                return _create_empty_tessellation(geometry.crs, include_tess_id=False)
     else:
         tessellation = _create_empty_tessellation(geometry.crs, include_tess_id=False)
 

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -379,11 +379,15 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             crs=sample_crs,
         )
 
+        # The "far" centroid at (3, 0) projects onto the segment endpoint (1, 0)
+        # with a 2.0 access leg; an ``extent_buffer`` below that access distance
+        # excludes it, while "near" sits on the segment (zero access).
         filtered = _filter_tessellation_by_network_distance(
             tessellation,
             segments,
             Point(0, 0),
             2.2,
+            extent_buffer=1.0,
         )
 
         assert list(filtered["private_id"]) == ["near"]
@@ -486,7 +490,6 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             keep_buildings=True,
             private_id_col="private_id",
             include_unenclosed_buildings=True,
-            network_segments=segments,
         )
 
         assert set(tessellation["building_id"].dropna()) == {"enclosed", "near_missing"}
@@ -638,10 +641,111 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         private_ids = set(nodes["private"].index)
         faced_private_ids = set(faced.index.get_level_values(0)) if not faced.empty else set()
 
-        # The "isolated" cell is reachable by centroid projection but faces no
-        # street, so it receives a nearest public fallback faced_to edge.
+        # The "isolated" cell sits 30 m from the street, within the default
+        # extent_buffer (50 m), so it receives a nearest public fallback
+        # faced_to edge and is kept rather than pruned.
         assert private_ids == {"near", "isolated"}
         assert private_ids <= faced_private_ids
+
+    def test_extent_buffer_drops_cells_beyond_access_cap(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cell whose only reachable street is farther than extent_buffer is dropped.
+
+        Reproduces the E01006640 symptom: a cell reachable along the network but
+        separated from the only retained street by a long straight-line access
+        leg. The old summed budget (network + access) retained it; the two-cap
+        rule rejects it because the access distance exceeds ``extent_buffer``.
+        """
+        near = Polygon([(49, 1), (51, 1), (51, 3), (49, 3)])  # centroid (50, 2), 2 m access
+        far = Polygon([(49, 59), (51, 59), (51, 61), (49, 61)])  # centroid (50, 60), 60 m access
+        buildings = gpd.GeoDataFrame(geometry=[near, far], crs=sample_crs)
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (100, 0)])],
+            crs=sample_crs,
+        )
+
+        def fake_create_tessellation(
+            geometry: gpd.GeoDataFrame,
+            primary_barriers: gpd.GeoDataFrame | None = None,
+        ) -> gpd.GeoDataFrame:
+            _ = (geometry, primary_barriers)
+            return gpd.GeoDataFrame(
+                {"tess_id": ["near", "far"], "enclosure_index": [0, 0]},
+                geometry=[near, far],
+                crs=sample_crs,
+            )
+
+        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+
+        # distance budget (150) would admit "far" under a summed network+access
+        # cost (50 + 60 = 110); the access cap (50) is what excludes it.
+        nodes, edges = morphological_graph(
+            buildings,
+            segments,
+            center_point=Point(0, 0),
+            distance=150.0,
+            clipping_buffer=200.0,
+            extent_buffer=50.0,
+        )
+
+        private_ids = set(nodes["private"].index)
+        faced = edges[("private", "faced_to", "public")]
+        faced_private_ids = set(faced.index.get_level_values(0)) if not faced.empty else set()
+
+        assert private_ids == {"near"}
+        assert "far" not in faced_private_ids
+
+    def test_extent_buffer_validation(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """extent_buffer must be non-negative and not exceed clipping_buffer."""
+        with pytest.raises(ValueError, match="clipping_buffer must be greater"):
+            morphological_graph(
+                sample_buildings_gdf,
+                sample_segments_gdf,
+                clipping_buffer=10.0,
+                extent_buffer=50.0,
+            )
+        with pytest.raises(ValueError, match="extent_buffer cannot be negative"):
+            morphological_graph(
+                sample_buildings_gdf,
+                sample_segments_gdf,
+                extent_buffer=-1.0,
+            )
+
+    def test_private_to_public_respects_max_connection_distance(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """Fallback connections farther than max_connection_distance are not created."""
+        private_gdf = gpd.GeoDataFrame(
+            {"private_id": ["near", "far"]},
+            geometry=[
+                Polygon([(0, 1), (2, 1), (2, 3), (0, 3)]),  # 1 m from the segment
+                Polygon([(0, 100), (2, 100), (2, 102), (0, 102)]),  # 100 m from the segment
+            ],
+            crs=sample_crs,
+        )
+        public_gdf = gpd.GeoDataFrame(
+            {"public_id": [0]},
+            geometry=[LineString([(0, 0), (50, 0)])],
+            crs=sample_crs,
+        )
+
+        _, edges = private_to_public_graph(
+            private_gdf,
+            public_gdf,
+            max_connection_distance=10.0,
+        )
+
+        connected = set(edges["private_id"]) if not edges.empty else set()
+        assert "near" in connected
+        assert "far" not in connected
 
     def test_networkx_conversion(
         self,

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1,6 +1,7 @@
 """Refactored test module for morphology.py with improved maintainability and reduced redundancy."""
 
 import logging
+import math
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -13,6 +14,11 @@ from shapely.geometry import LineString
 from shapely.geometry import Point
 from shapely.geometry import Polygon
 
+from city2graph.morphology import _create_and_filter_tessellation
+from city2graph.morphology import _filter_buildings_by_network_distance
+from city2graph.morphology import _filter_tessellation_by_network_distance
+from city2graph.morphology import _include_unenclosed_building_tessellation
+from city2graph.morphology import _segments_within_network_distance
 from city2graph.morphology import morphological_graph
 from city2graph.morphology import private_to_private_graph
 from city2graph.morphology import private_to_public_graph
@@ -142,7 +148,7 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             predicate: str,
         ) -> gpd.GeoDataFrame:
             assert how == "left"
-            assert predicate == "intersects"
+            assert predicate == "contains"
             return tessellation.copy()
 
         monkeypatch.setattr("city2graph.morphology.gpd.sjoin", fake_sjoin)
@@ -154,6 +160,337 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         )
 
         assert "building_geometry" in nodes["private"].columns
+
+    def test_include_unenclosed_buildings_is_opt_in(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Buildings missed by enclosed tessellation are only added when requested."""
+        buildings = gpd.GeoDataFrame(
+            {"building_id": ["inside", "unenclosed"]},
+            geometry=[
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(10, 0), (11, 0), (11, 1), (10, 1)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(-1, -1), (2, -1)])],
+            crs=sample_crs,
+        )
+
+        def fake_create_tessellation(
+            geometry: gpd.GeoDataFrame,
+            primary_barriers: gpd.GeoDataFrame | None = None,
+        ) -> gpd.GeoDataFrame:
+            if primary_barriers is not None:
+                return gpd.GeoDataFrame(
+                    {"tess_id": ["enclosed"], "enclosure_index": [0]},
+                    geometry=[geometry.geometry.iloc[0]],
+                    crs=sample_crs,
+                )
+            msg = "fallback should not create a non-local tessellation"
+            raise AssertionError(msg)
+
+        def passthrough_filter(
+            tessellation: gpd.GeoDataFrame,
+            _segments: gpd.GeoDataFrame,
+            max_distance: float = float("inf"),
+        ) -> gpd.GeoDataFrame:
+            _ = max_distance
+            return tessellation
+
+        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology._filter_adjacent_tessellation",
+            passthrough_filter,
+        )
+
+        default_nodes, _ = morphological_graph(buildings, segments, keep_buildings=True)
+        opt_in_nodes, _ = morphological_graph(
+            buildings,
+            segments,
+            keep_buildings=True,
+            include_unenclosed_buildings=True,
+        )
+
+        assert len(default_nodes["private"]) == 1
+        assert len(opt_in_nodes["private"]) == 2
+        assert "fallback_1" in opt_in_nodes["private"].index
+
+    def test_morphological_graph_passes_tessellation_limit(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Custom enclosure limits should propagate to tessellation creation."""
+        custom_limit = Polygon([(-10, -10), (10, -10), (10, 10), (-10, 10)])
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(-1, 0), (2, 0)])],
+            crs=sample_crs,
+        )
+        captured: dict[str, object] = {}
+
+        def fake_create_tessellation(
+            geometry: gpd.GeoDataFrame,
+            primary_barriers: gpd.GeoDataFrame | None = None,
+            **kwargs: object,
+        ) -> gpd.GeoDataFrame:
+            _ = (geometry, primary_barriers)
+            captured["limit"] = kwargs.get("limit")
+            return gpd.GeoDataFrame(
+                {"tess_id": ["cell"], "enclosure_index": [0]},
+                geometry=[buildings.geometry.iloc[0]],
+                crs=sample_crs,
+            )
+
+        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+
+        morphological_graph(buildings, segments, limit=custom_limit)
+
+        assert captured["limit"] is custom_limit
+
+    def test_include_unenclosed_buildings_uses_prefiltered_fallback_buildings(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Fallback tessellation should use the buildings already selected for graph inclusion."""
+        buildings = gpd.GeoDataFrame(
+            {"building_id": ["enclosed", "near_missing", "far_missing"]},
+            geometry=[
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(2, 0), (3, 0), (3, 1), (2, 1)]),
+                Polygon([(9, 0), (10, 0), (10, 1), (9, 1)]),
+            ],
+            crs=sample_crs,
+        )
+        tessellation = gpd.GeoDataFrame(
+            {"private_id": ["enclosed"], "enclosure_index": [0]},
+            geometry=[buildings.geometry.iloc[0]],
+            crs=sample_crs,
+        )
+
+        def fake_create_tessellation(
+            geometry: gpd.GeoDataFrame,
+            primary_barriers: gpd.GeoDataFrame | None = None,
+        ) -> gpd.GeoDataFrame:
+            _ = (geometry, primary_barriers)
+            msg = "fallback should not create a non-local tessellation"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+
+        result = _include_unenclosed_building_tessellation(
+            tessellation,
+            buildings.iloc[:2],
+            "private_id",
+        )
+
+        assert list(result["private_id"]) == ["enclosed", "fallback_1"]
+
+    def test_keep_buildings_excludes_distance_filtered_buildings_from_fallback_cells(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Large fallback cells must not reattach buildings filtered out by distance."""
+        buildings = gpd.GeoDataFrame(
+            {"building_id": ["enclosed", "near_missing", "far_outside"]},
+            geometry=[
+                Polygon([(0, 0), (0.5, 0), (0.5, 0.5), (0, 0.5)]),
+                Polygon([(1, 0), (1.5, 0), (1.5, 0.5), (1, 0.5)]),
+                Polygon([(4, 0), (4.5, 0), (4.5, 0.5), (4, 0.5)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (5, 0)])],
+            crs=sample_crs,
+        )
+
+        def fake_create_tessellation(
+            geometry: gpd.GeoDataFrame,
+            primary_barriers: gpd.GeoDataFrame | None = None,
+        ) -> gpd.GeoDataFrame:
+            if primary_barriers is not None:
+                return gpd.GeoDataFrame(
+                    {"tess_id": ["enclosed"], "enclosure_index": [0]},
+                    geometry=[geometry.geometry.iloc[0]],
+                    crs=sample_crs,
+                )
+            return gpd.GeoDataFrame(
+                {"tess_id": geometry.index.to_list()},
+                geometry=[Polygon([(0.75, -1), (5, -1), (5, 2), (0.75, 2)])],
+                crs=sample_crs,
+            )
+
+        def passthrough_filter(
+            tessellation: gpd.GeoDataFrame,
+            _segments: gpd.GeoDataFrame,
+            max_distance: float = float("inf"),
+        ) -> gpd.GeoDataFrame:
+            _ = max_distance
+            return tessellation
+
+        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology._filter_adjacent_tessellation",
+            passthrough_filter,
+        )
+        monkeypatch.setattr(
+            "city2graph.morphology._filter_tessellation_by_network_distance",
+            lambda tessellation, *_args, **_kwargs: tessellation,
+        )
+
+        nodes, _ = morphological_graph(
+            buildings,
+            segments,
+            center_point=Point(0, 0),
+            distance=2.0,
+            keep_buildings=True,
+            include_unenclosed_buildings=True,
+        )
+
+        attached_ids = set(nodes["private"]["building_id"].dropna())
+        assert attached_ids == {"enclosed", "near_missing"}
+        assert "far_outside" not in attached_ids
+
+    def test_network_distance_filter_does_not_use_centroid_shortcuts(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """Private cells should not make distant cells reachable through centroid-to-centroid edges."""
+        tessellation = gpd.GeoDataFrame(
+            {"private_id": ["near", "far"]},
+            geometry=[
+                Polygon([(0.9, -0.1), (1.1, -0.1), (1.1, 0.1), (0.9, 0.1)]),
+                Polygon([(2.9, -0.1), (3.1, -0.1), (3.1, 0.1), (2.9, 0.1)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (1, 0)])],
+            crs=sample_crs,
+        )
+
+        filtered = _filter_tessellation_by_network_distance(
+            tessellation,
+            segments,
+            Point(0, 0),
+            2.2,
+        )
+
+        assert list(filtered["private_id"]) == ["near"]
+
+    def test_network_distance_projects_center_and_private_cells_to_segments(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """A center and private cell near the middle of a long segment should use the segment."""
+        tessellation = gpd.GeoDataFrame(
+            {"private_id": ["near_midpoint", "too_far"]},
+            geometry=[
+                Polygon([(59, 0), (61, 0), (61, 2), (59, 2)]),
+                Polygon([(89, 0), (91, 0), (91, 2), (89, 2)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (100, 0)])],
+            crs=sample_crs,
+        )
+
+        filtered = _filter_tessellation_by_network_distance(
+            tessellation,
+            segments,
+            Point(50, 0),
+            12.0,
+        )
+
+        assert list(filtered["private_id"]) == ["near_midpoint"]
+
+    def test_building_network_distance_uses_segment_projection(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """Buildings should be selected by distance to the nearest point on a segment."""
+        buildings = gpd.GeoDataFrame(
+            {"building_id": ["near_midpoint", "too_far"]},
+            geometry=[
+                Polygon([(59, 0), (61, 0), (61, 2), (59, 2)]),
+                Polygon([(89, 0), (91, 0), (91, 2), (89, 2)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (100, 0)])],
+            crs=sample_crs,
+        )
+
+        filtered = _filter_buildings_by_network_distance(
+            buildings,
+            segments,
+            Point(50, 0),
+            12.0,
+        )
+
+        assert list(filtered["building_id"]) == ["near_midpoint"]
+
+    def test_unenclosed_fallback_uses_projected_network_distance(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Fallback cells should include unenclosed buildings reachable along segment middles."""
+        buildings = gpd.GeoDataFrame(
+            {"building_id": ["enclosed", "near_missing", "far_missing"]},
+            geometry=[
+                Polygon([(49, 0), (51, 0), (51, 2), (49, 2)]),
+                Polygon([(59, 0), (61, 0), (61, 2), (59, 2)]),
+                Polygon([(89, 0), (91, 0), (91, 2), (89, 2)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (100, 0)])],
+            crs=sample_crs,
+        )
+
+        def fake_create_tessellation(
+            geometry: gpd.GeoDataFrame,
+            primary_barriers: gpd.GeoDataFrame | None = None,
+        ) -> gpd.GeoDataFrame:
+            _ = primary_barriers
+            return gpd.GeoDataFrame(
+                {"tess_id": ["enclosed"], "enclosure_index": [0]},
+                geometry=[geometry.geometry.iloc[0]],
+                crs=sample_crs,
+            )
+
+        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+
+        tessellation = _create_and_filter_tessellation(
+            buildings,
+            segments,
+            segments,
+            "geometry",
+            12.0,
+            math.inf,
+            Point(50, 0),
+            keep_buildings=True,
+            private_id_col="private_id",
+            include_unenclosed_buildings=True,
+            network_segments=segments,
+        )
+
+        assert set(tessellation["building_id"].dropna()) == {"enclosed", "near_missing"}
+        assert "fallback_1" in set(tessellation["private_id"])
 
     def test_distance_filter_handles_missing_center_node(
         self,
@@ -184,12 +521,13 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             _ = (segments, max_distance)
             return tessellation
 
-        def fake_find_closest_node_to_center(
-            graph: nx.Graph,
-            center_geom: gpd.GeoSeries | gpd.GeoDataFrame,
-        ) -> str:
-            _ = (graph, center_geom)
-            return "missing-node"
+        def fake_connect_point_to_nearest_edge(
+            _graph: nx.Graph,
+            _point_node_id: str,
+            _point: Point,
+            edge_records: list[tuple[Any, Any, LineString, float]],
+        ) -> tuple[tuple[Any, Any, LineString, float], float, float]:
+            return edge_records[0], 0.0, 0.0
 
         monkeypatch.setattr(
             "city2graph.morphology.create_tessellation",
@@ -200,8 +538,8 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             fake_filter_adjacent_tessellation,
         )
         monkeypatch.setattr(
-            "city2graph.morphology._find_closest_node_to_center",
-            fake_find_closest_node_to_center,
+            "city2graph.morphology._connect_point_to_nearest_edge",
+            fake_connect_point_to_nearest_edge,
         )
 
         nodes, _edges = morphological_graph(
@@ -212,6 +550,98 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         )
 
         assert nodes["private"].empty
+
+    def test_segments_use_same_reachability_field_as_cells(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """Street acceptance is derived from the same projected cost field as cells."""
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (50, 0)]), LineString([(50, 0), (100, 0)])],
+            crs=sample_crs,
+        )
+        tessellation = gpd.GeoDataFrame(
+            {"private_id": ["near", "far"]},
+            geometry=[
+                Polygon([(9, -1), (11, -1), (11, 1), (9, 1)]),
+                Polygon([(69, -1), (71, -1), (71, 1), (69, 1)]),
+            ],
+            crs=sample_crs,
+        )
+
+        kept_segments = _segments_within_network_distance(segments, Point(0, 0), 20.0)
+        kept_cells = _filter_tessellation_by_network_distance(
+            tessellation,
+            segments,
+            Point(0, 0),
+            20.0,
+        )
+
+        # The near segment (reachable from x=0) is kept; the far one (min endpoint
+        # cost 50) is dropped. The near cell (cost ~10) is kept while the far cell
+        # (cost ~70) is dropped, all from the single reachability metric.
+        assert len(kept_segments) == 1
+        assert list(kept_cells["private_id"]) == ["near"]
+
+    def test_segments_within_distance_keeps_boundary_straddling_segment(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """A segment whose near endpoint is within budget is kept whole, not dropped."""
+        segments = gpd.GeoDataFrame(
+            {"public_id": ["straddle", "beyond"]},
+            geometry=[LineString([(0, 0), (50, 0)]), LineString([(50, 0), (100, 0)])],
+            crs=sample_crs,
+        )
+
+        kept = _segments_within_network_distance(segments, Point(0, 0), 20.0)
+
+        # "straddle" spans x=0..50 and crosses the 20 budget boundary yet is kept
+        # whole because its reachable portion is within budget; "beyond" is dropped.
+        assert list(kept["public_id"]) == ["straddle"]
+
+    def test_morphological_graph_has_no_isolated_private_nodes(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reachability-budgeted output never contains a private cell without a faced_to edge."""
+        near = Polygon([(4, -1), (6, -1), (6, 0), (4, 0)])
+        isolated = Polygon([(4, 29), (6, 29), (6, 31), (4, 31)])
+        buildings = gpd.GeoDataFrame(geometry=[near, isolated], crs=sample_crs)
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (20, 0)])],
+            crs=sample_crs,
+        )
+
+        def fake_create_tessellation(
+            geometry: gpd.GeoDataFrame,
+            primary_barriers: gpd.GeoDataFrame | None = None,
+        ) -> gpd.GeoDataFrame:
+            _ = (geometry, primary_barriers)
+            return gpd.GeoDataFrame(
+                {"tess_id": ["near", "isolated"], "enclosure_index": [0, 0]},
+                geometry=[near, isolated],
+                crs=sample_crs,
+            )
+
+        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+
+        nodes, edges = morphological_graph(
+            buildings,
+            segments,
+            center_point=Point(0, 0),
+            distance=50.0,
+        )
+
+        faced = edges[("private", "faced_to", "public")]
+        private_ids = set(nodes["private"].index)
+        faced_private_ids = set(faced.index.get_level_values(0)) if not faced.empty else set()
+
+        # The "isolated" cell is reachable by centroid projection but faces no
+        # street, so it receives a nearest public fallback faced_to edge.
+        assert private_ids == {"near", "isolated"}
+        assert private_ids <= faced_private_ids
 
     def test_networkx_conversion(
         self,
@@ -490,8 +920,11 @@ class TestIndividualGraphFunctions(TestMorphologyBase):
         with pytest.raises(ValueError, match="Expected ID column 'public_id' not found"):
             private_to_public_graph(private_with_id, public_no_id)
 
-    def test_private_to_public_empty_join_result(self, sample_crs: str) -> None:
-        """Test case where spatial join produces no results."""
+    def test_private_to_public_nearest_fallback_for_empty_join_result(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """Private spaces missed by dwithin should connect to the nearest public segment."""
         # Create non-overlapping geometries that won't intersect
         private_gdf = make_grid_polygons_gdf(1, 1, crs=sample_crs)
         private_gdf = private_gdf.reset_index().rename(columns={"id": "private_id"})
@@ -502,9 +935,21 @@ class TestIndividualGraphFunctions(TestMorphologyBase):
         )
 
         nodes, edges = private_to_public_graph(private_gdf, public_gdf, tolerance=0.1)
-        # Should return empty edges but combined nodes
-        assert edges.empty
+        assert not edges.empty
+        assert set(edges["private_id"]) == set(private_gdf["private_id"])
+        assert set(edges["public_id"]) == {1}
         assert len(nodes) == 2  # Both private and public nodes combined
+
+    def test_private_to_public_empty_public_stays_empty(self, sample_crs: str) -> None:
+        """Nearest fallback should not change empty-public behavior."""
+        private_gdf = make_grid_polygons_gdf(1, 1, crs=sample_crs)
+        private_gdf = private_gdf.reset_index().rename(columns={"id": "private_id"})
+        public_gdf = gpd.GeoDataFrame({"public_id": []}, geometry=[], crs=sample_crs)
+
+        nodes, edges = private_to_public_graph(private_gdf, public_gdf, tolerance=0.1)
+
+        assert edges.empty
+        assert len(nodes) == 1
 
     # Public-to-Public Tests
     def test_public_to_public_basic(self, sample_segments_gdf: gpd.GeoDataFrame) -> None:
@@ -631,7 +1076,7 @@ class TestInputValidationAndErrors(TestMorphologyBase):
                 for msg in warning_messages
                 if "Source node for distance filtering not found" in msg
             ]
-            # Since the str() cast bug is fixed, KDTree always returns a valid node ID
+            # The projection helper snaps the source to an edge when graph context exists.
             assert len(distance_warnings) == 0
 
         # Should still return valid (possibly empty) results

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -14,6 +14,7 @@ from shapely.geometry import LineString
 from shapely.geometry import Point
 from shapely.geometry import Polygon
 
+import city2graph.morphology as morph
 from city2graph.morphology import _create_and_filter_tessellation
 from city2graph.morphology import _filter_buildings_by_network_distance
 from city2graph.morphology import _filter_tessellation_by_network_distance
@@ -1494,3 +1495,116 @@ class TestSpecialScenarios(TestMorphologyBase):
         except KeyError:
             # Expected if no connections are found, but MultiIndex code was still executed
             pass
+
+
+class TestReachabilityFieldRefactor(TestMorphologyBase):
+    """Invariants introduced by the shared reachability-field refactor."""
+
+    def test_reachability_field_computed_once(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        mg_center_point: gpd.GeoSeries,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A budgeted morphological_graph computes the cost field exactly once.
+
+        Previously the field was recomputed independently for segments, buildings
+        and cells (up to three Dijkstra/snap passes). It must now be built once on
+        the full network and shared across all node types.
+        """
+        original = morph._network_reachability_field
+        calls = {"n": 0}
+
+        def counting(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            calls["n"] += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(morph, "_network_reachability_field", counting)
+
+        morphological_graph(
+            sample_buildings_gdf,
+            sample_segments_gdf,
+            center_point=mg_center_point,
+            distance=100.0,
+        )
+
+        assert calls["n"] == 1
+
+    def test_shared_field_reaches_cell_and_building_filters(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        mg_center_point: gpd.GeoSeries,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The single full-network field is threaded into the centroid filters.
+
+        This locks in the fix for the full-vs-truncated network discrepancy:
+        buildings and cells are judged against the same field used for streets,
+        not one rebuilt on the already-truncated segments.
+        """
+        original = morph._geometry_ilocs_within_network_distance
+        seen_fields: list[object] = []
+
+        def recording(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            seen_fields.append(kwargs.get("field"))
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(morph, "_geometry_ilocs_within_network_distance", recording)
+
+        morphological_graph(
+            sample_buildings_gdf,
+            sample_segments_gdf,
+            center_point=mg_center_point,
+            distance=100.0,
+        )
+
+        # The centroid filters (buildings + cells) ran and every one received the
+        # shared field instance rather than None.
+        assert seen_fields
+        assert all(field is not None for field in seen_fields)
+        assert len({id(field) for field in seen_fields}) == 1
+
+    def test_geographic_crs_emits_warning(self) -> None:
+        """Distance params are metric, so a geographic CRS input must warn the user.
+
+        Exercised through ``private_to_public_graph`` because it shares the CRS
+        chokepoint (``_ensure_crs_consistency``) with ``morphological_graph`` but
+        does not invoke tessellation, which momepy refuses to run on a geographic
+        CRS.
+        """
+        private_gdf = gpd.GeoDataFrame(
+            {"private_id": [0]},
+            geometry=[Polygon([(0, 0), (0, 0.001), (0.001, 0.001), (0.001, 0)])],
+            crs="EPSG:4326",
+        )
+        public_gdf = gpd.GeoDataFrame(
+            {"public_id": [10]},
+            geometry=[LineString([(0, 0), (0.001, 0.001)])],
+            crs="EPSG:4326",
+        )
+
+        with pytest.warns(UserWarning, match="geographic CRS"):
+            private_to_public_graph(private_gdf, public_gdf)
+
+    def test_projected_crs_does_not_emit_geographic_warning(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """A projected CRS input must not raise the geographic-CRS warning."""
+        private_gdf = gpd.GeoDataFrame(
+            {"private_id": [0]},
+            geometry=[Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])],
+            crs=sample_crs,
+        )
+        public_gdf = gpd.GeoDataFrame(
+            {"public_id": [10]},
+            geometry=[LineString([(0, 0), (1, 1)])],
+            crs=sample_crs,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            # Should not raise: inputs are in EPSG:27700 (projected).
+            private_to_public_graph(private_gdf, public_gdf)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -223,6 +223,79 @@ class TestTessellation(BaseGraphTest):
         assert list(result.columns) == ["geometry", "enclosure_index", "tess_id"]
         assert "returning empty GeoDataFrame" in caplog.text
 
+    def test_enclosed_tessellation_passes_explicit_limit(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Explicit enclosure limits should be forwarded to momepy.enclosures."""
+        custom_limit = Polygon([(-10, -10), (10, -10), (10, 10), (-10, 10)])
+        captured: dict[str, object] = {}
+
+        def fake_enclosures(**kwargs: object) -> gpd.GeoDataFrame:
+            captured["limit"] = kwargs["limit"]
+            return gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[custom_limit],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        def fake_enclosed_tessellation(**_kwargs: object) -> gpd.GeoDataFrame:
+            return gpd.GeoDataFrame(
+                {"enclosure_index": [1]},
+                geometry=[sample_buildings_gdf.geometry.iloc[0]],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        monkeypatch.setattr(momepy, "enclosures", fake_enclosures)
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        result = utils.create_tessellation(
+            sample_buildings_gdf,
+            primary_barriers=sample_segments_gdf,
+            limit=custom_limit,
+        )
+
+        assert captured["limit"] is custom_limit
+        assert not result.empty
+
+    def test_enclosed_tessellation_computes_default_limit(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-empty buffered hull limit should be computed when none is supplied."""
+        captured: dict[str, object] = {}
+
+        def fake_enclosures(**kwargs: object) -> gpd.GeoDataFrame:
+            captured["limit"] = kwargs["limit"]
+            return gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[kwargs["limit"]],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        def fake_enclosed_tessellation(**_kwargs: object) -> gpd.GeoDataFrame:
+            return gpd.GeoDataFrame(
+                {"enclosure_index": [1]},
+                geometry=[sample_buildings_gdf.geometry.iloc[0]],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        monkeypatch.setattr(momepy, "enclosures", fake_enclosures)
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        result = utils.create_tessellation(
+            sample_buildings_gdf, primary_barriers=sample_segments_gdf
+        )
+
+        limit = captured["limit"]
+        assert isinstance(limit, Polygon)
+        assert not limit.is_empty
+        assert not result.empty
+
 
 # ============================================================================
 # GRAPH STRUCTURE TESTS

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import rustworkx as rx
+import shapely.errors
 from shapely.geometry import LineString
 from shapely.geometry import MultiLineString
 from shapely.geometry import Point
@@ -222,6 +223,188 @@ class TestTessellation(BaseGraphTest):
         assert result.empty
         assert list(result.columns) == ["geometry", "enclosure_index", "tess_id"]
         assert "returning empty GeoDataFrame" in caplog.text
+
+    def test_enclosed_tessellation_retries_without_simplify_on_geometry_type_error(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A coverage_simplify TypeError should trigger a retry with simplify=False."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        calls: list[object] = []
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append(kwargs.get("simplify"))
+            if kwargs.get("simplify") is not False:
+                msg = "One of the Geometry inputs is of incorrect geometry type."
+                raise TypeError(msg)
+            return gpd.GeoDataFrame(
+                {"enclosure_index": [1]},
+                geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+                index=[0],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert not result.empty
+        assert "tess_id" in result.columns
+        assert calls[-1] is False  # retried with simplify=False
+        assert "retrying with simplify=False" in caplog.text
+
+    def test_enclosed_tessellation_reraises_unrelated_type_error(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A TypeError unrelated to coverage_simplify should propagate."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        def raise_unrelated(**_kwargs: object) -> gpd.GeoDataFrame:
+            msg = "something else entirely"
+            raise TypeError(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", raise_unrelated)
+
+        with pytest.raises(TypeError, match="something else entirely"):
+            utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+    def test_enclosed_tessellation_retries_with_coarser_grid_size_on_geos_error(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A GEOS topology error should trigger a retry with a coarser grid_size."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        calls: list[object] = []
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append(kwargs.get("grid_size"))
+            if kwargs.get("grid_size") is None:
+                msg = "TopologyException: side location conflict at 0 0"
+                raise shapely.errors.GEOSException(msg)
+            return gpd.GeoDataFrame(
+                {"enclosure_index": [1]},
+                geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+                index=[0],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert not result.empty
+        assert "tess_id" in result.columns
+        assert calls[-1] == 1e-3  # retried with coarser grid_size
+        assert "retrying with coarser" in caplog.text
+
+    def test_enclosed_tessellation_returns_empty_when_geos_error_persists(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A GEOS error that persists at coarser precision degrades to empty output."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        def always_raise(**_kwargs: object) -> gpd.GeoDataFrame:
+            msg = "TopologyException: side location conflict at 0 0"
+            raise shapely.errors.GEOSException(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", always_raise)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert result.empty
+        assert "returning empty" in caplog.text
+
+    def test_enclosed_tessellation_reraises_geos_error_with_explicit_grid_size(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the caller pins grid_size, a GEOS error must propagate unchanged."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        def raise_geos(**_kwargs: object) -> gpd.GeoDataFrame:
+            msg = "TopologyException: side location conflict at 0 0"
+            raise shapely.errors.GEOSException(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", raise_geos)
+
+        with pytest.raises(shapely.errors.GEOSException, match="side location conflict"):
+            utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+                grid_size=1e-5,
+            )
 
     def test_enclosed_tessellation_passes_explicit_limit(
         self,


### PR DESCRIPTION
## Description

This pull request fixes tessellation coverage and distance filtering in `morphological_graph`, especially for cases where enclosed tessellation misses buildings near the edge of the street/barrier context or where private cells were retained through unrealistic straight-line access paths.

The main changes are:

- Adds `extent_buffer` to `morphological_graph` to separate walkable network distance from perpendicular street access distance. This prevents distant private cells from being kept because of long straight-line fallback connections.
- Adds optional `include_unenclosed_buildings` support so buildings missed by enclosed tessellation can be added via fallback tessellation when explicitly requested.
- Adds a `limit` parameter to `morphological_graph` and `create_tessellation`, forwarding custom enclosure limits to `momepy.enclosures`.
- Reworks network-distance filtering so segments, buildings, and tessellation cells share a single reachability field computed once on the full street network.
- Caps nearest public fallback edges in `private_to_public_graph` with `max_connection_distance`, avoiding long star-shaped `faced_to` edges.
- Improves enclosed tessellation resilience by retrying known momepy/Shapely failure modes:
  - retry without simplification for geometry type errors;
  - retry with a coarser `grid_size` for GEOS topology errors;
  - return an empty tessellation when the retry still fails.
- Adds warnings for geographic CRS inputs where metric distance parameters would be unreliable.
- Adds tests covering the new tessellation fallback behavior, shared reachability filtering, extent-buffer validation, private-to-public fallback limits, geographic CRS warnings, and tessellation retry paths.

## Related Issues

Not linked to an existing issue.

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.