### PR TITLE
Set multigraph by default for `segments_to_graph()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Added
+- Added `canonicalize_edges()` to collapse reciprocal `(u, v)` / `(v, u)` rows and parallel duplicates in edge GeoDataFrames, with `duplicates="first" | "key" | "error"` handling.
+- Added a `directed` parameter to `segments_to_graph()`; `directed=False` canonicalizes each edge to an unordered `(min, max)` node-id order so reverse-drawn duplicate segments become parallel edges of one unordered pair.
+
+### Changed
+- **Breaking:** `segments_to_graph()` now defaults to `multigraph=True`, returning a three-level `(from_node_id, to_node_id, edge_key)` MultiIndex (and an `nx.MultiGraph` when `as_nx=True`). With `multigraph=False`, duplicate node pairs now raise a `ValueError` instead of silently returning a duplicated MultiIndex.
+- Improved the undirected validation errors in `gdf_to_pyg()`: they now report the total number of affected node pairs with examples, explain the typical cause (reciprocal rows from directed sources such as OSMnx), and point to `canonicalize_edges()` as a remedy.
+
+### Fixed
+- Fixed `segments_to_graph()` ignoring `as_nx=True` for empty inputs; it now returns an empty NetworkX graph instead of a tuple, and empty outputs carry properly named indexes.
+- Fixed `segments_to_graph(multigraph=True, as_nx=True)` silently collapsing parallel edges by returning an `nx.Graph`; it now returns an `nx.MultiGraph`.
+
+
 ## 0.3.1 (2026-03-21)
 
 ### Added

--- a/city2graph/graph.py
+++ b/city2graph/graph.py
@@ -84,6 +84,58 @@ DEVICE_ERROR_MSG = "Device must be 'cuda', 'cpu', a torch.device object, or None
 GRAPH_NO_NODES_MSG = "Graph has no nodes"
 
 
+def _unique_unordered_pairs(srcs: list[Any], dsts: list[Any]) -> list[tuple[Any, Any]]:
+    """
+    Collect unique unordered node pairs from parallel source/target lists.
+
+    Pairs differing only in orientation (``(u, v)`` vs ``(v, u)``) are reported
+    once, in the orientation of their first appearance.
+
+    Parameters
+    ----------
+    srcs : list[Any]
+        Source node identifiers.
+    dsts : list[Any]
+        Target node identifiers.
+
+    Returns
+    -------
+    list[tuple[Any, Any]]
+        Unique unordered pairs in first-appearance order.
+    """
+    seen: set[tuple[str, str]] = set()
+    unique: list[tuple[Any, Any]] = []
+    for u, v in zip(srcs, dsts, strict=True):
+        key = (str(u), str(v)) if str(u) <= str(v) else (str(v), str(u))
+        if key not in seen:
+            seen.add(key)
+            unique.append((u, v))
+    return unique
+
+
+def _format_pair_examples(pairs: list[tuple[Any, Any]], limit: int = 3) -> str:
+    """
+    Format up to ``limit`` node pairs for use in validation error messages.
+
+    Renders each pair as ``(u, v)`` and joins them with commas, appending an
+    ellipsis when more pairs exist than the limit allows.
+
+    Parameters
+    ----------
+    pairs : list[tuple[Any, Any]]
+        Unordered node pairs to format.
+    limit : int, default 3
+        Maximum number of pairs to include.
+
+    Returns
+    -------
+    str
+        Comma-separated pair examples, with an ellipsis when truncated.
+    """
+    examples = ", ".join(f"({u}, {v})" for u, v in pairs[:limit])
+    return f"{examples}, ..." if len(pairs) > limit else examples
+
+
 # ============================================================================
 # GRAPH CONVERSION FUNCTIONS
 # ============================================================================
@@ -1057,13 +1109,20 @@ class PyGConverter(BaseGraphConverter):
         reverse_pairs = unique_pairs.rename(columns={"src": "dst", "dst": "src"})
         bidirectional = unique_pairs.merge(reverse_pairs, on=merge_cols, how="inner")
         if not bidirectional.empty:
-            s = bidirectional.iloc[0]["src"]
-            d = bidirectional.iloc[0]["dst"]
+            unordered = _unique_unordered_pairs(
+                bidirectional["src"].tolist(), bidirectional["dst"].tolist()
+            )
             et_label = f" for edge type {edge_type}" if edge_type else ""
             msg = (
-                f"Ambiguous undirected input{et_label}: both ({s}, {d}) and "
-                f"({d}, {s}) are present. Pass directed=True for directed edges, "
-                f"or provide only one row per undirected edge."
+                f"Ambiguous undirected input{et_label}: {len(unordered)} node "
+                f"pair(s) appear in both directions, e.g. "
+                f"{_format_pair_examples(unordered)}. This typically happens "
+                f"when edges come from a directed source such as an OSMnx "
+                f"MultiDiGraph, where two-way streets are stored as reciprocal "
+                f"(u, v) and (v, u) rows. Pass directed=True to keep them as "
+                f"directed edges, or collapse them to one row per undirected "
+                f"edge with city2graph.canonicalize_edges(edges) before "
+                f"conversion."
             )
             raise ValueError(msg)
 
@@ -1071,10 +1130,10 @@ class PyGConverter(BaseGraphConverter):
         # unordered pair. In multigraph inputs it is (unordered pair, edge key),
         # so distinct parallel keys are first-class edges.
         if not non_loop_pairs.empty:
-            id_codes = pd.factorize(
+            id_codes, id_values = pd.factorize(
                 pd.concat([pairs["src"], pairs["dst"]], ignore_index=True),
                 sort=False,
-            )[0]
+            )
             src_codes = id_codes[: len(pairs)]
             dst_codes = id_codes[len(pairs) :]
             non_loop_mask = (pairs["src"] != pairs["dst"]).to_numpy()
@@ -1086,20 +1145,27 @@ class PyGConverter(BaseGraphConverter):
             )
             if "key" in pairs:
                 canonical["key_2"] = pairs.loc[non_loop_mask, "key"].to_numpy()
-            has_parallel = bool(canonical.duplicated(keep=False).any())
+            duplicated_mask = canonical.duplicated(keep=False)
         else:
-            has_parallel = False
+            duplicated_mask = pd.Series(dtype=bool)
 
-        if has_parallel:
+        if duplicated_mask.any():
+            dup_rows = canonical[duplicated_mask]
+            dup_pairs = _unique_unordered_pairs(
+                id_values.take(dup_rows["key_0"].to_numpy()).tolist(),
+                id_values.take(dup_rows["key_1"].to_numpy()).tolist(),
+            )
             et_label = f" for edge type {edge_type}" if edge_type else ""
             msg = (
-                f"Parallel undirected edges detected{et_label}. "
-                f"Round-trip reconstruction cannot safely preserve multiple "
-                f"geometries/attributes for the same unordered pair without "
-                f"explicit multigraph support. Provide a three-level "
-                f"(source, target, key) index, pass multigraph=True to "
-                f"generate keys, or pass directed=True to keep parallel edges "
-                f"as directed rows."
+                f"Parallel undirected edges detected{et_label}: "
+                f"{len(dup_rows)} row(s) across {len(dup_pairs)} unordered "
+                f"node pair(s) share the same key, e.g. "
+                f"{_format_pair_examples(dup_pairs)}. Round-trip "
+                f"reconstruction cannot preserve multiple geometries/attributes "
+                f"per pair. Provide a three-level (source, target, key) index "
+                f"or pass multigraph=True to keep parallel edges, pass "
+                f"directed=True to treat rows as directed, or deduplicate with "
+                f"city2graph.canonicalize_edges(edges, duplicates='first')."
             )
             raise ValueError(msg)
 

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -773,7 +773,8 @@ def public_to_public_graph(
 
 def segments_to_graph(
     segments_gdf: gpd.GeoDataFrame,
-    multigraph: bool = False,
+    multigraph: bool = True,
+    directed: bool = True,
     as_nx: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph | nx.MultiGraph:
     r"""
@@ -787,19 +788,34 @@ def segments_to_graph(
     and end points of the input line segments. The edges GeoDataFrame is a copy
     of the input, but with a new MultiIndex (`from_node_id`, `to_node_id`) that
     references the IDs in the new nodes GeoDataFrame. If `multigraph` is True
-    and there are multiple edges between the same pair of nodes, an additional
-    index level (`edge_key`) is added to distinguish them.
+    (the default), an additional index level (`edge_key`) distinguishes multiple
+    edges between the same pair of nodes.
 
     Parameters
     ----------
     segments_gdf : geopandas.GeoDataFrame
         A GeoDataFrame where each row represents a line segment, and the
         'geometry' column contains LineString objects.
-    multigraph : bool, default False
+    multigraph : bool, default True
         If True, supports multiple edges between the same pair of nodes by
-        adding an `edge_key` level to the MultiIndex. This is useful when
-        the input contains duplicate node-to-node connections that should
-        be preserved as separate edges.
+        adding an `edge_key` level to the MultiIndex. Real-world segment data
+        (e.g. from OSMnx) commonly contains parallel edges, so this is the
+        default. If False, duplicate node pairs raise a ``ValueError``.
+
+        .. versionchanged:: 0.4
+            The default changed from ``False`` to ``True``, and
+            ``multigraph=False`` now raises on duplicate node pairs instead
+            of silently returning a duplicated MultiIndex.
+    directed : bool, default True
+        If True, edge orientation follows the LineString draw order: the
+        first coordinate becomes `from_node_id` and the last becomes
+        `to_node_id`. If False, each non-self-loop edge is canonicalized to
+        an unordered ``(min, max)`` node-id order, so the same road drawn in
+        opposite directions yields parallel edges of one unordered pair
+        instead of reciprocal ``(u, v)`` / ``(v, u)`` rows. Geometries are
+        left unchanged; only the index order is normalized. Use
+        ``directed=False`` when the output feeds an undirected pipeline such
+        as ``gdf_to_pyg(..., directed=False)``.
     as_nx : bool, default False
         If True, returns a NetworkX graph instead of a tuple of GeoDataFrames.
 
@@ -812,6 +828,16 @@ def segments_to_graph(
         - edges_gdf: A GeoDataFrame of edges (LineStrings), with a MultiIndex
           mapping to the `node_id` in `nodes_gdf`. If `multigraph` is True,
           the index includes a third level (`edge_key`) for duplicate connections.
+
+    Raises
+    ------
+    ValueError
+        If ``multigraph=False`` and the segments contain duplicate node pairs
+        (after canonicalization when ``directed=False``).
+
+    See Also
+    --------
+    city2graph.canonicalize_edges : Collapse reciprocal/parallel edge rows.
 
     Examples
     --------
@@ -831,12 +857,12 @@ def segments_to_graph(
     0        POINT (0 0)
     1        POINT (1 1)
     2        POINT (1 0)
-                                    road_name   geometry
-    from_node_id to_node_id
-    0            1                  A           LINESTRING (0 0, 1 1)
-    1            2                  B           LINESTRING (1 1, 1 0)
+                                             road_name   geometry
+    from_node_id to_node_id edge_key
+    0            1          0                A           LINESTRING (0 0, 1 1)
+    1            2          0                B           LINESTRING (1 1, 1 0)
 
-    >>> # Example with duplicate connections (multigraph)
+    >>> # Duplicate connections become parallel edges with distinct keys
     >>> segments_with_duplicates = gpd.GeoDataFrame(
     ...     {"road_name": ["A", "B", "C"]},
     ...     geometry=[LineString([(0, 0), (1, 1)]),
@@ -844,7 +870,7 @@ def segments_to_graph(
     ...               LineString([(1, 1), (1, 0)])],
     ...     crs="EPSG:32633"
     ... )
-    >>> nodes_gdf, edges_gdf = segments_to_graph(segments_with_duplicates, multigraph=True)
+    >>> nodes_gdf, edges_gdf = segments_to_graph(segments_with_duplicates)
     >>> print(edges_gdf.index.names)
     ['from_node_id', 'to_node_id', 'edge_key']
     """
@@ -855,7 +881,14 @@ def segments_to_graph(
 
     if segments_clean is None or segments_clean.empty:
         empty_nodes = gpd.GeoDataFrame(columns=["geometry"], crs=segments_gdf.crs)
-        empty_edges = gpd.GeoDataFrame(columns=["geometry"], crs=segments_gdf.crs)
+        empty_nodes.index.name = "node_id"
+        empty_edges = gpd.GeoDataFrame(
+            columns=["geometry"],
+            crs=segments_gdf.crs,
+            index=pd.MultiIndex.from_arrays([[], []], names=["from_node_id", "to_node_id"]),
+        )
+        if as_nx:
+            return gdf_to_nx(nodes=empty_nodes, edges=empty_edges, multigraph=multigraph)
         return empty_nodes, empty_edges
 
     # Extract coordinates
@@ -884,6 +917,15 @@ def segments_to_graph(
     from_ids = start_coords.map(coord_to_id)
     to_ids = end_coords.map(coord_to_id)
 
+    if not directed:
+        # Canonicalize each edge to an unordered (min, max) node-id order so
+        # reverse-drawn duplicate segments share one unordered pair. The
+        # geometries themselves are left unchanged.
+        from_arr = from_ids.to_numpy()
+        to_arr = to_ids.to_numpy()
+        from_ids = pd.Series(np.minimum(from_arr, to_arr), index=from_ids.index)
+        to_ids = pd.Series(np.maximum(from_arr, to_arr), index=to_ids.index)
+
     edges_gdf = segments_clean.copy()
 
     if multigraph:
@@ -896,12 +938,22 @@ def segments_to_graph(
             names=["from_node_id", "to_node_id", "edge_key"],
         )
     else:
+        duplicated = pd.DataFrame({"from_id": from_ids, "to_id": to_ids}).duplicated()
+        if duplicated.any():
+            msg = (
+                f"Found {int(duplicated.sum())} duplicate node pair(s) with "
+                f"multigraph=False. Pass multigraph=True (the default) to keep "
+                f"them as parallel edges, or deduplicate the segments first."
+            )
+            raise ValueError(msg)
         edges_gdf.index = pd.MultiIndex.from_arrays(
             [from_ids, to_ids],
             names=["from_node_id", "to_node_id"],
         )
 
-    return gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf) if as_nx else (nodes_gdf, edges_gdf)
+    if as_nx:
+        return gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf, multigraph=multigraph)
+    return nodes_gdf, edges_gdf
 
 
 # ============================================================================

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -58,6 +58,7 @@ from .base import GraphMetadata
 
 # Public API definition
 __all__ = [
+    "canonicalize_edges",
     "clip_graph",
     "create_isochrone",
     "create_tessellation",
@@ -1877,6 +1878,151 @@ def dual_graph(
     if as_nx:
         return gdf_to_nx(dual_nodes, dual_edges)
     return dual_nodes, dual_edges
+
+
+def canonicalize_edges(
+    edges: gpd.GeoDataFrame,
+    duplicates: Literal["first", "key", "error"] = "first",
+) -> gpd.GeoDataFrame:
+    """
+    Canonicalize an edge GeoDataFrame to one deterministic row per undirected pair.
+
+    Reorders the first two MultiIndex levels (source, target) of every
+    non-self-loop edge into a deterministic canonical order, so reciprocal rows
+    ``(u, v)`` and ``(v, u)`` — the typical shape of bidirectional roads exported
+    from a directed source such as an OSMnx MultiDiGraph — map onto the same
+    unordered key. Attributes and geometry of each row are left untouched; only
+    the index values change (geometries are NOT reversed). Self-loops are
+    returned unchanged.
+
+    Rows that share the same unordered key after canonicalization are handled
+    according to ``duplicates``.
+
+    Parameters
+    ----------
+    edges : geopandas.GeoDataFrame
+        Edge GeoDataFrame with a two-level (source, target) or three-level
+        (source, target, key) MultiIndex. For heterogeneous graphs, call this
+        function separately on each edge type's GeoDataFrame.
+    duplicates : {"first", "key", "error"}, default "first"
+        How to handle rows sharing the same unordered key after
+        canonicalization:
+
+        - ``"first"``: keep the first occurrence and drop the rest. For
+          three-level input the key level participates in the comparison, so
+          distinct parallel keys are preserved.
+        - ``"key"``: keep all rows and (re)generate an integer key level per
+          unordered pair, producing a valid three-level multigraph index.
+        - ``"error"``: raise ``ValueError`` reporting the offending pairs.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The canonicalized edge GeoDataFrame. Row order, columns, attributes,
+        geometry, and CRS are preserved (apart from rows dropped by
+        ``duplicates="first"``). Index level names are kept positionally:
+        level 0 keeps its original name even where values were swapped.
+
+    Raises
+    ------
+    ValueError
+        If the index is not a MultiIndex with at least two levels, if
+        ``duplicates`` is not a recognized option, or if duplicate unordered
+        keys remain and ``duplicates="error"``.
+
+    See Also
+    --------
+    gdf_to_pyg : Convert GeoDataFrames to PyTorch Geometric objects.
+    segments_to_graph : Convert LineString segments to a graph structure.
+
+    Notes
+    -----
+    Node identifiers are ordered with a vectorized comparison when they are
+    mutually comparable (e.g. all integers or all strings). For mixed,
+    non-comparable identifier types the order falls back to first-appearance
+    codes, which is deterministic for a given input but input-dependent.
+
+    Examples
+    --------
+    >>> import geopandas as gpd
+    >>> import pandas as pd
+    >>> from shapely.geometry import LineString
+    >>> index = pd.MultiIndex.from_tuples([(0, 1), (1, 0)], names=["u", "v"])
+    >>> edges = gpd.GeoDataFrame(
+    ...     {"name": ["ab", "ba"]},
+    ...     geometry=[LineString([(0, 0), (1, 1)]), LineString([(1, 1), (0, 0)])],
+    ...     index=index,
+    ...     crs="EPSG:32633",
+    ... )
+    >>> canonicalize_edges(edges).index.tolist()
+    [(0, 1)]
+    >>> canonicalize_edges(edges, duplicates="key").index.tolist()
+    [(0, 1, 0), (0, 1, 1)]
+    """
+    allowed = ("first", "key", "error")
+    if duplicates not in allowed:
+        msg = f"duplicates must be one of {allowed}, got {duplicates!r}."
+        raise ValueError(msg)
+
+    if not isinstance(edges.index, pd.MultiIndex) or edges.index.nlevels < 2:
+        msg = (
+            "Edge GeoDataFrame index must be a MultiIndex with at least "
+            "two levels (source, target)."
+        )
+        raise ValueError(msg)
+
+    if edges.empty:
+        return edges.copy()
+
+    src = np.asarray(edges.index.get_level_values(0), dtype=object)
+    dst = np.asarray(edges.index.get_level_values(1), dtype=object)
+    try:
+        swap = src > dst
+    except TypeError:
+        # Mixed, non-comparable identifier types: order by first-appearance codes.
+        codes = pd.factorize(np.concatenate([src, dst]), sort=False)[0]
+        swap = codes[: len(src)] > codes[len(src) :]
+    canon_src = np.where(swap, dst, src)
+    canon_dst = np.where(swap, src, dst)
+
+    names = list(edges.index.names)
+    has_key_level = edges.index.nlevels >= 3
+    pairs = pd.DataFrame({"u": canon_src, "v": canon_dst})
+    if has_key_level:
+        pairs["key"] = np.asarray(edges.index.get_level_values(2), dtype=object)
+
+    result = edges.copy()
+
+    if duplicates == "key":
+        keys = pairs.groupby(["u", "v"], sort=False).cumcount().to_numpy()
+        key_name = names[2] if has_key_level else "key"
+        result.index = pd.MultiIndex.from_arrays(
+            [canon_src, canon_dst, keys],
+            names=[names[0], names[1], key_name],
+        )
+        return result
+
+    duplicated_mask = pairs.duplicated(keep=False).to_numpy()
+    if duplicates == "error" and duplicated_mask.any():
+        dup_pairs = pairs.loc[duplicated_mask, ["u", "v"]].drop_duplicates()
+        examples = ", ".join(f"({u}, {v})" for u, v in dup_pairs.head(3).itertuples(index=False))
+        msg = (
+            f"Duplicate undirected edges detected after canonicalization: "
+            f"{int(duplicated_mask.sum())} row(s) across {len(dup_pairs)} "
+            f"unordered pair(s), e.g. {examples}. Pass duplicates='first' to "
+            f"keep one row per pair or duplicates='key' to keep all rows as "
+            f"a multigraph."
+        )
+        raise ValueError(msg)
+
+    index_arrays = [canon_src, canon_dst]
+    if has_key_level:
+        index_arrays.append(np.asarray(edges.index.get_level_values(2), dtype=object))
+    result.index = pd.MultiIndex.from_arrays(index_arrays, names=names)
+    if duplicates == "first":
+        keep_mask = ~pairs.duplicated(keep="first").to_numpy()
+        result = result[keep_mask]
+    return result
 
 
 def _validate_dual_graph_input(

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -17,6 +17,7 @@ The utils module provides core utility functions for graph conversion, validatio
         - rx_to_nx
         - validate_gdf
         - validate_nx
+        - canonicalize_edges
         - dual_graph
         - filter_graph_by_distance
         - create_tessellation

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -21,6 +21,7 @@ from torch_geometric.data import HeteroData
 from city2graph import graph as graph_module
 from city2graph.base import GraphMetadata
 from city2graph.proximity import contiguity_graph
+from city2graph.utils import canonicalize_edges
 
 # Import torch-related modules conditionally
 try:
@@ -1399,6 +1400,89 @@ class TestUndirectedEdgeHandling:
 
         with pytest.raises(ValueError, match="Parallel undirected edges"):
             gdf_to_pyg(simple_nodes, edges, directed=False)
+
+    def test_bidirectional_error_reports_pair_count_and_helper(
+        self, simple_nodes: gpd.GeoDataFrame
+    ) -> None:
+        """The ambiguous-input error reports all affected pairs and the helper."""
+        source_ids = [1, 2, 2, 3]
+        target_ids = [2, 1, 3, 2]
+        edges = gpd.GeoDataFrame(
+            {"geometry": [LineString([(0, 0), (i, 1)]) for i in range(4)]},
+            index=pd.MultiIndex.from_arrays(
+                [source_ids, target_ids], names=["source_id", "target_id"]
+            ),
+            crs="EPSG:27700",
+        )
+
+        with pytest.raises(ValueError, match=r"2 node pair\(s\).*canonicalize_edges"):
+            gdf_to_pyg(simple_nodes, edges, directed=False)
+
+    def test_parallel_error_reports_counts_and_helper(self, simple_nodes: gpd.GeoDataFrame) -> None:
+        """The parallel-edge error reports row/pair counts and the helper."""
+        source_ids = [1, 1]
+        target_ids = [2, 2]
+        edges = gpd.GeoDataFrame(
+            {"geometry": [LineString([(0, 0), (1, 0)])] * 2},
+            index=pd.MultiIndex.from_arrays(
+                [source_ids, target_ids], names=["source_id", "target_id"]
+            ),
+            crs="EPSG:27700",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"2 row\(s\) across 1 unordered node pair\(s\).*canonicalize_edges",
+        ):
+            gdf_to_pyg(simple_nodes, edges, directed=False)
+
+    def test_bidirectional_error_includes_edge_type_label(
+        self, sample_hetero_nodes_dict: dict[str, gpd.GeoDataFrame]
+    ) -> None:
+        """Hetero validation errors still name the offending edge type."""
+        source_ids = ["b1", "b2"]
+        target_ids = ["b2", "b1"]
+        edges = gpd.GeoDataFrame(
+            {
+                "geometry": [
+                    LineString([(10, 10), (11, 11)]),
+                    LineString([(11, 11), (10, 10)]),
+                ]
+            },
+            index=pd.MultiIndex.from_arrays(
+                [source_ids, target_ids], names=["building_id", "building_id_to"]
+            ),
+            crs="EPSG:27700",
+        )
+        edges_dict = {("building", "adjacent_to", "building"): edges}
+
+        with pytest.raises(ValueError, match=r"Ambiguous undirected input for edge type"):
+            gdf_to_pyg(sample_hetero_nodes_dict, edges_dict, directed=False)
+
+    def test_canonicalize_edges_unblocks_undirected_conversion(
+        self, simple_nodes: gpd.GeoDataFrame
+    ) -> None:
+        """canonicalize_edges output passes where the raw reciprocal input raised."""
+        source_ids = [1, 2]
+        target_ids = [2, 1]
+        edges = gpd.GeoDataFrame(
+            {"weight": [0.5, 0.5]},
+            geometry=[
+                LineString([(0, 0), (1, 0)]),
+                LineString([(1, 0), (0, 0)]),
+            ],
+            index=pd.MultiIndex.from_arrays(
+                [source_ids, target_ids], names=["source_id", "target_id"]
+            ),
+            crs="EPSG:27700",
+        )
+
+        with pytest.raises(ValueError, match="Ambiguous undirected input"):
+            gdf_to_pyg(simple_nodes, edges, directed=False)
+
+        data = gdf_to_pyg(simple_nodes, canonicalize_edges(edges), directed=False)
+        # One undirected edge, symmetrized into both directions.
+        assert data.num_edges == 2
 
     def test_cross_type_auto_reverse_store(
         self,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -681,6 +681,87 @@ class TestGraphStructures(BaseGraphTest):
         edge_keys = edges_gdf.index.get_level_values("edge_key")
         assert list(edge_keys) == [0, 1]
 
+    def test_segments_to_graph_default_is_multigraph(
+        self,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """The default output carries a three-level multigraph index."""
+        _, edges_gdf = morphology.segments_to_graph(sample_segments_gdf)
+        assert edges_gdf.index.names == ["from_node_id", "to_node_id", "edge_key"]
+
+    def test_segments_to_graph_multigraph_false_duplicates_raise(
+        self,
+        duplicate_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """multigraph=False raises on duplicate node pairs instead of passing silently."""
+        with pytest.raises(ValueError, match=r"1 duplicate node pair\(s\)"):
+            morphology.segments_to_graph(duplicate_segments_gdf, multigraph=False)
+
+    def test_segments_to_graph_directed_default_preserves_draw_order(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """Default directed=True keeps reverse-drawn segments as reciprocal pairs."""
+        segments = gpd.GeoDataFrame(
+            {"name": ["fwd", "rev"]},
+            geometry=[
+                LineString([(0, 0), (1, 1)]),
+                LineString([(1, 1), (0, 0)]),
+            ],
+            crs=sample_crs,
+        )
+        _, edges_gdf = morphology.segments_to_graph(segments)
+
+        pairs = list(
+            zip(
+                edges_gdf.index.get_level_values("from_node_id"),
+                edges_gdf.index.get_level_values("to_node_id"),
+                strict=True,
+            )
+        )
+        assert pairs == [(0, 1), (1, 0)]
+
+    def test_segments_to_graph_undirected_canonicalizes_reverse_segments(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """directed=False folds reverse-drawn segments into one unordered pair."""
+        segments = gpd.GeoDataFrame(
+            {"name": ["fwd", "rev"]},
+            geometry=[
+                LineString([(0, 0), (1, 1)]),
+                LineString([(1, 1), (0, 0)]),
+            ],
+            crs=sample_crs,
+        )
+        _, edges_gdf = morphology.segments_to_graph(segments, directed=False)
+
+        assert edges_gdf.index.tolist() == [(0, 1, 0), (0, 1, 1)]
+        # Geometries are left unchanged; only the index order is normalized.
+        assert list(edges_gdf.geometry) == list(segments.geometry)
+
+    def test_segments_to_graph_empty_as_nx(
+        self,
+        empty_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """Empty input honors as_nx=True instead of returning a tuple."""
+        result = morphology.segments_to_graph(empty_gdf, as_nx=True)
+        assert isinstance(result, nx.MultiGraph)
+        assert result.number_of_nodes() == 0
+
+        simple = morphology.segments_to_graph(empty_gdf, multigraph=False, as_nx=True)
+        assert isinstance(simple, nx.Graph)
+        assert not isinstance(simple, nx.MultiGraph)
+
+    def test_segments_to_graph_as_nx_keeps_parallel_edges(
+        self,
+        duplicate_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """as_nx=True with the multigraph default preserves parallel edges."""
+        graph = morphology.segments_to_graph(duplicate_segments_gdf, as_nx=True)
+        assert isinstance(graph, nx.MultiGraph)
+        assert graph.number_of_edges() == 2
+
     def test_dual_graph_empty_result_with_edge_id_col(
         self, sample_nodes_gdf: gpd.GeoDataFrame, sample_crs: str
     ) -> None:
@@ -714,6 +795,124 @@ class TestGraphStructures(BaseGraphTest):
         """Test _canonical_edge_pair with self-loop (line 1370)."""
         assert utils._canonical_edge_pair(1, 1) == (1, 1)
         assert utils._canonical_edge_pair("a", "a") == ("a", "a")
+
+
+# ============================================================================
+# EDGE CANONICALIZATION TESTS
+# ============================================================================
+
+
+class TestCanonicalizeEdges(BaseGraphTest):
+    """Test canonicalize_edges collapsing of reciprocal and parallel rows."""
+
+    @staticmethod
+    def _make_edges(
+        tuples: list[tuple[Any, ...]],
+        names: list[str] | None = None,
+    ) -> gpd.GeoDataFrame:
+        """Build an edge GeoDataFrame with one distinct row per index tuple."""
+        if names is None:
+            names = ["u", "v"] if len(tuples[0]) == 2 else ["u", "v", "k"]
+        return gpd.GeoDataFrame(
+            {"name": [f"e{i}" for i in range(len(tuples))]},
+            geometry=[LineString([(i, 0), (i + 1, 1)]) for i in range(len(tuples))],
+            index=pd.MultiIndex.from_tuples(tuples, names=names),
+            crs="EPSG:27700",
+        )
+
+    def test_first_keeps_first_row_per_unordered_pair(self) -> None:
+        """duplicates='first' keeps the first reciprocal row verbatim."""
+        edges = self._make_edges([(0, 1), (1, 0), (1, 2)])
+        result = utils.canonicalize_edges(edges)
+
+        assert result.index.tolist() == [(0, 1), (1, 2)]
+        assert result.index.names == ["u", "v"]
+        assert list(result["name"]) == ["e0", "e2"]
+        assert result.geometry.iloc[0] == edges.geometry.iloc[0]
+        assert result.crs == edges.crs
+
+    def test_key_keeps_all_rows_as_multigraph(self) -> None:
+        """duplicates='key' keeps reciprocal rows under distinct keys."""
+        edges = self._make_edges([(0, 1), (1, 0), (1, 2)])
+        result = utils.canonicalize_edges(edges, duplicates="key")
+
+        assert result.index.tolist() == [(0, 1, 0), (0, 1, 1), (1, 2, 0)]
+        assert result.index.names == ["u", "v", "key"]
+        assert list(result["name"]) == ["e0", "e1", "e2"]
+
+    def test_error_reports_offending_pairs(self) -> None:
+        """duplicates='error' raises with row and pair counts."""
+        edges = self._make_edges([(0, 1), (1, 0)])
+        with pytest.raises(ValueError, match=r"2 row\(s\) across 1 unordered pair\(s\)"):
+            utils.canonicalize_edges(edges, duplicates="error")
+
+    def test_error_passes_when_no_duplicates(self) -> None:
+        """duplicates='error' returns canonicalized edges when keys are unique."""
+        edges = self._make_edges([(1, 0), (2, 1)])
+        result = utils.canonicalize_edges(edges, duplicates="error")
+        assert result.index.tolist() == [(0, 1), (1, 2)]
+
+    def test_three_level_input_preserves_distinct_keys(self) -> None:
+        """Three-level input keeps distinct parallel keys under 'first'."""
+        edges = self._make_edges([(1, 0, 0), (0, 1, 1), (1, 0, 1)])
+        result = utils.canonicalize_edges(edges)
+
+        # (1, 0, 1) duplicates (0, 1, 1) after canonicalization and is dropped.
+        assert result.index.tolist() == [(0, 1, 0), (0, 1, 1)]
+        assert result.index.names == ["u", "v", "k"]
+
+    def test_three_level_input_regenerates_keys(self) -> None:
+        """duplicates='key' regenerates keys per unordered pair."""
+        edges = self._make_edges([(1, 0, 0), (0, 1, 0)])
+        result = utils.canonicalize_edges(edges, duplicates="key")
+        assert result.index.tolist() == [(0, 1, 0), (0, 1, 1)]
+        assert result.index.names == ["u", "v", "k"]
+
+    def test_self_loops_unchanged(self) -> None:
+        """Self-loops keep their index values."""
+        edges = self._make_edges([(2, 2), (1, 0)])
+        result = utils.canonicalize_edges(edges)
+        assert result.index.tolist() == [(2, 2), (0, 1)]
+
+    def test_string_ids_sorted(self) -> None:
+        """String identifiers are ordered lexicographically."""
+        edges = self._make_edges([("b", "a")])
+        result = utils.canonicalize_edges(edges)
+        assert result.index.tolist() == [("a", "b")]
+
+    def test_mixed_type_ids_use_factorize_fallback(self) -> None:
+        """Non-comparable mixed-type identifiers fall back to appearance order."""
+        edges = self._make_edges([("a", 1), (1, "a")])
+        result = utils.canonicalize_edges(edges)
+        assert result.index.tolist() == [("a", 1)]
+
+    def test_empty_input_returns_copy(self) -> None:
+        """An empty edge GeoDataFrame is returned unchanged."""
+        edges = gpd.GeoDataFrame(
+            {"name": []},
+            geometry=[],
+            index=pd.MultiIndex.from_arrays([[], []], names=["u", "v"]),
+            crs="EPSG:27700",
+        )
+        result = utils.canonicalize_edges(edges)
+        assert result.empty
+        assert result is not edges
+
+    def test_non_multiindex_raises(self) -> None:
+        """A flat index is rejected."""
+        edges = gpd.GeoDataFrame(
+            {"name": ["e0"]},
+            geometry=[LineString([(0, 0), (1, 1)])],
+            crs="EPSG:27700",
+        )
+        with pytest.raises(ValueError, match="MultiIndex with at least"):
+            utils.canonicalize_edges(edges)
+
+    def test_invalid_duplicates_option_raises(self) -> None:
+        """Unknown duplicates options are rejected."""
+        edges = self._make_edges([(0, 1)])
+        with pytest.raises(ValueError, match="duplicates must be one of"):
+            utils.canonicalize_edges(edges, duplicates="drop")  # type: ignore[arg-type]
 
 
 # ============================================================================


### PR DESCRIPTION
## Description

This pull request makes multigraph output the default for `segments_to_graph()` so duplicate or parallel segment connections are preserved instead of being silently represented with duplicated two-level edge indexes.

The main behavior changes are:

- `segments_to_graph()` now defaults to `multigraph=True`, producing a three-level `(from_node_id, to_node_id, edge_key)` MultiIndex.
- `segments_to_graph(..., as_nx=True)` now returns an `nx.MultiGraph` by default, preserving parallel edges.
- `multigraph=False` now raises a `ValueError` when duplicate node pairs are present, avoiding ambiguous duplicated indexes.
- A new `directed` parameter allows `segments_to_graph(..., directed=False)` to canonicalize reverse-drawn segments into a single unordered node pair while leaving geometries unchanged.
- Empty `segments_to_graph(..., as_nx=True)` inputs now correctly return an empty NetworkX graph.

This also adds `canonicalize_edges()`, a public utility for collapsing reciprocal `(u, v)` / `(v, u)` rows and handling duplicate undirected edges via `duplicates="first"`, `"key"`, or `"error"`. The undirected `gdf_to_pyg()` validation messages were expanded to explain reciprocal and parallel edge issues more clearly and point users to `canonicalize_edges()` as a remedy.

Documentation, changelog entries, and tests were added for the new default behavior, duplicate handling, undirected canonicalization, NetworkX output, and the new utility function.

## Related Issues

N/A

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.