### PR TITLE
Add `symmetrize_edges()` and `duplicate_edges` parameter for the functions of undirected graph construction

### DIFF
--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -40,6 +40,7 @@ from .utils import dual_graph
 from .utils import filter_graph_by_distance
 from .utils import gdf_to_nx
 from .utils import nx_to_gdf
+from .utils import symmetrize_edges
 
 if typing.TYPE_CHECKING:
     from shapely.geometry.base import BaseGeometry
@@ -56,6 +57,65 @@ __all__ = [
 # Module logger configuration
 logger = logging.getLogger(__name__)
 _SOURCE_BUILDING_INDEX_COL = "_source_building_index"
+
+
+def _validate_duplicate_edges(duplicate_edges: bool, as_nx: bool) -> None:
+    """
+    Reject ``duplicate_edges`` combined with NetworkX output.
+
+    Reciprocal (u, v) / (v, u) rows can only be represented in GeoDataFrame
+    output, so the conflicting combination is rejected before any computation.
+
+    Parameters
+    ----------
+    duplicate_edges : bool
+        Whether the caller requested reciprocal edge rows.
+    as_nx : bool
+        Whether the caller requested NetworkX output.
+
+    Raises
+    ------
+    ValueError
+        If ``duplicate_edges`` is combined with ``as_nx=True``.
+    """
+    if duplicate_edges and as_nx:
+        msg = (
+            "duplicate_edges=True is not supported with as_nx=True: an "
+            "undirected nx.Graph cannot hold reciprocal (u, v) and (v, u) "
+            "edges. Use as_nx=False to get a symmetrized edge GeoDataFrame."
+        )
+        raise ValueError(msg)
+
+
+def _symmetrize_edge_columns(
+    edges: gpd.GeoDataFrame, from_col: str, to_col: str
+) -> gpd.GeoDataFrame:
+    """
+    Symmetrize a column-based edge table by adding reverse rows.
+
+    The morphology sub-functions return edge tables whose endpoints live in id
+    columns rather than a MultiIndex, so the table is round-tripped through a
+    (source, target) MultiIndex to reuse :func:`symmetrize_edges`.
+
+    Parameters
+    ----------
+    edges : geopandas.GeoDataFrame
+        Edge GeoDataFrame with source and target id columns.
+    from_col : str
+        Name of the source id column.
+    to_col : str
+        Name of the target id column.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The symmetrized edge GeoDataFrame with the same column layout.
+    """
+    if edges.empty:
+        return edges
+    column_order = list(edges.columns)
+    symmetrized = symmetrize_edges(edges.set_index([from_col, to_col])).reset_index()
+    return symmetrized[column_order]
 
 
 # ============================================================================
@@ -83,6 +143,7 @@ def morphological_graph(  # noqa: PLR0913
     tolerance: float = 1e-6,
     include_unenclosed_buildings: bool = False,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]] | nx.Graph:
     """
     Create a morphological graph from buildings and street segments.
@@ -145,6 +206,15 @@ def morphological_graph(  # noqa: PLR0913
         barrier-free tessellation before distance filters are applied.
     as_nx : bool, default=False
         If True, convert the output to a NetworkX graph.
+    duplicate_edges : bool, default=False
+        If True, the undirected same-type edge GeoDataFrames —
+        ("private", "touched_to", "private") and
+        ("public", "connected_to", "public") — contain both (u, v) and (v, u)
+        rows (roughly doubling their row count), so neighbourhood queries on
+        the MultiIndex are complete. The heterogeneous
+        ("private", "faced_to", "public") edges are left unchanged because a
+        reverse row would mix public ids into the private index level.
+        Incompatible with ``as_nx=True``.
 
     Returns
     -------
@@ -169,6 +239,7 @@ def morphological_graph(  # noqa: PLR0913
     ValueError
         If contiguity parameter is not "queen" or "rook".
         If clipping_buffer is negative.
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     See Also
     --------
@@ -202,6 +273,7 @@ def morphological_graph(  # noqa: PLR0913
     private_id_col = "private_id"
     public_id_col = "public_id"
 
+    _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_input_gdfs(buildings_gdf, segments_gdf)
 
     # Validate contiguity parameter
@@ -278,6 +350,15 @@ def morphological_graph(  # noqa: PLR0913
         extent_buffer=extent_buffer,
     )
 
+    if duplicate_edges:
+        # Only same-node-type undirected edges can hold reverse rows; the
+        # heterogeneous faced_to edges would mix id spaces across index levels.
+        for edge_type in (
+            ("private", "touched_to", "private"),
+            ("public", "connected_to", "public"),
+        ):
+            edges[edge_type] = symmetrize_edges(edges[edge_type])
+
     return (nodes, edges) if not as_nx else gdf_to_nx(nodes, edges)
 
 
@@ -291,6 +372,7 @@ def private_to_private_graph(
     group_col: str | None = None,
     contiguity: str = "queen",
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     """
     Create edges between contiguous private polygons based on spatial adjacency.
@@ -312,6 +394,11 @@ def private_to_private_graph(
         Queen contiguity includes vertex neighbors, Rook includes only edge neighbors.
     as_nx : bool, default=False
         If True, convert the output to a NetworkX graph.
+    duplicate_edges : bool, default=False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), with the
+        'from_private_id' and 'to_private_id' values swapped on reverse rows.
+        Incompatible with ``as_nx=True``.
 
     Returns
     -------
@@ -329,6 +416,7 @@ def private_to_private_graph(
         If private_gdf is not a GeoDataFrame.
     ValueError
         If contiguity not in {"queen", "rook"}, or if group_col doesn't exist.
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     See Also
     --------
@@ -351,6 +439,7 @@ def private_to_private_graph(
     >>> nodes, edges = private_to_private_graph(tessellation_gdf, group_col='enclosure_id')
     """
     # Input validation
+    _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_single_gdf_input(private_gdf, "private_gdf")
 
     private_id_col = "private_id"
@@ -420,6 +509,9 @@ def private_to_private_graph(
     if as_nx:
         return gdf_to_nx(nodes=gdf_unique, edges=edges_gdf)
 
+    if duplicate_edges:
+        edges_gdf = _symmetrize_edge_columns(edges_gdf, "from_private_id", "to_private_id")
+
     return gdf_unique, edges_gdf
 
 
@@ -435,6 +527,7 @@ def private_to_public_graph(
     tolerance: float = 1e-6,
     as_nx: bool = False,
     max_connection_distance: float = math.inf,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     """
     Create edges between private polygons and nearby public geometries.
@@ -464,6 +557,11 @@ def private_to_public_graph(
         connected only by the fallback are dropped when their nearest public
         geometry lies farther than this distance, preventing long star-shaped
         edges to distant streets.
+    duplicate_edges : bool, default=False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every edge (roughly doubling the row count). Note that on reverse
+        rows the 'private_id' column holds a public id and vice versa, because
+        the endpoints are swapped. Incompatible with ``as_nx=True``.
 
     Returns
     -------
@@ -481,6 +579,7 @@ def private_to_public_graph(
         If private_gdf or public_gdf are not GeoDataFrames.
     ValueError
         If 'private_id' or 'public_id' columns are missing from input GDFs.
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     See Also
     --------
@@ -503,6 +602,7 @@ def private_to_public_graph(
     >>> nodes, edges = private_to_public_graph(tessellation_gdf, segments_gdf, tolerance=2.0)
     """
     # Input validation
+    _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_single_gdf_input(private_gdf, "private_gdf")
     _validate_single_gdf_input(public_gdf, "public_gdf")
 
@@ -576,7 +676,13 @@ def private_to_public_graph(
 
     nodes_gdf = pd.concat([private_gdf, public_gdf], ignore_index=True)
 
-    return (nodes_gdf, edges_gdf) if not as_nx else gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf)
+    if as_nx:
+        return gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf)
+
+    if duplicate_edges:
+        edges_gdf = _symmetrize_edge_columns(edges_gdf, "private_id", "public_id")
+
+    return nodes_gdf, edges_gdf
 
 
 def _connect_unmatched_private_to_nearest_public(
@@ -673,6 +779,7 @@ def _connect_unmatched_private_to_nearest_public(
 def public_to_public_graph(
     public_gdf: gpd.GeoDataFrame,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     """
     Create edges between connected public segments based on topological connectivity.
@@ -688,6 +795,11 @@ def public_to_public_graph(
         GeoDataFrame containing public space geometries (typically LineString).
     as_nx : bool, default=False
         If True, convert the output to a NetworkX graph.
+    duplicate_edges : bool, default=False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), with the
+        'from_public_id' and 'to_public_id' values swapped on reverse rows.
+        Incompatible with ``as_nx=True``.
 
     Returns
     -------
@@ -703,6 +815,8 @@ def public_to_public_graph(
     ------
     TypeError
         If public_gdf is not a GeoDataFrame.
+    ValueError
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     See Also
     --------
@@ -724,6 +838,7 @@ def public_to_public_graph(
     >>> graph = public_to_public_graph(segments_gdf, as_nx=True)
     """
     # Input validation
+    _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_single_gdf_input(public_gdf, "public_gdf")
 
     # Handle empty or insufficient data: return empty edges GeoDataFrame
@@ -763,7 +878,13 @@ def public_to_public_graph(
     # Reset index to ensure it is a regular DataFrame
     dual_edges = dual_edges.reset_index()
 
-    return (public_gdf, dual_edges) if not as_nx else gdf_to_nx(nodes=public_gdf, edges=dual_edges)
+    if as_nx:
+        return gdf_to_nx(nodes=public_gdf, edges=dual_edges)
+
+    if duplicate_edges:
+        dual_edges = _symmetrize_edge_columns(dual_edges, "from_public_id", "to_public_id")
+
+    return public_gdf, dual_edges
 
 
 # ============================================================================

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -40,6 +40,7 @@ from sklearn.neighbors import NearestNeighbors
 # Local imports
 from .utils import gdf_to_nx
 from .utils import nx_to_gdf
+from .utils import symmetrize_edges
 from .utils import validate_gdf
 
 # Module logger configuration
@@ -615,7 +616,9 @@ class GraphBuilder:
 
         return weights, geoms
 
-    def to_output(self, as_nx: bool) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
+    def to_output(
+        self, as_nx: bool, *, duplicate_edges: bool = False
+    ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
         """
         Return graph in requested format.
 
@@ -626,13 +629,65 @@ class GraphBuilder:
         ----------
         as_nx : bool
             If True, return a NetworkX graph. Otherwise, return GeoDataFrames.
+        duplicate_edges : bool, default False
+            If True, add the reverse (v, u) row of every undirected edge to
+            the edges GeoDataFrame. Only valid when ``as_nx`` is False.
 
         Returns
         -------
         tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph
             The generated graph.
         """
-        return self.G if as_nx else nx_to_gdf(self.G, nodes=True, edges=True)
+        if as_nx:
+            return self.G
+        nodes, edges = nx_to_gdf(self.G, nodes=True, edges=True)
+        if duplicate_edges:
+            edges = symmetrize_edges(edges)
+        return nodes, edges
+
+
+def _validate_duplicate_edges(
+    duplicate_edges: bool,
+    as_nx: bool,
+    target_gdf: gpd.GeoDataFrame | None = None,
+) -> None:
+    """
+    Validate ``duplicate_edges`` against incompatible output options.
+
+    Reciprocal (u, v) / (v, u) rows can only be represented in GeoDataFrame
+    output of undirected graphs, so conflicting combinations are rejected
+    before any computation happens.
+
+    Parameters
+    ----------
+    duplicate_edges : bool
+        Whether the caller requested reciprocal edge rows.
+    as_nx : bool
+        Whether the caller requested NetworkX output.
+    target_gdf : geopandas.GeoDataFrame, optional
+        Target GeoDataFrame triggering the directed graph variant, if any.
+
+    Raises
+    ------
+    ValueError
+        If ``duplicate_edges`` is combined with ``as_nx=True`` or with a
+        directed graph variant.
+    """
+    if not duplicate_edges:
+        return
+    if as_nx:
+        msg = (
+            "duplicate_edges=True is not supported with as_nx=True: an "
+            "undirected nx.Graph cannot hold reciprocal (u, v) and (v, u) "
+            "edges. Use as_nx=False to get a symmetrized edge GeoDataFrame."
+        )
+        raise ValueError(msg)
+    if target_gdf is not None:
+        msg = (
+            "duplicate_edges=True is not supported with target_gdf: the "
+            "resulting graph is directed, so its edges are not symmetrized."
+        )
+        raise ValueError(msg)
 
 
 # ============================================================================
@@ -649,6 +704,7 @@ def knn_graph(
     *,
     target_gdf: gpd.GeoDataFrame | None = None,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
     Generate a k-nearest neighbour graph from a GeoDataFrame of points.
@@ -684,6 +740,11 @@ def knn_graph(
     as_nx : bool, default False
         If True, returns a NetworkX graph object. Otherwise, returns a tuple of
         GeoDataFrames (nodes, edges).
+    duplicate_edges : bool, default False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), so
+        neighbourhood queries on the MultiIndex are complete. Incompatible
+        with ``as_nx=True`` and with ``target_gdf`` (directed variant).
 
     Returns
     -------
@@ -698,7 +759,10 @@ def knn_graph(
     ValueError
         If `distance_metric` is "network" but `network_gdf` is not provided.
         If `k` is greater than or equal to the number of available nodes.
+        If `duplicate_edges` is True together with `as_nx=True` or `target_gdf`.
     """
+    _validate_duplicate_edges(duplicate_edges, as_nx, target_gdf)
+
     # Handle directed variant
     if target_gdf is not None:
         return _directed_graph(
@@ -719,7 +783,7 @@ def knn_graph(
     assert builder.node_ids is not None
 
     if len(builder.coords) <= 1 or k <= 0:
-        return builder.to_output(as_nx)
+        return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
     if metric.name == "network":
         builder.compute_distance_matrix()
@@ -745,7 +809,7 @@ def knn_graph(
         ]
 
     builder.add_edges(edges)
-    return builder.to_output(as_nx)
+    return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
 
 def delaunay_graph(
@@ -755,6 +819,7 @@ def delaunay_graph(
     network_weight: str | None = None,
     *,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
     Generate a Delaunay triangulation graph from a GeoDataFrame of points.
@@ -780,6 +845,11 @@ def delaunay_graph(
     as_nx : bool, default False
         If True, returns a NetworkX graph object. Otherwise, returns a tuple of
         GeoDataFrames (nodes, edges).
+    duplicate_edges : bool, default False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), so
+        neighbourhood queries on the MultiIndex are complete. Incompatible
+        with ``as_nx=True``.
 
     Returns
     -------
@@ -793,6 +863,7 @@ def delaunay_graph(
     ------
     ValueError
         If `distance_metric` is "network" but `network_gdf` is not provided.
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     See Also
     --------
@@ -814,6 +885,8 @@ def delaunay_graph(
        Delaunay triangulation. International Journal of Computer & Information Sciences, 9(3),
        219-242. https://doi.org/10.1007/BF00977785
     """
+    _validate_duplicate_edges(duplicate_edges, as_nx)
+
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
     builder = GraphBuilder(gdf, metric)
     builder.prepare_nodes()
@@ -821,7 +894,7 @@ def delaunay_graph(
     assert builder.node_ids is not None
 
     if len(builder.coords) < 3:
-        return builder.to_output(as_nx)
+        return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
     tri = Delaunay(builder.coords)
     edges = {
@@ -831,7 +904,7 @@ def delaunay_graph(
     }
 
     builder.add_edges(edges)
-    return builder.to_output(as_nx)
+    return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
 
 def gabriel_graph(
@@ -841,6 +914,7 @@ def gabriel_graph(
     network_weight: str | None = None,
     *,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
     Generate a Gabriel graph from a GeoDataFrame of points.
@@ -862,6 +936,11 @@ def gabriel_graph(
     as_nx : bool, default False
         If True return a NetworkX graph, otherwise return two GeoDataFrames (nodes, edges)
         via `nx_to_gdf`.
+    duplicate_edges : bool, default False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), so
+        neighbourhood queries on the MultiIndex are complete. Incompatible
+        with ``as_nx=True``.
 
     Returns
     -------
@@ -870,6 +949,11 @@ def gabriel_graph(
         - nodes_gdf: GeoDataFrame of nodes with spatial and attribute information
         - edges_gdf: GeoDataFrame of edges with 'weight' and 'geometry' attributes
         If `as_nx` is True, returns a NetworkX graph object with spatial attributes.
+
+    Raises
+    ------
+    ValueError
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     Notes
     -----
@@ -886,6 +970,8 @@ def gabriel_graph(
        variation analysis. Systematic zoology, 18(3), 259-278.
        https://doi.org/10.2307/2412323
     """
+    _validate_duplicate_edges(duplicate_edges, as_nx)
+
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
     builder = GraphBuilder(gdf, metric)
     builder.prepare_nodes()
@@ -894,7 +980,7 @@ def gabriel_graph(
 
     n_points = len(builder.coords)
     if n_points < 2:
-        return builder.to_output(as_nx)
+        return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
     # Candidate edges
     if n_points == 2:
@@ -920,7 +1006,7 @@ def gabriel_graph(
             kept_edges.add((builder.node_ids[i], builder.node_ids[j]))
 
     builder.add_edges(kept_edges)
-    return builder.to_output(as_nx)
+    return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
 
 def relative_neighborhood_graph(
@@ -930,6 +1016,7 @@ def relative_neighborhood_graph(
     network_weight: str | None = None,
     *,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
     Generate a Relative-Neighbourhood Graph (RNG) from a GeoDataFrame.
@@ -952,6 +1039,11 @@ def relative_neighborhood_graph(
     as_nx : bool, default False
         If True return a NetworkX graph, otherwise return two GeoDataFrames (nodes, edges)
         via `nx_to_gdf`.
+    duplicate_edges : bool, default False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), so
+        neighbourhood queries on the MultiIndex are complete. Incompatible
+        with ``as_nx=True``.
 
     Returns
     -------
@@ -960,6 +1052,11 @@ def relative_neighborhood_graph(
         - nodes_gdf: GeoDataFrame of nodes with spatial and attribute information
         - edges_gdf: GeoDataFrame of edges with 'weight' and 'geometry' attributes
         If `as_nx` is True, returns a NetworkX graph object with spatial attributes.
+
+    Raises
+    ------
+    ValueError
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     Notes
     -----
@@ -975,6 +1072,8 @@ def relative_neighborhood_graph(
        set. Pattern recognition, 12(4), 261-268.
        https://doi.org/10.1016/0031-3203(80)90066-7
     """
+    _validate_duplicate_edges(duplicate_edges, as_nx)
+
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
     builder = GraphBuilder(gdf, metric)
     builder.prepare_nodes()
@@ -983,7 +1082,7 @@ def relative_neighborhood_graph(
 
     n_points = len(builder.coords)
     if n_points < 2:
-        return builder.to_output(as_nx)
+        return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
     if n_points == 2:
         cand_edges = {(0, 1)}
@@ -1006,7 +1105,7 @@ def relative_neighborhood_graph(
             kept_edges.add((builder.node_ids[i], builder.node_ids[j]))
 
     builder.add_edges(kept_edges)
-    return builder.to_output(as_nx)
+    return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
 
 def euclidean_minimum_spanning_tree(
@@ -1016,6 +1115,7 @@ def euclidean_minimum_spanning_tree(
     network_weight: str | None = None,
     *,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
     Generate a (generalised) Euclidean Minimum Spanning Tree from a GeoDataFrame of points.
@@ -1044,6 +1144,11 @@ def euclidean_minimum_spanning_tree(
     as_nx : bool, default False
         If True return a NetworkX graph, otherwise return two GeoDataFrames (nodes, edges)
         via `nx_to_gdf`.
+    duplicate_edges : bool, default False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), so
+        neighbourhood queries on the MultiIndex are complete. Incompatible
+        with ``as_nx=True``.
 
     Returns
     -------
@@ -1052,6 +1157,11 @@ def euclidean_minimum_spanning_tree(
         - nodes_gdf: GeoDataFrame of nodes with spatial and attribute information
         - edges_gdf: GeoDataFrame of edges with 'weight' and 'geometry' attributes
         If `as_nx` is True, returns a NetworkX graph object with spatial attributes.
+
+    Raises
+    ------
+    ValueError
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     See Also
     --------
@@ -1074,6 +1184,8 @@ def euclidean_minimum_spanning_tree(
        SIGKDD international conference on Knowledge discovery and data mining (pp.
        603-612). https://doi.org/10.1145/1835804.1835882
     """
+    _validate_duplicate_edges(duplicate_edges, as_nx)
+
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
     builder = GraphBuilder(gdf, metric)
     builder.prepare_nodes()
@@ -1082,7 +1194,7 @@ def euclidean_minimum_spanning_tree(
 
     n_points = len(builder.coords)
     if n_points < 2:
-        return builder.to_output(as_nx)
+        return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
     # Candidate edges
     if metric.name == "euclidean" and n_points >= 3:
@@ -1102,7 +1214,12 @@ def euclidean_minimum_spanning_tree(
 
     # Compute MST
     mst_G = nx.minimum_spanning_tree(builder.G, weight="weight", algorithm="kruskal")
-    return mst_G if as_nx else nx_to_gdf(mst_G, nodes=True, edges=True)
+    if as_nx:
+        return mst_G
+    nodes, edges = nx_to_gdf(mst_G, nodes=True, edges=True)
+    if duplicate_edges:
+        edges = symmetrize_edges(edges)
+    return nodes, edges
 
 
 def fixed_radius_graph(
@@ -1114,6 +1231,7 @@ def fixed_radius_graph(
     *,
     target_gdf: gpd.GeoDataFrame | None = None,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
     Generate a fixed-radius graph from a GeoDataFrame of points.
@@ -1149,6 +1267,11 @@ def fixed_radius_graph(
     as_nx : bool, default False
         If True, returns a NetworkX graph object. Otherwise, returns a tuple of
         GeoDataFrames (nodes, edges).
+    duplicate_edges : bool, default False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), so
+        neighbourhood queries on the MultiIndex are complete. Incompatible
+        with ``as_nx=True`` and with ``target_gdf`` (directed variant).
 
     Returns
     -------
@@ -1163,6 +1286,7 @@ def fixed_radius_graph(
     ValueError
         If `distance_metric` is "network" but `network_gdf` is not provided.
         If `radius` is not positive.
+        If `duplicate_edges` is True together with `as_nx=True` or `target_gdf`.
 
     See Also
     --------
@@ -1184,6 +1308,8 @@ def fixed_radius_graph(
        finding fixed-radius near neighbors. Information processing letters, 6(6),
        209-212. https://doi.org/10.1016/0020-0190(77)90070-9
     """
+    _validate_duplicate_edges(duplicate_edges, as_nx, target_gdf)
+
     if target_gdf is not None:
         return _directed_graph(
             src_gdf=gdf,
@@ -1203,7 +1329,7 @@ def fixed_radius_graph(
     assert builder.node_ids is not None
 
     if len(builder.coords) < 2:
-        return builder.to_output(as_nx)
+        return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
     if metric.name == "network":
         builder.compute_distance_matrix()
@@ -1228,7 +1354,7 @@ def fixed_radius_graph(
 
     builder.add_edges(edges)
     builder.G.graph["radius"] = radius
-    return builder.to_output(as_nx)
+    return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
 
 def waxman_graph(
@@ -1241,6 +1367,7 @@ def waxman_graph(
     network_weight: str | None = None,
     *,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
     Generate a probabilistic Waxman graph from a GeoDataFrame of points.
@@ -1285,6 +1412,11 @@ def waxman_graph(
     as_nx : bool, default False
         If True, returns a NetworkX graph object. Otherwise, returns a tuple of
         GeoDataFrames (nodes, edges).
+    duplicate_edges : bool, default False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), so
+        neighbourhood queries on the MultiIndex are complete. Incompatible
+        with ``as_nx=True``.
 
     Returns
     -------
@@ -1299,6 +1431,7 @@ def waxman_graph(
     ValueError
         If `distance_metric` is "network" but `network_gdf` is not provided.
         If `beta` is not between 0 and 1, or if `r0` is not positive.
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     See Also
     --------
@@ -1321,6 +1454,8 @@ def waxman_graph(
        selected areas in communications, 6(9), 1617-1622.
        https://doi.org/10.1109/49.12889
     """
+    _validate_duplicate_edges(duplicate_edges, as_nx)
+
     rng = np.random.default_rng(seed)
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
     builder = GraphBuilder(gdf, metric)
@@ -1329,7 +1464,7 @@ def waxman_graph(
     assert builder.node_ids is not None
 
     if len(builder.coords) < 2:
-        return builder.to_output(as_nx)
+        return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
     builder.compute_distance_matrix()
     assert builder.dm is not None
@@ -1345,7 +1480,7 @@ def waxman_graph(
 
     builder.add_edges(edges)
     builder.G.graph.update({"beta": beta, "r0": r0})
-    return builder.to_output(as_nx)
+    return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
 
 def _normalize_layer_types(
@@ -1704,6 +1839,7 @@ def contiguity_graph(
     node_geom_col: str | None = None,
     set_point_nodes: bool = False,
     as_nx: bool = False,
+    duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
     Generate a contiguity-based spatial graph from polygon geometries.
@@ -1759,6 +1895,12 @@ def contiguity_graph(
         Output format control. If True, returns a NetworkX Graph object with spatial
         attributes. If False, returns a tuple of GeoDataFrames for nodes and edges,
         compatible with other city2graph functions.
+    duplicate_edges : bool, default False
+        If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
+        for every undirected edge (roughly doubling the row count), so
+        neighbourhood queries on the MultiIndex are complete, e.g.
+        ``edges_gdf.xs(node_id, level=0)`` returns every contiguity neighbour.
+        Incompatible with ``as_nx=True``.
 
     Returns
     -------
@@ -1775,6 +1917,7 @@ def contiguity_graph(
         If `gdf` contains geometries that are not polygons (Point, LineString, etc.).
         If `gdf` contains invalid or corrupt polygon geometries.
         If libpysal fails to create spatial weights matrix.
+        If `duplicate_edges` is True together with `as_nx=True`.
 
     See Also
     --------
@@ -1787,6 +1930,7 @@ def contiguity_graph(
     relative_neighborhood_graph : Generate relative neighborhood graphs.
     waxman_graph : Generate probabilistic Waxman graphs.
     """
+    _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_contiguity_input(gdf, contiguity)
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
     metric.validate(gdf.crs)
@@ -1825,7 +1969,7 @@ def contiguity_graph(
     builder.G.graph["contiguity"] = contiguity
     builder.G.graph["distance_metric"] = metric.name
 
-    return builder.to_output(as_nx)
+    return builder.to_output(as_nx, duplicate_edges=duplicate_edges)
 
 
 # ============================================================================

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -70,6 +70,7 @@ __all__ = [
     "plot_graph",
     "remove_isolated_components",
     "rx_to_nx",
+    "symmetrize_edges",
     "validate_gdf",
     "validate_nx",
 ]
@@ -1932,6 +1933,7 @@ def canonicalize_edges(
 
     See Also
     --------
+    symmetrize_edges : Inverse operation adding the reverse row of each edge.
     gdf_to_pyg : Convert GeoDataFrames to PyTorch Geometric objects.
     segments_to_graph : Convert LineString segments to a graph structure.
 
@@ -2023,6 +2025,103 @@ def canonicalize_edges(
         keep_mask = ~pairs.duplicated(keep="first").to_numpy()
         result = result[keep_mask]
     return result
+
+
+def symmetrize_edges(edges: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Symmetrize an edge GeoDataFrame by adding the reverse row of each edge.
+
+    For every non-self-loop edge ``(u, v)`` whose reverse ``(v, u)`` is not
+    already present, appends a row indexed ``(v, u)`` with the same attributes
+    and a reversed geometry, so that each row's geometry starts at its source
+    node. This makes neighbourhood queries on the MultiIndex complete (e.g.
+    ``edges.xs(node, level=0)`` returns every neighbour of ``node``), at the
+    cost of duplicating edge attributes and geometries. Self-loops and edges
+    whose reverse already exists are left untouched, so the operation is
+    idempotent. Three-level (source, target, key) multigraph indexes keep the
+    key of the original row on the reverse row.
+
+    This is the inverse operation of :func:`canonicalize_edges`.
+
+    Parameters
+    ----------
+    edges : geopandas.GeoDataFrame
+        Edge GeoDataFrame with a two-level (source, target) or three-level
+        (source, target, key) MultiIndex. For heterogeneous graphs, call this
+        function separately on each edge type's GeoDataFrame.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The symmetrized edge GeoDataFrame. Original rows come first with
+        columns, attributes, and CRS preserved; reverse rows are appended in
+        the order of the rows they mirror. Index level names are kept
+        positionally.
+
+    Raises
+    ------
+    ValueError
+        If the index is not a MultiIndex with at least two levels.
+
+    See Also
+    --------
+    canonicalize_edges : Inverse operation collapsing reciprocal rows.
+    gdf_to_pyg : Convert GeoDataFrames to PyTorch Geometric objects.
+
+    Notes
+    -----
+    ``gdf_to_pyg(..., directed=False)`` rejects edge tables containing both
+    ``(u, v)`` and ``(v, u)`` rows as ambiguous. Collapse a symmetrized table
+    with :func:`canonicalize_edges` first, or pass ``directed=True`` to keep
+    the reciprocal rows as directed edges.
+
+    Examples
+    --------
+    >>> import geopandas as gpd
+    >>> import pandas as pd
+    >>> from shapely.geometry import LineString
+    >>> index = pd.MultiIndex.from_tuples([(0, 1)], names=["u", "v"])
+    >>> edges = gpd.GeoDataFrame(
+    ...     {"name": ["ab"]},
+    ...     geometry=[LineString([(0, 0), (1, 1)])],
+    ...     index=index,
+    ...     crs="EPSG:32633",
+    ... )
+    >>> symmetrize_edges(edges).index.tolist()
+    [(0, 1), (1, 0)]
+    """
+    if not isinstance(edges.index, pd.MultiIndex) or edges.index.nlevels < 2:
+        msg = (
+            "Edge GeoDataFrame index must be a MultiIndex with at least "
+            "two levels (source, target)."
+        )
+        raise ValueError(msg)
+
+    if edges.empty:
+        return edges.copy()
+
+    src = np.asarray(edges.index.get_level_values(0), dtype=object)
+    dst = np.asarray(edges.index.get_level_values(1), dtype=object)
+    names = list(edges.index.names)
+
+    reversed_arrays = [dst, src]
+    reversed_arrays.extend(
+        np.asarray(edges.index.get_level_values(level), dtype=object)
+        for level in range(2, edges.index.nlevels)
+    )
+    reversed_index = pd.MultiIndex.from_arrays(reversed_arrays, names=names)
+
+    # Self-loops reverse onto themselves, so the membership test alone keeps
+    # them out of the appended rows.
+    missing = (src != dst) & ~reversed_index.isin(edges.index)
+    if not missing.any():
+        return edges.copy()
+
+    reverse_rows = edges[missing].copy()
+    reverse_rows.index = reversed_index[missing]
+    reverse_rows.geometry = reverse_rows.geometry.reverse()
+
+    return gpd.GeoDataFrame(pd.concat([edges, reverse_rows]))
 
 
 def _validate_dual_graph_input(

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,6 +1,6 @@
 ---
 description: API reference for the Utils module. Utility functions for graph conversion between GeoDataFrame, NetworkX and rustworkx, validation, tessellation, isochrone creation, and plotting.
-keywords: gdf_to_nx, nx_to_gdf, rustworkx, tessellation, isochrone, dual_graph, plot_graph, graph validation, spatial utilities
+keywords: gdf_to_nx, nx_to_gdf, rustworkx, tessellation, isochrone, dual_graph, plot_graph, graph validation, spatial utilities, canonicalize_edges, symmetrize_edges
 ---
 
 # Utils Module
@@ -18,6 +18,7 @@ The utils module provides core utility functions for graph conversion, validatio
         - validate_gdf
         - validate_nx
         - canonicalize_edges
+        - symmetrize_edges
         - dual_graph
         - filter_graph_by_distance
         - create_tessellation

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -22,6 +22,7 @@ from city2graph import graph as graph_module
 from city2graph.base import GraphMetadata
 from city2graph.proximity import contiguity_graph
 from city2graph.utils import canonicalize_edges
+from city2graph.utils import symmetrize_edges
 
 # Import torch-related modules conditionally
 try:
@@ -1483,6 +1484,18 @@ class TestUndirectedEdgeHandling:
         data = gdf_to_pyg(simple_nodes, canonicalize_edges(edges), directed=False)
         # One undirected edge, symmetrized into both directions.
         assert data.num_edges == 2
+
+    def test_symmetrize_edges_output_requires_directed_true(
+        self, simple_nodes: gpd.GeoDataFrame, simple_edges: gpd.GeoDataFrame
+    ) -> None:
+        """symmetrize_edges output converts with directed=True but not directed=False."""
+        symmetrized = symmetrize_edges(simple_edges)
+
+        with pytest.raises(ValueError, match="Ambiguous undirected input"):
+            gdf_to_pyg(simple_nodes, symmetrized, directed=False)
+
+        data = gdf_to_pyg(simple_nodes, symmetrized, directed=True)
+        assert data.num_edges == 4
 
     def test_cross_type_auto_reverse_store(
         self,

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -103,6 +103,41 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         for edge_type in expected_edges:
             assert edge_type in edges
 
+    def test_duplicate_edges_symmetrizes_same_type_edges(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """duplicate_edges=True doubles same-type edges and keeps faced_to as-is."""
+        _, base_edges = morphological_graph(sample_buildings_gdf, sample_segments_gdf)
+        _, dup_edges = morphological_graph(
+            sample_buildings_gdf, sample_segments_gdf, duplicate_edges=True
+        )
+
+        for edge_type in [
+            ("private", "touched_to", "private"),
+            ("public", "connected_to", "public"),
+        ]:
+            base = base_edges[edge_type]
+            dup = dup_edges[edge_type]
+            assert len(dup) == 2 * len(base)
+            pairs = set(base.index)
+            assert set(dup.index) == pairs | {(v, u) for u, v in pairs}
+
+        faced_to = ("private", "faced_to", "public")
+        assert dup_edges[faced_to].index.tolist() == base_edges[faced_to].index.tolist()
+
+    def test_duplicate_edges_rejects_as_nx(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """duplicate_edges=True with as_nx=True raises ValueError."""
+        with pytest.raises(ValueError, match="not supported with as_nx=True"):
+            morphological_graph(
+                sample_buildings_gdf, sample_segments_gdf, as_nx=True, duplicate_edges=True
+            )
+
     def test_missing_enclosure_index_warning(
         self,
         sample_buildings_gdf: gpd.GeoDataFrame,
@@ -1092,6 +1127,69 @@ class TestIndividualGraphFunctions(TestMorphologyBase):
 
         nodes, edges = public_to_public_graph(segments_gdf)
         self.validate_basic_output(nodes, edges)
+
+    # duplicate_edges Tests
+    def test_private_to_private_duplicate_edges(
+        self, sample_tessellation_gdf: gpd.GeoDataFrame
+    ) -> None:
+        """duplicate_edges=True doubles rows with swapped private id columns."""
+        _, base_edges = private_to_private_graph(sample_tessellation_gdf)
+        _, dup_edges = private_to_private_graph(sample_tessellation_gdf, duplicate_edges=True)
+
+        assert len(dup_edges) == 2 * len(base_edges)
+        pairs = set(zip(base_edges["from_private_id"], base_edges["to_private_id"], strict=True))
+        dup_pairs = set(zip(dup_edges["from_private_id"], dup_edges["to_private_id"], strict=True))
+        assert dup_pairs == pairs | {(v, u) for u, v in pairs}
+
+    def test_private_to_public_duplicate_edges(
+        self,
+        sample_tessellation_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """duplicate_edges=True doubles rows with swapped endpoint columns."""
+        _, base_edges = private_to_public_graph(sample_tessellation_gdf, sample_segments_gdf)
+        _, dup_edges = private_to_public_graph(
+            sample_tessellation_gdf, sample_segments_gdf, duplicate_edges=True
+        )
+
+        # private and public ids share the same integer space in the fixtures,
+        # so a base pair's reverse may already exist as another connection and
+        # the idempotent symmetrization adds no duplicate row for it.
+        pairs = set(zip(base_edges["private_id"], base_edges["public_id"], strict=True))
+        expected_pairs = pairs | {(v, u) for u, v in pairs}
+        dup_pairs = set(zip(dup_edges["private_id"], dup_edges["public_id"], strict=True))
+        assert dup_pairs == expected_pairs
+        assert len(dup_edges) == len(expected_pairs)
+        assert len(dup_edges) > len(base_edges)
+
+    def test_public_to_public_duplicate_edges(self, sample_segments_gdf: gpd.GeoDataFrame) -> None:
+        """duplicate_edges=True doubles rows with swapped public id columns."""
+        _, base_edges = public_to_public_graph(sample_segments_gdf)
+        _, dup_edges = public_to_public_graph(sample_segments_gdf, duplicate_edges=True)
+
+        assert len(dup_edges) == 2 * len(base_edges)
+        pairs = set(zip(base_edges["from_public_id"], base_edges["to_public_id"], strict=True))
+        dup_pairs = set(zip(dup_edges["from_public_id"], dup_edges["to_public_id"], strict=True))
+        assert dup_pairs == pairs | {(v, u) for u, v in pairs}
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda tess, _segs, **kw: private_to_private_graph(tess, **kw),
+            private_to_public_graph,
+            lambda _tess, segs, **kw: public_to_public_graph(segs, **kw),
+        ],
+        ids=["private_to_private", "private_to_public", "public_to_public"],
+    )
+    def test_duplicate_edges_rejects_as_nx(
+        self,
+        sample_tessellation_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        call: Callable[..., object],
+    ) -> None:
+        """duplicate_edges=True with as_nx=True raises ValueError."""
+        with pytest.raises(ValueError, match="not supported with as_nx=True"):
+            call(sample_tessellation_gdf, sample_segments_gdf, as_nx=True, duplicate_edges=True)
 
 
 class TestInputValidationAndErrors(TestMorphologyBase):

--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -116,6 +116,9 @@ def test_mst_and_waxman(small_points: gpd.GeoDataFrame) -> None:
     """MST has n-1 edges and Waxman returns expected schema."""
     _, mst_edges = euclidean_minimum_spanning_tree(small_points)
     assert len(mst_edges) == max(len(small_points) - 1, 0)
+    mst_nx = euclidean_minimum_spanning_tree(small_points, as_nx=True)
+    assert isinstance(mst_nx, nx.Graph)
+    assert mst_nx.number_of_edges() == len(mst_edges)
     _, wax_edges = waxman_graph(small_points, beta=0.8, r0=2.0, seed=7)
     # Probabilistic: just ensure schema
     assert {"weight", "geometry"}.issubset(wax_edges.columns)
@@ -262,6 +265,76 @@ def test_contiguity_empty_input() -> None:
 def test_contiguity_network_requires_network_gdf() -> None:
     """Network metric without network_gdf raises ValueError."""
     assert_network_metric_requires_network_gdf(contiguity_graph, make_square_polygons())
+
+
+# ---------------------------------------------------------------------------
+# duplicate_edges public API coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda gdf, **kw: knn_graph(gdf, k=2, **kw),
+        delaunay_graph,
+        gabriel_graph,
+        relative_neighborhood_graph,
+        euclidean_minimum_spanning_tree,
+        lambda gdf, **kw: fixed_radius_graph(gdf, radius=1.5, **kw),
+        lambda gdf, **kw: waxman_graph(gdf, beta=0.9, r0=2.0, seed=42, **kw),
+    ],
+    ids=["knn", "delaunay", "gabriel", "rng", "emst", "fixed_radius", "waxman"],
+)
+def test_duplicate_edges_adds_reverse_rows(
+    small_points: gpd.GeoDataFrame,
+    build: Callable[..., tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]],
+) -> None:
+    """duplicate_edges=True adds the reverse row of every undirected edge."""
+    _, base_edges = build(small_points)
+    _, dup_edges = build(small_points, duplicate_edges=True)
+
+    pairs = set(base_edges.index)
+    assert len(dup_edges) == 2 * len(base_edges)
+    assert set(dup_edges.index) == pairs | {(v, u) for u, v in pairs}
+
+
+def test_contiguity_duplicate_edges_completes_neighbor_queries() -> None:
+    """duplicate_edges=True makes MultiIndex neighbour queries complete (issue #156)."""
+    gdf = make_square_polygons()
+    _, base_edges = contiguity_graph(gdf, contiguity="queen")
+    _, dup_edges = contiguity_graph(gdf, contiguity="queen", duplicate_edges=True)
+
+    assert len(dup_edges) == 2 * len(base_edges)
+    srcs = base_edges.index.get_level_values(0)
+    dsts = base_edges.index.get_level_values(1)
+    for node in gdf.index:
+        forward = set(base_edges.xs(node, level=0).index) if node in srcs else set()
+        backward = set(base_edges.xs(node, level=1).index) if node in dsts else set()
+        neighbors = set(dup_edges.xs(node, level=0).index)
+        assert neighbors == forward | backward
+
+
+def test_duplicate_edges_rejects_as_nx() -> None:
+    """duplicate_edges=True with as_nx=True raises ValueError."""
+    gdf = make_square_polygons()
+    with pytest.raises(ValueError, match="not supported with as_nx=True"):
+        contiguity_graph(gdf, duplicate_edges=True, as_nx=True)
+
+
+def test_duplicate_edges_rejects_target_gdf(small_points: gpd.GeoDataFrame) -> None:
+    """duplicate_edges=True with target_gdf (directed variant) raises ValueError."""
+    with pytest.raises(ValueError, match="not supported with target_gdf"):
+        knn_graph(small_points, k=2, target_gdf=small_points, duplicate_edges=True)
+    with pytest.raises(ValueError, match="not supported with target_gdf"):
+        fixed_radius_graph(small_points, radius=1.5, target_gdf=small_points, duplicate_edges=True)
+
+
+def test_contiguity_duplicate_edges_empty_input() -> None:
+    """Empty input with duplicate_edges=True returns empty GeoDataFrames."""
+    empty = gpd.GeoDataFrame({"geometry": []}, geometry="geometry", crs="EPSG:3857")
+    nodes, edges = contiguity_graph(empty, duplicate_edges=True)
+    assert nodes.empty
+    assert edges.empty
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -915,6 +915,105 @@ class TestCanonicalizeEdges(BaseGraphTest):
             utils.canonicalize_edges(edges, duplicates="drop")  # type: ignore[arg-type]
 
 
+class TestSymmetrizeEdges(BaseGraphTest):
+    """Test symmetrize_edges adding reverse rows of undirected edges."""
+
+    @staticmethod
+    def _make_edges(
+        tuples: list[tuple[Any, ...]],
+        names: list[str] | None = None,
+    ) -> gpd.GeoDataFrame:
+        """Build an edge GeoDataFrame with one distinct row per index tuple."""
+        if names is None:
+            names = ["u", "v"] if len(tuples[0]) == 2 else ["u", "v", "k"]
+        return gpd.GeoDataFrame(
+            {"name": [f"e{i}" for i in range(len(tuples))]},
+            geometry=[LineString([(i, 0), (i + 1, 1)]) for i in range(len(tuples))],
+            index=pd.MultiIndex.from_tuples(tuples, names=names),
+            crs="EPSG:27700",
+        )
+
+    def test_adds_reverse_rows(self) -> None:
+        """Each canonical edge gains a reverse row with copied attributes."""
+        edges = self._make_edges([(0, 1), (1, 2)])
+        result = utils.symmetrize_edges(edges)
+
+        assert result.index.tolist() == [(0, 1), (1, 2), (1, 0), (2, 1)]
+        assert result.index.names == ["u", "v"]
+        assert list(result["name"]) == ["e0", "e1", "e0", "e1"]
+        assert result.crs == edges.crs
+
+    def test_reverse_rows_have_reversed_geometry(self) -> None:
+        """Reverse rows reverse the LineString so it starts at the source node."""
+        edges = self._make_edges([(0, 1)])
+        result = utils.symmetrize_edges(edges)
+
+        forward = list(result.geometry.loc[(0, 1)].coords)
+        backward = list(result.geometry.loc[(1, 0)].coords)
+        assert backward == forward[::-1]
+
+    def test_self_loops_not_duplicated(self) -> None:
+        """Self-loops appear only once in the output."""
+        edges = self._make_edges([(2, 2), (0, 1)])
+        result = utils.symmetrize_edges(edges)
+        assert result.index.tolist() == [(2, 2), (0, 1), (1, 0)]
+
+    def test_idempotent(self) -> None:
+        """Applying symmetrize_edges twice equals applying it once."""
+        edges = self._make_edges([(0, 1), (1, 2)])
+        once = utils.symmetrize_edges(edges)
+        twice = utils.symmetrize_edges(once)
+        assert twice.equals(once)
+
+    def test_already_bidirectional_input_unchanged(self) -> None:
+        """Inputs already holding both directions gain no extra rows."""
+        edges = self._make_edges([(0, 1), (1, 0)])
+        result = utils.symmetrize_edges(edges)
+        assert result.index.tolist() == [(0, 1), (1, 0)]
+        assert list(result["name"]) == ["e0", "e1"]
+
+    def test_three_level_index_keeps_keys(self) -> None:
+        """Multigraph keys are preserved on reverse rows."""
+        edges = self._make_edges([(0, 1, 0), (0, 1, 1)])
+        result = utils.symmetrize_edges(edges)
+        assert result.index.tolist() == [(0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1)]
+        assert result.index.names == ["u", "v", "k"]
+
+    def test_round_trip_with_canonicalize(self) -> None:
+        """canonicalize_edges collapses symmetrized output back to the input."""
+        edges = self._make_edges([(0, 1), (1, 2)])
+        result = utils.canonicalize_edges(utils.symmetrize_edges(edges))
+        assert result.equals(edges)
+
+    def test_mixed_type_ids_supported(self) -> None:
+        """Mixed, non-comparable identifier types are symmetrized verbatim."""
+        edges = self._make_edges([("a", 1)])
+        result = utils.symmetrize_edges(edges)
+        assert result.index.tolist() == [("a", 1), (1, "a")]
+
+    def test_empty_input_returns_copy(self) -> None:
+        """An empty edge GeoDataFrame is returned unchanged."""
+        edges = gpd.GeoDataFrame(
+            {"name": []},
+            geometry=[],
+            index=pd.MultiIndex.from_arrays([[], []], names=["u", "v"]),
+            crs="EPSG:27700",
+        )
+        result = utils.symmetrize_edges(edges)
+        assert result.empty
+        assert result is not edges
+
+    def test_non_multiindex_raises(self) -> None:
+        """A flat index is rejected."""
+        edges = gpd.GeoDataFrame(
+            {"name": ["e0"]},
+            geometry=[LineString([(0, 0), (1, 1)])],
+            crs="EPSG:27700",
+        )
+        with pytest.raises(ValueError, match="MultiIndex with at least"):
+            utils.symmetrize_edges(edges)
+
+
 # ============================================================================
 # GRAPH ANALYSIS TESTS
 # ============================================================================


### PR DESCRIPTION
## Summary

Add `symmetrize_edges()` and `duplicate_edges` parameter for complete neighbourhood queries

Undirected graph construction functions return edge GeoDataFrames with one row per edge `(u, v)`, so GeoPandas-based neighbourhood queries such as `edges.xs(node, level=0)` return incomplete results. This PR adds an opt-in way to materialize both `(u, v)` and `(v, u)` rows.

Closes #156 (the GeoDataFrame-side follow-up discussed after #157).

## What changed

- **New public utility `city2graph.symmetrize_edges(edges)`** in `utils.py`, the inverse of `canonicalize_edges`:
  - Appends the reverse `(v, u)` row of every non-self-loop edge whose reverse is not already present (idempotent: applying it twice is a no-op).
  - Reverse rows copy attributes and **reverse the LineString geometry**, so each row's geometry starts at its source node.
  - Three-level `(source, target, key)` multigraph indexes keep the key on the reverse row, consistent with the `(src, dst, key)` matching in `gdf_to_pyg`.
- **New keyword parameter `duplicate_edges: bool = False`** on the undirected construction functions:
  - `proximity.py`: `knn_graph`, `delaunay_graph`, `gabriel_graph`, `relative_neighborhood_graph`, `euclidean_minimum_spanning_tree`, `fixed_radius_graph`, `waxman_graph`, `contiguity_graph` (hooked into the shared `GraphBuilder.to_output`).
  - `morphology.py`: `morphological_graph` (only the same-node-type `touched_to` / `connected_to` edge types; `faced_to` is excluded because a reverse row would mix public ids into the private index level), `private_to_private_graph`, `public_to_public_graph`, `private_to_public_graph`.
- **Conflicts are rejected up front with `ValueError`**: `duplicate_edges=True` with `as_nx=True` (an undirected `nx.Graph` cannot hold reciprocal edges), and with `target_gdf` on `knn_graph`/`fixed_radius_graph` (directed variant).
- Docs: `symmetrize_edges` added to `docs/api/utils.md`.

## Notes

- The existing undirected/multigraph rules in `gdf_to_pyg` are untouched: `directed=False` still rejects bidirectional input. The `symmetrize_edges` docstring documents that symmetrized tables must be collapsed with `canonicalize_edges` first (or passed with `directed=True`), and a test asserts this interplay.
- Default stays `False` to avoid doubling edge geometries unless explicitly requested.
- Tests cover geometry reversal, idempotency, self-loops, multigraph keys, the round-trip with `canonicalize_edges`, the issue's neighbour-query use case, and all conflict errors. `uv run pytest -q` (769 passed, new lines fully covered) and `uv run pre-commit run --all-files` both pass.

## Related Issues

#156 (the GeoDataFrame-side follow-up discussed after #157).

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.