### PR TITLE
Fix the default value of `extent_buffer` from 50.0 to 100.0

### DIFF
--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -137,7 +137,7 @@ def morphological_graph(  # noqa: PLR0913
     center_point: gpd.GeoSeries | gpd.GeoDataFrame | None = None,
     distance: float | None = None,
     clipping_buffer: float = math.inf,
-    extent_buffer: float = 50.0,
+    extent_buffer: float = 100.0,
     limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None = None,
     primary_barrier_col: str | None = "barrier_geometry",
     contiguity: str = "queen",
@@ -177,7 +177,7 @@ def morphological_graph(  # noqa: PLR0913
     clipping_buffer : float, default=math.inf
         Buffer distance to ensure adequate context for generating tessellation.
         Must be non-negative and not smaller than ``extent_buffer``.
-    extent_buffer : float, default=50.0
+    extent_buffer : float, default=100.0
         Maximum perpendicular access distance (a bounded catchment cap) from a
         street to a building/cell for it to be retained, and the maximum length
         of a ``faced_to`` connection. Unlike ``distance`` this access term is

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1,5 +1,6 @@
 """Refactored test module for morphology.py with improved maintainability and reduced redundancy."""
 
+import inspect
 import logging
 import math
 import warnings
@@ -681,7 +682,7 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         faced_place_ids = set(faced.index.get_level_values(0)) if not faced.empty else set()
 
         # The "isolated" cell sits 30 m from the street, within the default
-        # extent_buffer (50 m), so it receives a nearest movement fallback
+        # extent_buffer (100 m), so it receives a nearest movement fallback
         # faced_to edge and is kept rather than pruned.
         assert place_ids == {"near", "isolated"}
         assert place_ids <= faced_place_ids
@@ -743,6 +744,9 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         sample_segments_gdf: gpd.GeoDataFrame,
     ) -> None:
         """extent_buffer must be non-negative and not exceed clipping_buffer."""
+        sig = inspect.signature(morphological_graph)
+        assert sig.parameters["extent_buffer"].default == 100.0
+
         with pytest.raises(ValueError, match="clipping_buffer must be greater"):
             morphological_graph(
                 sample_buildings_gdf,


### PR DESCRIPTION
## Description

Fix the parameter `extent_buffer` in `morphological_graph()` with default of 100.0 rather than 50.0.

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
