### PR TITLE
Enhance options for morphological_graph()

### DIFF
--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -147,6 +147,9 @@ def morphological_graph(  # noqa: PLR0913
     include_unenclosed_buildings: bool = False,
     as_nx: bool = False,
     duplicate_edges: bool = False,
+    non_movement_barrier_col: str | None = None,
+    tessellation_fallback: bool = False,
+    tessellation_n_jobs: int = -1,
 ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]] | nx.Graph:
     """
     Create a morphological graph from buildings and street segments.
@@ -192,6 +195,10 @@ def morphological_graph(  # noqa: PLR0913
     primary_barrier_col : str, optional
         Column name containing alternative geometry for movement spaces. If specified and exists,
         this geometry will be used instead of the main geometry column for tessellation barriers.
+        This only *substitutes the geometry* of a segment; it never removes a row from the movement
+        layer, so every segment it applies to still becomes a movement node. To make individual rows
+        act as barriers only (excluded from the movement layer), use ``non_movement_barrier_col``,
+        which is an orthogonal setting.
     contiguity : str, default="queen"
         Type of spatial contiguity for place-to-place connections.
         Must be either "queen" or "rook".
@@ -218,6 +225,28 @@ def morphological_graph(  # noqa: PLR0913
         ("place", "faced_to", "movement") edges are left unchanged because a
         reverse row would mix movement ids into the place index level.
         Incompatible with ``as_nx=True``.
+    non_movement_barrier_col : str, optional
+        Name of a boolean column in ``segments_gdf`` flagging rows that act as
+        barriers only. Flagged segments contribute to the tessellation barriers
+        (clipped to the same radius as the buffered movement network) but are
+        excluded from the movement nodes, the movement-to-movement graph and the
+        network-distance computation. Rows where the column is missing or false
+        are treated as ordinary movement segments. When None (default) every
+        segment is a movement segment, preserving the previous behaviour.
+        Whereas ``primary_barrier_col`` selects *which geometry* a segment uses,
+        this flag decides *whether a row becomes a movement node at all*; the two
+        settings are orthogonal.
+    tessellation_fallback : bool, default=False
+        If True and the enclosed tessellation encloses no area (``momepy`` raises
+        ``"No objects to concatenate"``) or yields no cells while buildings and
+        reachable segments exist, fall back to using the reachable building
+        footprints themselves as place cells. When False (default) the enclosed
+        tessellation result is returned unchanged, preserving the previous
+        behaviour (the underlying error is propagated).
+    tessellation_n_jobs : int, default=-1
+        Number of parallel jobs forwarded to the enclosed tessellation. Use
+        ``1`` to run serially, which avoids oversubscription when this function
+        is itself called inside an outer parallel loop.
 
     Returns
     -------
@@ -305,8 +334,17 @@ def morphological_graph(  # noqa: PLR0913
     segments_gdf = segments_gdf.copy()
     segments_gdf[movement_id_col] = segments_gdf.index
 
-    # Compute the single-source reachability cost field once on the full network so that
-    # streets, buildings and cells are all judged against the same metric on the same network.
+    # Split out barrier-only segments so they shape the tessellation barriers
+    # without ever becoming movement nodes or entering the reachability network.
+    barrier_segments = None
+    if non_movement_barrier_col and non_movement_barrier_col in segments_gdf.columns:
+        barrier_mask = segments_gdf[non_movement_barrier_col].fillna(value=False).astype(bool)
+        barrier_segments = segments_gdf.loc[barrier_mask].copy()
+        segments_gdf = segments_gdf.loc[~barrier_mask].copy()
+
+    # Compute the single-source reachability cost field once on the movement network so
+    # that streets, buildings and cells are all judged against the same metric on the
+    # same network.
     reachability_field: _ReachabilityField | None = None
     if center_point is not None and distance is not None and not segments_gdf.empty:
         _, full_segment_edges = segments_to_graph(segments_gdf)
@@ -318,6 +356,17 @@ def morphological_graph(  # noqa: PLR0913
         distance,
         clipping_buffer,
         field=reachability_field,
+    )
+
+    # Barrier-only segments enrich the tessellation context only; they never
+    # reach the movement layers built from ``segments_filtered``.
+    segments_buffer = _append_barrier_context_segments(
+        segments_buffer,
+        barrier_segments,
+        center_point,
+        distance,
+        clipping_buffer,
+        primary_barrier_col,
     )
 
     tessellation = _create_and_filter_tessellation(
@@ -334,6 +383,8 @@ def morphological_graph(  # noqa: PLR0913
         extent_buffer,
         limit=limit,
         field=reachability_field,
+        tessellation_fallback=tessellation_fallback,
+        n_jobs=tessellation_n_jobs,
     )
 
     # When a reachability budget is applied, prune place cells that face no
@@ -1331,6 +1382,8 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
     extent_buffer: float = math.inf,
     limit: gpd.GeoDataFrame | gpd.GeoSeries | BaseGeometry | None = None,
     field: _ReachabilityField | None = None,
+    tessellation_fallback: bool = False,
+    n_jobs: int = -1,
 ) -> gpd.GeoDataFrame:
     """
     Create tessellation and apply spatial filters.
@@ -1376,6 +1429,17 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
         provided it is reused for both the building and tessellation network
         filters so they share a single metric; when ``None`` each filter computes
         its own field from the segments it is given.
+    tessellation_fallback : bool, default False
+        If True, fall back to reachable building footprints as place cells when
+        the enclosed tessellation encloses no area (``momepy`` raises
+        ``"No objects to concatenate"``) or yields no cells while buildings and
+        reachable segments exist. When False the enclosed tessellation result is
+        returned unchanged and any underlying error is propagated.
+    n_jobs : int, default -1
+        Number of parallel jobs forwarded to `create_tessellation` (and in turn
+        `momepy.enclosed_tessellation`). Use ``1`` to run serially, which avoids
+        oversubscription when this function is itself called inside an outer
+        parallel loop.
 
     Returns
     -------
@@ -1387,11 +1451,30 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
     tessellation_kwargs = {}
     if limit is not None:
         tessellation_kwargs["limit"] = limit
-    tessellation = create_tessellation(
-        buildings_gdf,
-        primary_barriers=None if barriers.empty else barriers,  # Use barriers if available
-        **tessellation_kwargs,
-    )
+    if n_jobs != -1:
+        tessellation_kwargs["n_jobs"] = n_jobs
+    try:
+        tessellation = create_tessellation(
+            buildings_gdf,
+            primary_barriers=None if barriers.empty else barriers,  # Use barriers if available
+            **tessellation_kwargs,
+        )
+    except ValueError as exc:
+        # momepy raises "No objects to concatenate" when the barriers enclose no
+        # area. With the fallback enabled, use building footprints as cells
+        # instead of propagating the error.
+        if not (tessellation_fallback and str(exc) == "No objects to concatenate"):
+            raise
+        return _fallback_tessellation_without_enclosures(
+            buildings_gdf,
+            segments_filtered,
+            center_point,
+            distance,
+            place_id_col,
+            extent_buffer,
+            keep_buildings,
+            field=field,
+        )
 
     tessellation = tessellation.rename(columns={"tess_id": place_id_col})
 
@@ -1442,6 +1525,25 @@ def _create_and_filter_tessellation(  # noqa: PLR0913
     # Optionally preserve building information by joining tessellation with buildings
     if keep_buildings:
         tessellation = _add_building_info(tessellation, eligible_buildings)
+
+    # When the enclosed tessellation retained nothing despite usable inputs, fall
+    # back to building footprints so the morphology graph still has place cells.
+    if (
+        tessellation_fallback
+        and tessellation.empty
+        and not buildings_gdf.empty
+        and not segments_filtered.empty
+    ):
+        return _fallback_tessellation_without_enclosures(
+            buildings_gdf,
+            segments_filtered,
+            center_point,
+            distance,
+            place_id_col,
+            extent_buffer,
+            keep_buildings,
+            field=field,
+        )
 
     return tessellation
 
@@ -1546,6 +1648,122 @@ def _filter_buildings_by_network_distance(
         field=field,
     )
     return buildings_gdf.iloc[keep_ilocs].copy()
+
+
+def _valid_polygon_gdf(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Return only valid polygonal rows, repairing self-intersections in place.
+
+    Rows whose geometry is missing, empty or not a (Multi)Polygon are dropped.
+    Remaining invalid polygons are repaired with a zero-width buffer and
+    re-validated, so the result contains only usable polygon footprints.
+
+    Parameters
+    ----------
+    gdf : geopandas.GeoDataFrame
+        Candidate polygon geometries (typically building footprints).
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The valid polygonal subset of ``gdf``.
+    """
+    out = gdf.copy()
+    valid_geom = out.geometry.notna() & ~out.geometry.is_empty
+    valid_geom = valid_geom & out.geometry.geom_type.isin(["Polygon", "MultiPolygon"])
+    out = out.loc[valid_geom].copy()
+    if out.empty:
+        return out
+
+    invalid = ~out.geometry.is_valid
+    if invalid.any():
+        out.loc[invalid, out.geometry.name] = out.loc[invalid].geometry.buffer(0)
+        valid_geom = out.geometry.notna() & ~out.geometry.is_empty & out.geometry.is_valid
+        valid_geom = valid_geom & out.geometry.geom_type.isin(["Polygon", "MultiPolygon"])
+        out = out.loc[valid_geom].copy()
+    return out
+
+
+def _fallback_tessellation_without_enclosures(
+    buildings_gdf: gpd.GeoDataFrame,
+    segments_filtered: gpd.GeoDataFrame,
+    center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point | None,
+    distance: float | None,
+    place_id_col: str,
+    extent_buffer: float,
+    keep_buildings: bool,
+    field: _ReachabilityField | None = None,
+) -> gpd.GeoDataFrame:
+    """
+    Build place cells from building footprints when enclosed tessellation fails.
+
+    Used as a fallback when the enclosed tessellation encloses no area or yields
+    no cells. Each reachable building footprint becomes its own place cell, tagged
+    with a synthetic ``fallback_`` place id and a single ``"fallback"`` enclosure,
+    and is judged against the same reachability budget (network ``distance`` plus
+    ``extent_buffer`` access cap) as the primary path so retention rules match.
+
+    Parameters
+    ----------
+    buildings_gdf : geopandas.GeoDataFrame
+        Building footprints used as fallback cells.
+    segments_filtered : geopandas.GeoDataFrame
+        Reachable movement segments used for the network-distance filters.
+    center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point or None
+        Centre for the reachability budget. Distance filters are skipped when None.
+    distance : float or None
+        Maximum network distance for a cell to be retained.
+    place_id_col : str
+        Name of the place ID column.
+    extent_buffer : float
+        Maximum perpendicular access distance from a street to a cell centroid.
+    keep_buildings : bool
+        If True, attach building information via ``building_geometry``.
+    field : _ReachabilityField or None, optional
+        Shared reachability cost field reused for the network-distance filters.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Fallback tessellation cells, possibly empty when nothing is reachable.
+    """
+    buildings = _valid_polygon_gdf(buildings_gdf)
+    if buildings.empty:
+        return buildings.iloc[0:0].copy()
+
+    # Retention uses the reachable isochrone streets and the bounded access cap,
+    # matching the primary path so fallback cells obey the same acceptance rule.
+    buildings = _filter_buildings_by_network_distance(
+        buildings,
+        segments_filtered,
+        center_point,
+        distance,
+        extent_buffer,
+        field=field,
+    )
+    if buildings.empty:
+        return buildings.iloc[0:0].copy()
+
+    tessellation = gpd.GeoDataFrame(
+        {
+            place_id_col: "fallback_" + buildings.index.astype(str),
+            "enclosure_index": "fallback",
+        },
+        geometry=buildings.geometry.to_numpy(),
+        crs=buildings.crs,
+    )
+    if center_point is not None and distance is not None:
+        tessellation = _filter_tessellation_by_network_distance(
+            tessellation,
+            segments_filtered,
+            center_point,
+            distance,
+            extent_buffer,
+            field=field,
+        )
+    if keep_buildings:
+        tessellation = _add_building_info(tessellation, buildings)
+    return tessellation
 
 
 def _buildings_without_tessellation(
@@ -1770,6 +1988,78 @@ def _prepare_barriers(
             crs=segments.crs,
         )
     return segments.copy()
+
+
+def _append_barrier_context_segments(
+    segments_buffer: gpd.GeoDataFrame,
+    barrier_segments: gpd.GeoDataFrame | None,
+    center_point: gpd.GeoSeries | gpd.GeoDataFrame | Point | None,
+    distance: float | None,
+    clipping_buffer: float,
+    primary_barrier_col: str | None,
+) -> gpd.GeoDataFrame:
+    """
+    Merge barrier-only segments into the tessellation context buffer.
+
+    Barrier-only rows shape the tessellation barriers but are never movement
+    nodes, so they are added to ``segments_buffer`` (which provides tessellation
+    context only) rather than to the filtered movement segments. They are first
+    clipped to the same radius used for the buffered movement network so distant
+    barriers do not enlarge the tessellation extent.
+
+    Parameters
+    ----------
+    segments_buffer : geopandas.GeoDataFrame
+        Buffered movement segments used as tessellation context.
+    barrier_segments : geopandas.GeoDataFrame or None
+        Barrier-only segments to merge in. When None or empty the buffer is
+        returned unchanged.
+    center_point : geopandas.GeoSeries or geopandas.GeoDataFrame or shapely.geometry.Point or None
+        Centre used to clip barriers by radius. Clipping is skipped when None.
+    distance : float or None
+        Network-distance budget. Clipping is skipped when None.
+    clipping_buffer : float
+        Buffer added to ``distance`` to obtain the clipping radius. When infinite
+        the radius falls back to ``distance``.
+    primary_barrier_col : str or None
+        Name of the alternative barrier-geometry column. When present in the
+        buffer it is populated on the appended barriers (from their geometry) so
+        :func:`_prepare_barriers` reads both barrier sets from one column.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The buffer with barrier-only segments appended, or the unchanged buffer.
+    """
+    if barrier_segments is None or barrier_segments.empty:
+        return segments_buffer
+
+    barriers = barrier_segments
+    if center_point is not None and distance is not None:
+        radius = distance if math.isinf(clipping_buffer) else distance + clipping_buffer
+        center_geom = _extract_center_geometry(center_point)
+        barriers = barriers.loc[barriers.geometry.distance(center_geom) <= radius]
+    if barriers.empty:
+        return segments_buffer
+
+    barriers = barriers.copy()
+    geometry_name = segments_buffer.geometry.name
+    if barriers.geometry.name != geometry_name:
+        barriers = barriers.rename_geometry(geometry_name)
+    if (
+        primary_barrier_col
+        and primary_barrier_col != geometry_name
+        and primary_barrier_col in segments_buffer.columns
+        and primary_barrier_col not in barriers.columns
+    ):
+        barriers[primary_barrier_col] = barriers.geometry
+
+    merged = (
+        barriers
+        if segments_buffer.empty
+        else pd.concat([segments_buffer, barriers], ignore_index=False, sort=False)
+    )
+    return gpd.GeoDataFrame(merged, geometry=geometry_name, crs=segments_buffer.crs)
 
 
 def _add_building_info(

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -5,6 +5,7 @@ import logging
 import math
 import warnings
 from collections.abc import Callable
+from functools import partial
 from typing import Any
 
 import geopandas as gpd
@@ -30,6 +31,205 @@ from city2graph.morphology import private_to_public_graph
 from city2graph.morphology import public_to_public_graph
 from tests.helpers import assert_valid_nx_graph
 from tests.helpers import make_grid_polygons_gdf
+
+# ---------------------------------------------------------------------------
+# Module-level monkeypatch stubs.
+#
+# These replace the production callables that tests patch out. They live at
+# module scope (never nested inside a test) and receive any per-test state via
+# ``functools.partial`` rather than closures.
+# ---------------------------------------------------------------------------
+
+
+def _fake_sjoin_without_index_right(
+    tessellation: gpd.GeoDataFrame,
+    _buildings: gpd.GeoDataFrame,
+    *,
+    how: str,
+    predicate: str,
+) -> gpd.GeoDataFrame:
+    """Stub for ``sjoin`` that returns the tessellation without an ``index_right`` column."""
+    assert how == "left"
+    assert predicate == "contains"
+    return tessellation.copy()
+
+
+def _single_enclosed_cell_tessellation(
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+) -> gpd.GeoDataFrame:
+    """Return a single enclosed cell over the first input geometry."""
+    _ = primary_barriers
+    return gpd.GeoDataFrame(
+        {"tess_id": ["enclosed"], "enclosure_index": [0]},
+        geometry=[geometry.geometry.iloc[0]],
+        crs=geometry.crs,
+    )
+
+
+def _enclosed_cell_or_fail_on_fallback(
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+) -> gpd.GeoDataFrame:
+    """Enclosed cell for barrier input; fail if a non-local fallback is requested."""
+    if primary_barriers is not None:
+        return gpd.GeoDataFrame(
+            {"tess_id": ["enclosed"], "enclosure_index": [0]},
+            geometry=[geometry.geometry.iloc[0]],
+            crs=geometry.crs,
+        )
+    msg = "fallback should not create a non-local tessellation"
+    raise AssertionError(msg)
+
+
+def _enclosed_or_clip_fallback_tessellation(
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+) -> gpd.GeoDataFrame:
+    """Enclosed cell for barriers; a single large overlapping cell otherwise."""
+    if primary_barriers is not None:
+        return gpd.GeoDataFrame(
+            {"tess_id": ["enclosed"], "enclosure_index": [0]},
+            geometry=[geometry.geometry.iloc[0]],
+            crs=geometry.crs,
+        )
+    return gpd.GeoDataFrame(
+        {"tess_id": geometry.index.to_list()},
+        geometry=[Polygon([(0.75, -1), (5, -1), (5, 2), (0.75, 2)])],
+        crs=geometry.crs,
+    )
+
+
+def _fail_if_tessellation_called(
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+) -> gpd.GeoDataFrame:
+    """Guard stub asserting ``create_tessellation`` is never invoked."""
+    _ = (geometry, primary_barriers)
+    msg = "fallback should not create a non-local tessellation"
+    raise AssertionError(msg)
+
+
+def _unit_square_tessellation(
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+) -> gpd.GeoDataFrame:
+    """Single unit-square tessellation cell."""
+    _ = primary_barriers
+    return gpd.GeoDataFrame(
+        {"tess_id": ["t1"]},
+        geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+        crs=geometry.crs,
+    )
+
+
+def _two_cell_tessellation(
+    cell_ids: list[str],
+    cell_geometries: list[Polygon],
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+) -> gpd.GeoDataFrame:
+    """Return a fixed two-cell enclosed tessellation."""
+    _ = primary_barriers
+    return gpd.GeoDataFrame(
+        {"tess_id": cell_ids, "enclosure_index": [0] * len(cell_ids)},
+        geometry=cell_geometries,
+        crs=geometry.crs,
+    )
+
+
+def _key_recording_tessellation(
+    captured: dict[str, object],
+    key: str,
+    default: object,
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+    **kwargs: object,
+) -> gpd.GeoDataFrame:
+    """Record one ``create_tessellation`` kwarg, then return a single cell."""
+    _ = primary_barriers
+    captured[key] = kwargs.get(key, default)
+    return gpd.GeoDataFrame(
+        {"tess_id": ["cell"], "enclosure_index": [0]},
+        geometry=[geometry.geometry.iloc[0]],
+        crs=geometry.crs,
+    )
+
+
+def _raise_no_objects_tessellation(
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+    **kwargs: object,
+) -> gpd.GeoDataFrame:
+    """create_tessellation stub raising momepy's empty-concat error."""
+    _ = (geometry, primary_barriers, kwargs)
+    msg = "No objects to concatenate"
+    raise ValueError(msg)
+
+
+def _empty_tessellation(
+    geometry: gpd.GeoDataFrame,
+    primary_barriers: gpd.GeoDataFrame | None = None,
+    **kwargs: object,
+) -> gpd.GeoDataFrame:
+    """create_tessellation stub returning an empty enclosed tessellation."""
+    _ = (primary_barriers, kwargs)
+    return gpd.GeoDataFrame(
+        {"tess_id": [], "enclosure_index": []},
+        geometry=[],
+        crs=geometry.crs,
+    )
+
+
+def _passthrough_adjacent_filter(
+    tessellation: gpd.GeoDataFrame,
+    _segments: gpd.GeoDataFrame,
+    max_distance: float = float("inf"),
+) -> gpd.GeoDataFrame:
+    """Adjacent-tessellation filter stub that returns the input unchanged."""
+    _ = max_distance
+    return tessellation
+
+
+def _return_input_tessellation(
+    tessellation: gpd.GeoDataFrame,
+    *_args: object,
+    **_kwargs: object,
+) -> gpd.GeoDataFrame:
+    """Network-distance filter stub that returns the tessellation unchanged."""
+    return tessellation
+
+
+def _connect_to_first_edge(
+    _graph: nx.Graph,
+    _point_node_id: str,
+    _point: Point,
+    edge_records: list[tuple[Any, Any, LineString, float]],
+) -> tuple[tuple[Any, Any, LineString, float], float, float]:
+    """Connect a point to the first candidate edge with zero-length legs."""
+    return edge_records[0], 0.0, 0.0
+
+
+def _counting_wrapper(
+    state: dict[str, int],
+    wrapped: Callable[..., Any],
+    *args: Any,  # noqa: ANN401
+    **kwargs: Any,  # noqa: ANN401
+) -> Any:  # noqa: ANN401
+    """Count invocations while delegating to the wrapped callable."""
+    state["n"] += 1
+    return wrapped(*args, **kwargs)
+
+
+def _field_recording_wrapper(
+    seen_fields: list[object],
+    wrapped: Callable[..., Any],
+    *args: Any,  # noqa: ANN401
+    **kwargs: Any,  # noqa: ANN401
+) -> Any:  # noqa: ANN401
+    """Record the ``field`` kwarg while delegating to the wrapped callable."""
+    seen_fields.append(kwargs.get("field"))
+    return wrapped(*args, **kwargs)
 
 
 class TestMorphologyBase:
@@ -179,19 +379,7 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """keep_buildings should still allocate building_geometry when sjoin omits index_right."""
-
-        def fake_sjoin(
-            tessellation: gpd.GeoDataFrame,
-            _buildings: gpd.GeoDataFrame,
-            *,
-            how: str,
-            predicate: str,
-        ) -> gpd.GeoDataFrame:
-            assert how == "left"
-            assert predicate == "contains"
-            return tessellation.copy()
-
-        monkeypatch.setattr("city2graph.morphology.gpd.sjoin", fake_sjoin)
+        monkeypatch.setattr("city2graph.morphology.gpd.sjoin", _fake_sjoin_without_index_right)
 
         nodes, _edges = morphological_graph(
             sample_buildings_gdf,
@@ -220,31 +408,13 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             crs=sample_crs,
         )
 
-        def fake_create_tessellation(
-            geometry: gpd.GeoDataFrame,
-            primary_barriers: gpd.GeoDataFrame | None = None,
-        ) -> gpd.GeoDataFrame:
-            if primary_barriers is not None:
-                return gpd.GeoDataFrame(
-                    {"tess_id": ["enclosed"], "enclosure_index": [0]},
-                    geometry=[geometry.geometry.iloc[0]],
-                    crs=sample_crs,
-                )
-            msg = "fallback should not create a non-local tessellation"
-            raise AssertionError(msg)
-
-        def passthrough_filter(
-            tessellation: gpd.GeoDataFrame,
-            _segments: gpd.GeoDataFrame,
-            max_distance: float = float("inf"),
-        ) -> gpd.GeoDataFrame:
-            _ = max_distance
-            return tessellation
-
-        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _enclosed_cell_or_fail_on_fallback,
+        )
         monkeypatch.setattr(
             "city2graph.morphology._filter_adjacent_tessellation",
-            passthrough_filter,
+            _passthrough_adjacent_filter,
         )
 
         default_nodes, _ = morphological_graph(buildings, segments, keep_buildings=True)
@@ -276,20 +446,10 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         )
         captured: dict[str, object] = {}
 
-        def fake_create_tessellation(
-            geometry: gpd.GeoDataFrame,
-            primary_barriers: gpd.GeoDataFrame | None = None,
-            **kwargs: object,
-        ) -> gpd.GeoDataFrame:
-            _ = (geometry, primary_barriers)
-            captured["limit"] = kwargs.get("limit")
-            return gpd.GeoDataFrame(
-                {"tess_id": ["cell"], "enclosure_index": [0]},
-                geometry=[buildings.geometry.iloc[0]],
-                crs=sample_crs,
-            )
-
-        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            partial(_key_recording_tessellation, captured, "limit", None),
+        )
 
         morphological_graph(buildings, segments, limit=custom_limit)
 
@@ -316,15 +476,10 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             crs=sample_crs,
         )
 
-        def fake_create_tessellation(
-            geometry: gpd.GeoDataFrame,
-            primary_barriers: gpd.GeoDataFrame | None = None,
-        ) -> gpd.GeoDataFrame:
-            _ = (geometry, primary_barriers)
-            msg = "fallback should not create a non-local tessellation"
-            raise AssertionError(msg)
-
-        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _fail_if_tessellation_called,
+        )
 
         result = _include_unenclosed_building_tessellation(
             tessellation,
@@ -354,38 +509,17 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             crs=sample_crs,
         )
 
-        def fake_create_tessellation(
-            geometry: gpd.GeoDataFrame,
-            primary_barriers: gpd.GeoDataFrame | None = None,
-        ) -> gpd.GeoDataFrame:
-            if primary_barriers is not None:
-                return gpd.GeoDataFrame(
-                    {"tess_id": ["enclosed"], "enclosure_index": [0]},
-                    geometry=[geometry.geometry.iloc[0]],
-                    crs=sample_crs,
-                )
-            return gpd.GeoDataFrame(
-                {"tess_id": geometry.index.to_list()},
-                geometry=[Polygon([(0.75, -1), (5, -1), (5, 2), (0.75, 2)])],
-                crs=sample_crs,
-            )
-
-        def passthrough_filter(
-            tessellation: gpd.GeoDataFrame,
-            _segments: gpd.GeoDataFrame,
-            max_distance: float = float("inf"),
-        ) -> gpd.GeoDataFrame:
-            _ = max_distance
-            return tessellation
-
-        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _enclosed_or_clip_fallback_tessellation,
+        )
         monkeypatch.setattr(
             "city2graph.morphology._filter_adjacent_tessellation",
-            passthrough_filter,
+            _passthrough_adjacent_filter,
         )
         monkeypatch.setattr(
             "city2graph.morphology._filter_tessellation_by_network_distance",
-            lambda tessellation, *_args, **_kwargs: tessellation,
+            _return_input_tessellation,
         )
 
         nodes, _ = morphological_graph(
@@ -506,18 +640,10 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             crs=sample_crs,
         )
 
-        def fake_create_tessellation(
-            geometry: gpd.GeoDataFrame,
-            primary_barriers: gpd.GeoDataFrame | None = None,
-        ) -> gpd.GeoDataFrame:
-            _ = primary_barriers
-            return gpd.GeoDataFrame(
-                {"tess_id": ["enclosed"], "enclosure_index": [0]},
-                geometry=[geometry.geometry.iloc[0]],
-                crs=sample_crs,
-            )
-
-        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _single_enclosed_cell_tessellation,
+        )
 
         tessellation = _create_and_filter_tessellation(
             buildings,
@@ -545,44 +671,17 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
         """Distance filtering should degrade to an empty place layer if the center node is absent."""
         center_point = gpd.GeoSeries([Point(0.5, 0.5)], crs=sample_crs)
 
-        def fake_create_tessellation(
-            buildings_gdf: gpd.GeoDataFrame,
-            primary_barriers: gpd.GeoDataFrame | None = None,
-        ) -> gpd.GeoDataFrame:
-            _ = (buildings_gdf, primary_barriers)
-            return gpd.GeoDataFrame(
-                {"tess_id": ["t1"]},
-                geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
-                crs=sample_crs,
-            )
-
-        def fake_filter_adjacent_tessellation(
-            tessellation: gpd.GeoDataFrame,
-            segments: gpd.GeoDataFrame,
-            max_distance: float = float("inf"),
-        ) -> gpd.GeoDataFrame:
-            _ = (segments, max_distance)
-            return tessellation
-
-        def fake_connect_point_to_nearest_edge(
-            _graph: nx.Graph,
-            _point_node_id: str,
-            _point: Point,
-            edge_records: list[tuple[Any, Any, LineString, float]],
-        ) -> tuple[tuple[Any, Any, LineString, float], float, float]:
-            return edge_records[0], 0.0, 0.0
-
         monkeypatch.setattr(
             "city2graph.morphology.create_tessellation",
-            fake_create_tessellation,
+            _unit_square_tessellation,
         )
         monkeypatch.setattr(
             "city2graph.morphology._filter_adjacent_tessellation",
-            fake_filter_adjacent_tessellation,
+            _passthrough_adjacent_filter,
         )
         monkeypatch.setattr(
             "city2graph.morphology._connect_point_to_nearest_edge",
-            fake_connect_point_to_nearest_edge,
+            _connect_to_first_edge,
         )
 
         nodes, _edges = morphological_graph(
@@ -657,18 +756,10 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             crs=sample_crs,
         )
 
-        def fake_create_tessellation(
-            geometry: gpd.GeoDataFrame,
-            primary_barriers: gpd.GeoDataFrame | None = None,
-        ) -> gpd.GeoDataFrame:
-            _ = (geometry, primary_barriers)
-            return gpd.GeoDataFrame(
-                {"tess_id": ["near", "isolated"], "enclosure_index": [0, 0]},
-                geometry=[near, isolated],
-                crs=sample_crs,
-            )
-
-        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            partial(_two_cell_tessellation, ["near", "isolated"], [near, isolated]),
+        )
 
         nodes, edges = morphological_graph(
             buildings,
@@ -707,18 +798,10 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             crs=sample_crs,
         )
 
-        def fake_create_tessellation(
-            geometry: gpd.GeoDataFrame,
-            primary_barriers: gpd.GeoDataFrame | None = None,
-        ) -> gpd.GeoDataFrame:
-            _ = (geometry, primary_barriers)
-            return gpd.GeoDataFrame(
-                {"tess_id": ["near", "far"], "enclosure_index": [0, 0]},
-                geometry=[near, far],
-                crs=sample_crs,
-            )
-
-        monkeypatch.setattr("city2graph.morphology.create_tessellation", fake_create_tessellation)
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            partial(_two_cell_tessellation, ["near", "far"], [near, far]),
+        )
 
         # distance budget (150) would admit "far" under a summed network+access
         # cost (50 + 60 = 110); the access cap (50) is what excludes it.
@@ -865,6 +948,133 @@ class TestMorphologicalGraphCore(TestMorphologyBase):
             as_nx=False,
         )
         self.validate_basic_output(nodes, edges, ["place", "movement"])
+
+
+class TestMorphologicalGraphBarrierAndFallback(TestMorphologyBase):
+    """Barrier-only segments, tessellation fallback and tessellation parallelism."""
+
+    def test_non_movement_barrier_col_excludes_barriers_from_movement(
+        self, sample_crs: str
+    ) -> None:
+        """Barrier-only segments shape barriers but never become movement nodes."""
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)])],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            {"is_barrier_only": [False, True]},
+            geometry=[
+                LineString([(0, 0), (1, 0)]),  # movement street
+                LineString([(0, 1), (1, 1)]),  # barrier-only (e.g. railway)
+            ],
+            crs=sample_crs,
+        )
+
+        nodes, edges = morphological_graph(
+            buildings,
+            segments,
+            non_movement_barrier_col="is_barrier_only",
+        )
+
+        # Only the movement street becomes a movement node.
+        assert len(nodes["movement"]) == 1
+        assert "is_barrier_only" in nodes["movement"].columns
+        assert not nodes["movement"]["is_barrier_only"].any()
+        assert set(edges) == {
+            ("place", "touched_to", "place"),
+            ("movement", "connected_to", "movement"),
+            ("place", "faced_to", "movement"),
+        }
+
+    def test_non_movement_barrier_col_missing_treats_all_as_movement(self, sample_crs: str) -> None:
+        """When the flag column is absent every segment stays a movement node."""
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)])],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(0, 0), (1, 0)]), LineString([(0, 1), (1, 1)])],
+            crs=sample_crs,
+        )
+
+        nodes, _ = morphological_graph(
+            buildings, segments, non_movement_barrier_col="is_barrier_only"
+        )
+
+        assert len(nodes["movement"]) == 2
+
+    def test_tessellation_fallback_on_enclosure_error(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A momepy enclosure failure falls back to building footprints when enabled."""
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)])],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(geometry=[LineString([(0, 0), (1, 0)])], crs=sample_crs)
+
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _raise_no_objects_tessellation,
+        )
+
+        # Without the fallback the error propagates.
+        with pytest.raises(ValueError, match="No objects to concatenate"):
+            morphological_graph(buildings, segments)
+
+        # With the fallback a footprint cell stands in for the missing tessellation.
+        nodes, _ = morphological_graph(buildings, segments, tessellation_fallback=True)
+        assert len(nodes["place"]) == 1
+        assert nodes["place"].index[0].startswith("fallback_")
+
+    def test_tessellation_fallback_on_empty_tessellation(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An empty enclosed tessellation falls back to footprints when enabled."""
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)])],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(geometry=[LineString([(0, 0), (1, 0)])], crs=sample_crs)
+
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _empty_tessellation,
+        )
+
+        default_nodes, _ = morphological_graph(buildings, segments)
+        fallback_nodes, _ = morphological_graph(buildings, segments, tessellation_fallback=True)
+
+        assert default_nodes["place"].empty
+        assert len(fallback_nodes["place"]) == 1
+
+    def test_tessellation_n_jobs_forwarded(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """tessellation_n_jobs is forwarded to create_tessellation only when not -1."""
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(geometry=[LineString([(-1, 0), (2, 0)])], crs=sample_crs)
+        captured: dict[str, object] = {}
+
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            partial(_key_recording_tessellation, captured, "n_jobs", "absent"),
+        )
+
+        morphological_graph(buildings, segments, tessellation_n_jobs=1)
+        assert captured["n_jobs"] == 1
+
+        morphological_graph(buildings, segments)
+        assert captured["n_jobs"] == "absent"
 
 
 class TestMorphologicalGraphEdgeCases(TestMorphologyBase):
@@ -1627,11 +1837,11 @@ class TestReachabilityFieldRefactor(TestMorphologyBase):
         original = morph._network_reachability_field
         calls = {"n": 0}
 
-        def counting(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-            calls["n"] += 1
-            return original(*args, **kwargs)
-
-        monkeypatch.setattr(morph, "_network_reachability_field", counting)
+        monkeypatch.setattr(
+            morph,
+            "_network_reachability_field",
+            partial(_counting_wrapper, calls, original),
+        )
 
         morphological_graph(
             sample_buildings_gdf,
@@ -1658,11 +1868,11 @@ class TestReachabilityFieldRefactor(TestMorphologyBase):
         original = morph._geometry_ilocs_within_network_distance
         seen_fields: list[object] = []
 
-        def recording(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-            seen_fields.append(kwargs.get("field"))
-            return original(*args, **kwargs)
-
-        monkeypatch.setattr(morph, "_geometry_ilocs_within_network_distance", recording)
+        monkeypatch.setattr(
+            morph,
+            "_geometry_ilocs_within_network_distance",
+            partial(_field_recording_wrapper, seen_fields, original),
+        )
 
         morphological_graph(
             sample_buildings_gdf,


### PR DESCRIPTION
## Description

This PR adds three new optional parameters to `morphological_graph()` to make it more configurable, without changing default behaviour:

- **`non_movement_barrier_col`** (`str | None`, default `None`): flags a boolean column in `segments_gdf` marking rows that should act as barriers only. Flagged segments still shape the tessellation barriers (clipped to the same radius as the buffered movement network), but are excluded from the movement nodes, the movement-to-movement graph, and the network-distance computation. This is orthogonal to `primary_barrier_col`, which substitutes *geometry* for a segment without ever removing it from the movement layer — the new option decides *whether a row becomes a movement node at all*.

- **`tessellation_fallback`** (`bool`, default `False`): when enabled, falls back to using reachable building footprints directly as place cells if the enclosed tessellation encloses no area (`momepy` raises `"No objects to concatenate"`) or otherwise yields no cells despite reachable buildings/segments being available. Fallback cells go through the same reachability-budget filtering (network distance + `extent_buffer` access cap) as the primary path, so retention rules stay consistent. With the flag off, behaviour is unchanged and the underlying error still propagates.

- **`tessellation_n_jobs`** (`int`, default `-1`): forwards the number of parallel jobs to `create_tessellation` / `momepy.enclosed_tessellation`. Useful for setting it to `1` to run serially and avoid oversubscription when `morphological_graph()` is itself invoked from within an outer parallel loop (e.g. batched processing over many centre points).

## Related Issues

NA

## Checklist

- [x] I have read the [[Contributing Guide](https://claude.ai/epitaxy/https.city2graph.net/contributing.html)](https.city2graph.net/contributing.html).
- [x]  have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
