### PR TITLE
Refactor: improve enclosed tessellation fallback handling

### DIFF
--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -2199,7 +2199,10 @@ def _prepare_barriers(
     This function selects the appropriate geometry column from the segments
     GeoDataFrame to be used as barriers in the tessellation process. If an
     alternative geometry column is specified and exists, it is used; otherwise,
-    the default geometry column is used.
+    the default geometry column is used. Rows whose barrier geometry is missing
+    or empty are dropped: such segments stay in the movement network but never
+    act as tessellation barriers or as ``faced_to`` query geometries (e.g.
+    roads in tunnels or on bridges).
 
     Parameters
     ----------
@@ -2214,12 +2217,19 @@ def _prepare_barriers(
         A GeoDataFrame containing the prepared barrier geometries.
     """
     if geom_col and geom_col in segments.columns and geom_col != "geometry":
-        return gpd.GeoDataFrame(
+        # The alternative column may be object-dtype (e.g. after assigning
+        # None values or a parquet round trip), so coerce it to a GeoSeries.
+        barriers = gpd.GeoDataFrame(
             segments.drop(columns=["geometry"]),
-            geometry=segments[geom_col],
+            geometry=gpd.GeoSeries(segments[geom_col], index=segments.index, crs=segments.crs),
             crs=segments.crs,
         )
-    return segments.copy()
+    else:
+        barriers = segments.copy()
+    keep = barriers.geometry.notna() & ~barriers.geometry.is_empty
+    if not keep.all():
+        barriers = barriers.loc[keep].copy()
+    return barriers
 
 
 def _append_barrier_context_segments(

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -2326,6 +2326,49 @@ def _append_barrier_context_segments(
     return gpd.GeoDataFrame(merged, geometry=geometry_name, crs=segments_buffer.crs)
 
 
+def _match_fallback_cells_to_source_buildings(
+    joined: gpd.GeoDataFrame,
+    buildings: gpd.GeoDataFrame,
+    building_columns: list[str],
+) -> gpd.GeoDataFrame:
+    """
+    Overwrite fallback-cell spatial-join matches with their source building.
+
+    Fallback cells are matched exactly to their source building, so extra
+    sjoin matches only duplicate the cell's row and must be dropped. All
+    operations are positional: the sjoin can duplicate index labels when a
+    cell contains several building points, which breaks label alignment.
+
+    Parameters
+    ----------
+    joined : geopandas.GeoDataFrame
+        The tessellation joined against building representative points, with
+        the ``_SOURCE_BUILDING_INDEX_COL`` column present.
+    buildings : geopandas.GeoDataFrame
+        The buildings the source indices refer to.
+    building_columns : list[str]
+        Non-geometry building columns copied onto the fallback rows.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        ``joined`` with redundant fallback rows removed and their
+        ``index_right`` and building columns taken from the source building.
+    """
+    source_mask = joined[_SOURCE_BUILDING_INDEX_COL].notna().to_numpy()
+    redundant = source_mask & joined.index.duplicated(keep="first")
+    if redundant.any():
+        joined = joined.loc[~redundant]
+        source_mask = joined[_SOURCE_BUILDING_INDEX_COL].notna().to_numpy()
+    source_index = joined[_SOURCE_BUILDING_INDEX_COL]
+    joined["index_right"] = np.where(source_mask, source_index, joined["index_right"])
+    for column in building_columns:
+        joined.loc[source_mask, column] = (
+            source_index.loc[source_mask].map(buildings[column]).to_numpy()
+        )
+    return joined
+
+
 def _add_building_info(
     tessellation: gpd.GeoDataFrame,
     buildings: gpd.GeoDataFrame,
@@ -2370,25 +2413,7 @@ def _add_building_info(
         joined["index_right"] = None
 
     if _SOURCE_BUILDING_INDEX_COL in joined.columns:
-        # Fallback cells are matched exactly to their source building, so extra
-        # sjoin matches only duplicate the cell's row and must be dropped. All
-        # operations are positional: the sjoin can duplicate index labels when a
-        # cell contains several building points, which breaks label alignment.
-        source_mask = joined[_SOURCE_BUILDING_INDEX_COL].notna().to_numpy()
-        redundant = source_mask & joined.index.duplicated(keep="first")
-        if redundant.any():
-            joined = joined.loc[~redundant]
-            source_mask = joined[_SOURCE_BUILDING_INDEX_COL].notna().to_numpy()
-        source_index = joined[_SOURCE_BUILDING_INDEX_COL]
-        joined["index_right"] = np.where(source_mask, source_index, joined["index_right"])
-        for column in building_columns:
-            joined.loc[source_mask, column] = (
-                source_index.loc[source_mask]
-                .map(
-                    buildings[column],
-                )
-                .to_numpy()
-            )
+        joined = _match_fallback_cells_to_source_buildings(joined, buildings, building_columns)
 
     building_geom_map = buildings.geometry.to_dict()
     joined["building_geometry"] = gpd.GeoSeries(

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -797,15 +797,19 @@ def _create_enclosed_tessellation(
         Number of parallel jobs, forwarded to `create_tessellation` only when
         not ``-1`` (the default is left implicit).
     suppress_empty_error : bool
-        When True, the ``momepy`` error raised when the barriers enclose no
-        area ("No objects to concatenate") is converted into a ``None``
-        return; any other error always propagates.
+        When True, the ``momepy`` error raised when nothing can be
+        tessellated ("No objects to concatenate") is converted into a
+        ``None`` return; any other error always propagates. With barriers
+        present, `create_tessellation` already degrades this failure to an
+        empty tessellation internally, so the conversion applies to the
+        barrier-free morphological path (and the empty result is handled by
+        the caller's empty-tessellation fallback instead).
 
     Returns
     -------
     geopandas.GeoDataFrame or None
-        The enclosed tessellation, or ``None`` when the enclosures contain no
-        area and ``suppress_empty_error`` is True.
+        The enclosed tessellation, or ``None`` when nothing could be
+        tessellated and ``suppress_empty_error`` is True.
     """
     tessellation_kwargs = {}
     if limit is not None:

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -1797,6 +1797,10 @@ def _create_and_filter_tessellation(
     # Optionally preserve building information by joining tessellation with buildings
     if context.keep_buildings:
         tessellation = _add_building_info(tessellation, eligible_buildings)
+    else:
+        # _add_building_info consumes the fallback-cell source index; without
+        # it the internal column must not leak into the place nodes.
+        tessellation = tessellation.drop(columns=[_SOURCE_BUILDING_INDEX_COL], errors="ignore")
 
     # When the enclosed tessellation retained nothing despite usable inputs, fall
     # back to building footprints so the morphology graph still has place cells.
@@ -1847,20 +1851,47 @@ def _include_unenclosed_building_tessellation(
     if "enclosure_index" in tessellation.columns:
         tessellation["enclosure_index"] = tessellation["enclosure_index"].astype(str)
 
-    fallback = gpd.GeoDataFrame(
-        {_PLACE_ID_COL: missing_buildings.index.astype(str)},
-        geometry=missing_buildings.geometry.to_numpy(),
-        crs=missing_buildings.crs,
-    )
-    fallback[_SOURCE_BUILDING_INDEX_COL] = missing_buildings.index.to_numpy()
-    fallback[_PLACE_ID_COL] = "fallback_" + fallback[_PLACE_ID_COL].astype(str)
-    fallback["enclosure_index"] = "fallback"
+    fallback = _building_fallback_cells(missing_buildings)
 
     return gpd.GeoDataFrame(
         pd.concat([tessellation, fallback], ignore_index=True, sort=False),
         geometry=tessellation.geometry.name,
         crs=tessellation.crs,
     )
+
+
+def _building_fallback_cells(buildings: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Build fallback place cells from building footprints.
+
+    Each footprint becomes its own cell tagged with a synthetic
+    ``fallback_<index>`` place id, a single ``"fallback"`` enclosure and the
+    source building index recorded in ``_SOURCE_BUILDING_INDEX_COL``, so
+    :func:`_add_building_info` matches the cell to its building exactly
+    instead of relying on a spatial join. Shared by the whole-tessellation
+    fallback and the unenclosed-building fallback so both produce identical
+    cells.
+
+    Parameters
+    ----------
+    buildings : geopandas.GeoDataFrame
+        Building footprints to convert into cells; may be empty.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        One fallback cell per building.
+    """
+    cells = gpd.GeoDataFrame(
+        {
+            _PLACE_ID_COL: "fallback_" + buildings.index.astype(str),
+            "enclosure_index": "fallback",
+        },
+        geometry=buildings.geometry.to_numpy(),
+        crs=buildings.crs,
+    )
+    cells[_SOURCE_BUILDING_INDEX_COL] = buildings.index.to_numpy()
+    return cells
 
 
 def _filter_buildings_by_network_distance(
@@ -1957,10 +1988,10 @@ def _fallback_tessellation_without_enclosures(
     Build place cells from building footprints when enclosed tessellation fails.
 
     Used as a fallback when the enclosed tessellation encloses no area or yields
-    no cells. Each reachable building footprint becomes its own place cell, tagged
-    with a synthetic ``fallback_`` place id and a single ``"fallback"`` enclosure,
-    and is judged against the same reachability budget (network ``distance`` plus
-    ``extent_buffer`` access cap) as the primary path so retention rules match.
+    no cells. Each reachable building footprint becomes its own place cell (see
+    :func:`_building_fallback_cells`) and is judged against the same
+    reachability budget (network ``distance`` plus ``extent_buffer`` access
+    cap) as the primary path so retention rules match.
 
     Parameters
     ----------
@@ -1977,8 +2008,6 @@ def _fallback_tessellation_without_enclosures(
         Fallback tessellation cells, possibly empty when nothing is reachable.
     """
     buildings = _valid_polygon_gdf(context.buildings)
-    if buildings.empty:
-        return buildings.iloc[0:0].copy()
 
     # Retention uses the reachable isochrone streets and the bounded access cap,
     # matching the primary path so fallback cells obey the same acceptance rule.
@@ -1990,18 +2019,9 @@ def _fallback_tessellation_without_enclosures(
         context.extent_buffer,
         field=context.field,
     )
-    if buildings.empty:
-        return buildings.iloc[0:0].copy()
 
-    tessellation = gpd.GeoDataFrame(
-        {
-            _PLACE_ID_COL: "fallback_" + buildings.index.astype(str),
-            "enclosure_index": "fallback",
-        },
-        geometry=buildings.geometry.to_numpy(),
-        crs=buildings.crs,
-    )
-    if context.center_point is not None and distance is not None:
+    tessellation = _building_fallback_cells(buildings)
+    if not tessellation.empty and context.center_point is not None and distance is not None:
         tessellation = _filter_tessellation_by_network_distance(
             tessellation,
             segments_filtered,
@@ -2012,6 +2032,8 @@ def _fallback_tessellation_without_enclosures(
         )
     if context.keep_buildings:
         tessellation = _add_building_info(tessellation, buildings)
+    else:
+        tessellation = tessellation.drop(columns=[_SOURCE_BUILDING_INDEX_COL])
     return tessellation
 
 

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -1098,8 +1098,9 @@ def relative_neighborhood_graph(
         if np.any(dots < 0.0):
             continue
         dij2 = np.dot(coords[i] - coords[j], coords[i] - coords[j])
-        di2 = np.sum((coords - coords[i]) ** 2, axis=1) < dij2
-        dj2 = np.sum((coords - coords[j]) ** 2, axis=1) < dij2
+        threshold = dij2 - np.finfo(float).eps * max(dij2, 1.0) * 64.0
+        di2 = np.sum((coords - coords[i]) ** 2, axis=1) < threshold
+        dj2 = np.sum((coords - coords[j]) ** 2, axis=1) < threshold
         closer_both = np.where(di2 & dj2)[0]
         if len(closer_both) == 0:
             kept_edges.add((builder.node_ids[i], builder.node_ids[j]))

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -1094,6 +1094,9 @@ def relative_neighborhood_graph(
     coords = builder.coords
 
     for i, j in cand_edges:
+        dots = np.einsum("ij,ij->i", coords[i] - coords, coords[j] - coords)
+        if np.any(dots < 0.0):
+            continue
         dij2 = np.dot(coords[i] - coords[j], coords[i] - coords[j])
         di2 = np.sum((coords - coords[i]) ** 2, axis=1) < dij2
         dj2 = np.sum((coords - coords[j]) ** 2, axis=1) < dij2

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -4362,6 +4362,28 @@ def _overfilled_enclosures(
     return list(cell_areas.index[broken])
 
 
+def _degrade_to_empty_tessellation() -> tuple[None, bool]:
+    """
+    Log the terminal retry failure and degrade the unit to an empty tessellation.
+
+    This is the terminal step of the retry ladder in
+    :func:`_run_tessellation_with_retries`: when momepy keeps failing at the
+    coarser precision, the unit degrades to an empty tessellation instead of
+    aborting the whole run.
+
+    Returns
+    -------
+    tuple[None, bool]
+        ``(tessellation, include_tess_id)`` values signalling
+        :func:`_run_tessellation_with_retries` to return an empty result.
+    """
+    logger.warning(
+        "Tessellation still failed at coarser precision; returning empty "
+        "tessellation for this unit.",
+    )
+    return None, False
+
+
 def _run_tessellation_with_retries(
     run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
     kwargs: dict[str, object],
@@ -4375,8 +4397,11 @@ def _run_tessellation_with_retries(
     ``GEOSException``, or as a silently degenerate partition (handled
     separately by :func:`_repair_or_drop_degenerate_enclosures`). A coarser
     ``grid_size`` repairs the underlying partition, so it is preferred over
-    ``simplify=False``, which would keep the degenerate cells. Caller-pinned
-    ``simplify``/``grid_size`` values are never overridden.
+    ``simplify=False``, which would keep the degenerate cells. The coarser
+    grid can itself snap cells non-polygonal, so a ``GEOSException`` retry may
+    in turn hit the ``coverage_simplify`` ``TypeError`` and falls back to
+    ``simplify=False``. Caller-pinned ``simplify``/``grid_size`` values are
+    never overridden.
 
     Parameters
     ----------
@@ -4444,12 +4469,20 @@ def _run_tessellation_with_retries(
         try:
             tessellation = run_tessellation(**overrides)
         except shapely.errors.GEOSException:
+            tessellation, include_tess_id = _degrade_to_empty_tessellation()
+        except TypeError as te:
+            if "incorrect geometry type" not in str(te) or "simplify" in kwargs:
+                raise
+            overrides["simplify"] = False
             logger.warning(
-                "Tessellation still failed at coarser precision; returning empty "
-                "tessellation for this unit.",
+                "Tessellation retry failed boundary simplification (%s); retrying with "
+                "simplify=False.",
+                te,
             )
-            tessellation = None
-            include_tess_id = False
+            try:
+                tessellation = run_tessellation(**overrides)
+            except shapely.errors.GEOSException:
+                tessellation, include_tess_id = _degrade_to_empty_tessellation()
     return tessellation, overrides, include_tess_id
 
 

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -4249,12 +4249,8 @@ def create_tessellation(
     """
     if geometry.empty:
         if primary_barriers is not None:
-            # Enclosed tessellation needs 'enclosure_index' column
-            return gpd.GeoDataFrame(
-                columns=["geometry", "enclosure_index"],
-                geometry="geometry",
-                crs=geometry.crs,
-            )
+            return _create_empty_tessellation(geometry.crs)
+        # Morphological tessellation has no enclosures.
         return gpd.GeoDataFrame(
             columns=["geometry", "tess_id"],
             geometry="geometry",
@@ -4362,28 +4358,6 @@ def _overfilled_enclosures(
     return list(cell_areas.index[broken])
 
 
-def _degrade_to_empty_tessellation() -> tuple[None, bool]:
-    """
-    Log the terminal retry failure and degrade the unit to an empty tessellation.
-
-    This is the terminal step of the retry ladder in
-    :func:`_run_tessellation_with_retries`: when momepy keeps failing at the
-    coarser precision, the unit degrades to an empty tessellation instead of
-    aborting the whole run.
-
-    Returns
-    -------
-    tuple[None, bool]
-        ``(tessellation, include_tess_id)`` values signalling
-        :func:`_run_tessellation_with_retries` to return an empty result.
-    """
-    logger.warning(
-        "Tessellation still failed at coarser precision; returning empty "
-        "tessellation for this unit.",
-    )
-    return None, False
-
-
 def _is_known_tessellation_error(error: Exception) -> bool:
     """
     Report whether a tessellation failure belongs to the known retry ladder.
@@ -4411,9 +4385,9 @@ def _is_known_tessellation_error(error: Exception) -> bool:
     return isinstance(error, shapely.errors.GEOSException)
 
 
-def _degraded_tessellation_result(error: Exception) -> tuple[None, bool]:
+def _log_tessellation_degradation(error: Exception) -> None:
     """
-    Log a known terminal failure and degrade the unit to an empty tessellation.
+    Log a known terminal failure before degrading the unit to an empty result.
 
     The warning message depends on the failure kind: the momepy concat
     ``ValueError`` keeps its historical wording, while simplification and GEOS
@@ -4424,23 +4398,20 @@ def _degraded_tessellation_result(error: Exception) -> tuple[None, bool]:
     error : Exception
         The known failure (see :func:`_is_known_tessellation_error`) that
         exhausted the retry ladder.
-
-    Returns
-    -------
-    tuple[None, bool]
-        ``(tessellation, include_tess_id)`` values signalling
-        :func:`_run_tessellation_with_retries` to return an empty result.
     """
     if isinstance(error, ValueError):
         logger.warning("Momepy could not generate tessellation, returning empty GeoDataFrame.")
-        return None, True
-    return _degrade_to_empty_tessellation()
+        return
+    logger.warning(
+        "Tessellation still failed at coarser precision; returning empty "
+        "tessellation for this unit.",
+    )
 
 
 def _run_final_tessellation_attempt(
     run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
     overrides: dict[str, object],
-) -> tuple[gpd.GeoDataFrame | None, bool]:
+) -> gpd.GeoDataFrame | None:
     """
     Run the last rung of the retry ladder, degrading known failures to empty.
 
@@ -4457,23 +4428,24 @@ def _run_final_tessellation_attempt(
 
     Returns
     -------
-    tuple[geopandas.GeoDataFrame or None, bool]
-        ``(tessellation, include_tess_id)`` where ``tessellation`` is ``None``
-        when the attempt failed with another known error.
+    geopandas.GeoDataFrame or None
+        The tessellation, or ``None`` when the attempt failed with another
+        known error.
     """
     try:
-        return run_tessellation(**overrides), True
+        return run_tessellation(**overrides)
     except (ValueError, TypeError, shapely.errors.GEOSException) as error:
         if not _is_known_tessellation_error(error):
             raise
-        return _degraded_tessellation_result(error)
+        _log_tessellation_degradation(error)
+        return None
 
 
 def _retry_at_coarser_grid(
     run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
     kwargs: dict[str, object],
     overrides: dict[str, object],
-) -> tuple[gpd.GeoDataFrame | None, dict[str, object], bool]:
+) -> tuple[gpd.GeoDataFrame | None, dict[str, object]]:
     """
     Run the coarser-grid retry rung, escalating to ``simplify=False`` if needed.
 
@@ -4493,12 +4465,12 @@ def _retry_at_coarser_grid(
 
     Returns
     -------
-    tuple[geopandas.GeoDataFrame or None, dict[str, object], bool]
-        ``(tessellation, overrides, include_tess_id)`` mirroring
+    tuple[geopandas.GeoDataFrame or None, dict[str, object]]
+        ``(tessellation, overrides)`` mirroring
         :func:`_run_tessellation_with_retries`.
     """
     try:
-        return run_tessellation(**overrides), overrides, True
+        return run_tessellation(**overrides), overrides
     except (ValueError, TypeError, shapely.errors.GEOSException) as retry_error:
         if not _is_known_tessellation_error(retry_error):
             raise
@@ -4509,19 +4481,17 @@ def _retry_at_coarser_grid(
                 "simplify=False.",
                 retry_error,
             )
-            tessellation, include_tess_id = _run_final_tessellation_attempt(
-                run_tessellation,
-                overrides,
-            )
+            tessellation = _run_final_tessellation_attempt(run_tessellation, overrides)
         else:
-            tessellation, include_tess_id = _degraded_tessellation_result(retry_error)
-        return tessellation, overrides, include_tess_id
+            _log_tessellation_degradation(retry_error)
+            tessellation = None
+        return tessellation, overrides
 
 
 def _run_tessellation_with_retries(
     run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
     kwargs: dict[str, object],
-) -> tuple[gpd.GeoDataFrame | None, dict[str, object], bool]:
+) -> tuple[gpd.GeoDataFrame | None, dict[str, object]]:
     """
     Run momepy enclosed tessellation through the known-failure retry ladder.
 
@@ -4551,14 +4521,13 @@ def _run_tessellation_with_retries(
 
     Returns
     -------
-    tuple[geopandas.GeoDataFrame or None, dict[str, object], bool]
-        ``(tessellation, overrides, include_tess_id)`` where ``tessellation``
-        is ``None`` when momepy definitively failed and the caller should
-        return an empty tessellation (built with ``include_tess_id``), and
-        ``overrides`` records the retry options that produced the result.
+    tuple[geopandas.GeoDataFrame or None, dict[str, object]]
+        ``(tessellation, overrides)`` where ``tessellation`` is ``None`` when
+        momepy definitively failed and the caller should return an empty
+        tessellation, and ``overrides`` records the retry options that
+        produced the result.
     """
     overrides: dict[str, object] = {}
-    include_tess_id = True
     tessellation: gpd.GeoDataFrame | None
     try:
         tessellation = run_tessellation()
@@ -4573,7 +4542,8 @@ def _run_tessellation_with_retries(
         if "grid_size" in kwargs:
             if "simplify" in kwargs:
                 # Both retry options are pinned by the caller; nothing left.
-                tessellation, include_tess_id = _degrade_to_empty_tessellation()
+                _log_tessellation_degradation(e)
+                tessellation = None
             else:
                 overrides = {"simplify": False}
                 logger.warning(
@@ -4581,21 +4551,14 @@ def _run_tessellation_with_retries(
                     "simplify=False.",
                     e,
                 )
-                tessellation, include_tess_id = _run_final_tessellation_attempt(
-                    run_tessellation,
-                    overrides,
-                )
+                tessellation = _run_final_tessellation_attempt(run_tessellation, overrides)
         else:
             overrides = {"grid_size": 1e-3}
             logger.warning(
                 "Tessellation boundary simplification failed (%s); retrying with grid_size=1e-3.",
                 e,
             )
-            tessellation, overrides, include_tess_id = _retry_at_coarser_grid(
-                run_tessellation,
-                kwargs,
-                overrides,
-            )
+            tessellation, overrides = _retry_at_coarser_grid(run_tessellation, kwargs, overrides)
     except shapely.errors.GEOSException as e:
         # e.g. ``TopologyException: side location conflict`` on numerically
         # fragile footprints; ``voronoi_frames`` snaps coordinates at
@@ -4604,7 +4567,8 @@ def _run_tessellation_with_retries(
         if "grid_size" in kwargs:
             # The caller pinned the snapping precision; degrade instead of
             # overriding it.
-            tessellation, include_tess_id = _degrade_to_empty_tessellation()
+            _log_tessellation_degradation(e)
+            tessellation = None
         else:
             logger.warning(
                 "Tessellation hit a GEOS topology error (%s); retrying with coarser "
@@ -4612,12 +4576,8 @@ def _run_tessellation_with_retries(
                 e,
             )
             overrides = {"grid_size": 1e-3}
-            tessellation, overrides, include_tess_id = _retry_at_coarser_grid(
-                run_tessellation,
-                kwargs,
-                overrides,
-            )
-    return tessellation, overrides, include_tess_id
+            tessellation, overrides = _retry_at_coarser_grid(run_tessellation, kwargs, overrides)
+    return tessellation, overrides
 
 
 def _repair_or_drop_degenerate_enclosures(
@@ -4767,12 +4727,12 @@ def _create_enclosed_tessellation(
                 **{**kwargs, **extra_kwargs},
             )
 
-        tessellation, overrides, include_tess_id = _run_tessellation_with_retries(
+        tessellation, overrides = _run_tessellation_with_retries(
             _run_enclosed_tessellation,
             kwargs,
         )
         if tessellation is None:
-            return _create_empty_tessellation(geometry.crs, include_tess_id=include_tess_id)
+            return _create_empty_tessellation(geometry.crs)
         tessellation = _repair_or_drop_degenerate_enclosures(
             tessellation,
             enclosures,
@@ -4781,11 +4741,11 @@ def _create_enclosed_tessellation(
             overrides,
         )
     else:
-        tessellation = _create_empty_tessellation(geometry.crs, include_tess_id=False)
+        tessellation = _create_empty_tessellation(geometry.crs)
 
     tessellation = _polygonal_tessellation(tessellation)
     if tessellation.empty:
-        return _create_empty_tessellation(geometry.crs, include_tess_id=False)
+        return _create_empty_tessellation(geometry.crs)
 
     tessellation["tess_id"] = [
         f"{i}_{j}"
@@ -4832,32 +4792,30 @@ def _compute_enclosure_limit(
     return gpd.GeoSeries(geometries, crs=geometry.crs).union_all().convex_hull.buffer(buffer)
 
 
-def _create_empty_tessellation(
-    crs: Any,  # noqa: ANN401
-    include_tess_id: bool = True,
-) -> gpd.GeoDataFrame:
+def _create_empty_tessellation(crs: Any) -> gpd.GeoDataFrame:  # noqa: ANN401
     """
-    Create an empty tessellation GeoDataFrame.
+    Create an empty enclosed-tessellation GeoDataFrame.
 
-    This helper generates a properly structured but empty GeoDataFrame for tessellations,
-    ensuring consistent column names and types when no tessellation can be generated.
+    This helper generates a properly structured but empty GeoDataFrame when no
+    tessellation can be generated, matching the column schema of non-empty
+    enclosed tessellations so downstream consumers see a uniform shape.
 
     Parameters
     ----------
     crs : Any
         The Coordinate Reference System.
-    include_tess_id : bool, default True
-        Whether to include the 'tess_id' column.
 
     Returns
     -------
     geopandas.GeoDataFrame
-        An empty tessellation GeoDataFrame.
+        An empty tessellation GeoDataFrame with the columns ``geometry``,
+        ``enclosure_index`` and ``tess_id``.
     """
-    columns = ["geometry", "enclosure_index"]
-    if include_tess_id:
-        columns.append("tess_id")
-    return gpd.GeoDataFrame(columns=columns, geometry="geometry", crs=crs)
+    return gpd.GeoDataFrame(
+        columns=["geometry", "enclosure_index", "tess_id"],
+        geometry="geometry",
+        crs=crs,
+    )
 
 
 def _create_morphological_tessellation(

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -4384,6 +4384,140 @@ def _degrade_to_empty_tessellation() -> tuple[None, bool]:
     return None, False
 
 
+def _is_known_tessellation_error(error: Exception) -> bool:
+    """
+    Report whether a tessellation failure belongs to the known retry ladder.
+
+    Known failures are the errors the retry ladder in
+    :func:`_run_tessellation_with_retries` recovers from: the ``ValueError``
+    momepy raises when an enclosure produces nothing to concatenate, the
+    ``TypeError`` raised by ``shapely.coverage_simplify`` on non-polygonal
+    cells, and any ``GEOSException``. Anything else must propagate.
+
+    Parameters
+    ----------
+    error : Exception
+        The exception raised by ``momepy.enclosed_tessellation``.
+
+    Returns
+    -------
+    bool
+        True when the failure is a known, recoverable tessellation failure.
+    """
+    if isinstance(error, ValueError):
+        return "No objects to concatenate" in str(error)
+    if isinstance(error, TypeError):
+        return "incorrect geometry type" in str(error)
+    return isinstance(error, shapely.errors.GEOSException)
+
+
+def _degraded_tessellation_result(error: Exception) -> tuple[None, bool]:
+    """
+    Log a known terminal failure and degrade the unit to an empty tessellation.
+
+    The warning message depends on the failure kind: the momepy concat
+    ``ValueError`` keeps its historical wording, while simplification and GEOS
+    failures report the exhausted retry ladder.
+
+    Parameters
+    ----------
+    error : Exception
+        The known failure (see :func:`_is_known_tessellation_error`) that
+        exhausted the retry ladder.
+
+    Returns
+    -------
+    tuple[None, bool]
+        ``(tessellation, include_tess_id)`` values signalling
+        :func:`_run_tessellation_with_retries` to return an empty result.
+    """
+    if isinstance(error, ValueError):
+        logger.warning("Momepy could not generate tessellation, returning empty GeoDataFrame.")
+        return None, True
+    return _degrade_to_empty_tessellation()
+
+
+def _run_final_tessellation_attempt(
+    run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
+    overrides: dict[str, object],
+) -> tuple[gpd.GeoDataFrame | None, bool]:
+    """
+    Run the last rung of the retry ladder, degrading known failures to empty.
+
+    No further retry options remain at this point, so any known failure (see
+    :func:`_is_known_tessellation_error`) is logged and converted into an
+    empty result instead of aborting the run; unknown errors propagate.
+
+    Parameters
+    ----------
+    run_tessellation : Callable[..., geopandas.GeoDataFrame]
+        Closure invoking ``momepy.enclosed_tessellation``.
+    overrides : dict[str, object]
+        Retry overrides to apply on top of the caller-supplied options.
+
+    Returns
+    -------
+    tuple[geopandas.GeoDataFrame or None, bool]
+        ``(tessellation, include_tess_id)`` where ``tessellation`` is ``None``
+        when the attempt failed with another known error.
+    """
+    try:
+        return run_tessellation(**overrides), True
+    except (ValueError, TypeError, shapely.errors.GEOSException) as error:
+        if not _is_known_tessellation_error(error):
+            raise
+        return _degraded_tessellation_result(error)
+
+
+def _retry_at_coarser_grid(
+    run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
+    kwargs: dict[str, object],
+    overrides: dict[str, object],
+) -> tuple[gpd.GeoDataFrame | None, dict[str, object], bool]:
+    """
+    Run the coarser-grid retry rung, escalating to ``simplify=False`` if needed.
+
+    The coarser grid can snap cells non-polygonal and fail
+    ``shapely.coverage_simplify`` with a ``TypeError``, in which case the rung
+    escalates to ``simplify=False`` (unless pinned by the caller). Any other
+    known failure degrades the unit to an empty tessellation.
+
+    Parameters
+    ----------
+    run_tessellation : Callable[..., geopandas.GeoDataFrame]
+        Closure invoking ``momepy.enclosed_tessellation``.
+    kwargs : dict[str, object]
+        The caller-supplied momepy options (used to respect pinned values).
+    overrides : dict[str, object]
+        Retry overrides including the coarser ``grid_size``.
+
+    Returns
+    -------
+    tuple[geopandas.GeoDataFrame or None, dict[str, object], bool]
+        ``(tessellation, overrides, include_tess_id)`` mirroring
+        :func:`_run_tessellation_with_retries`.
+    """
+    try:
+        return run_tessellation(**overrides), overrides, True
+    except (ValueError, TypeError, shapely.errors.GEOSException) as retry_error:
+        if not _is_known_tessellation_error(retry_error):
+            raise
+        if isinstance(retry_error, TypeError) and "simplify" not in kwargs:
+            overrides = {**overrides, "simplify": False}
+            logger.warning(
+                "Tessellation retry failed boundary simplification (%s); retrying with "
+                "simplify=False.",
+                retry_error,
+            )
+            tessellation, include_tess_id = _run_final_tessellation_attempt(
+                run_tessellation,
+                overrides,
+            )
+        else:
+            tessellation, include_tess_id = _degraded_tessellation_result(retry_error)
+        return tessellation, overrides, include_tess_id
+
+
 def _run_tessellation_with_retries(
     run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
     kwargs: dict[str, object],
@@ -4401,7 +4535,11 @@ def _run_tessellation_with_retries(
     grid can itself snap cells non-polygonal, so a ``GEOSException`` retry may
     in turn hit the ``coverage_simplify`` ``TypeError`` and falls back to
     ``simplify=False``. Caller-pinned ``simplify``/``grid_size`` values are
-    never overridden.
+    never overridden; when the remaining options are exhausted the unit
+    degrades to an empty tessellation. Any known failure (see
+    :func:`_is_known_tessellation_error`) at any rung ends in a warning and
+    an empty result instead of aborting the whole run; only unknown errors
+    propagate.
 
     Parameters
     ----------
@@ -4430,59 +4568,55 @@ def _run_tessellation_with_retries(
         logger.warning("Momepy could not generate tessellation, returning empty GeoDataFrame.")
         tessellation = None
     except TypeError as e:
-        if "incorrect geometry type" not in str(e) or "simplify" in kwargs:
+        if "incorrect geometry type" not in str(e):
             raise
         if "grid_size" in kwargs:
-            overrides = {"simplify": False}
-            logger.warning(
-                "Tessellation boundary simplification failed (%s); retrying with simplify=False.",
-                e,
-            )
-            tessellation = run_tessellation(**overrides)
+            if "simplify" in kwargs:
+                # Both retry options are pinned by the caller; nothing left.
+                tessellation, include_tess_id = _degrade_to_empty_tessellation()
+            else:
+                overrides = {"simplify": False}
+                logger.warning(
+                    "Tessellation boundary simplification failed (%s); retrying with "
+                    "simplify=False.",
+                    e,
+                )
+                tessellation, include_tess_id = _run_final_tessellation_attempt(
+                    run_tessellation,
+                    overrides,
+                )
         else:
             overrides = {"grid_size": 1e-3}
             logger.warning(
                 "Tessellation boundary simplification failed (%s); retrying with grid_size=1e-3.",
                 e,
             )
-            try:
-                tessellation = run_tessellation(**overrides)
-            except TypeError:
-                overrides["simplify"] = False
-                logger.warning(
-                    "Tessellation boundary simplification still failed; retrying with "
-                    "simplify=False.",
-                )
-                tessellation = run_tessellation(**overrides)
+            tessellation, overrides, include_tess_id = _retry_at_coarser_grid(
+                run_tessellation,
+                kwargs,
+                overrides,
+            )
     except shapely.errors.GEOSException as e:
         # e.g. ``TopologyException: side location conflict`` on numerically
         # fragile footprints; ``voronoi_frames`` snaps coordinates at
         # ``grid_size`` (default 1e-5) and a single failing enclosure aborts
         # the whole parallel run.
         if "grid_size" in kwargs:
-            raise
-        logger.warning(
-            "Tessellation hit a GEOS topology error (%s); retrying with coarser grid_size=1e-3.",
-            e,
-        )
-        overrides = {"grid_size": 1e-3}
-        try:
-            tessellation = run_tessellation(**overrides)
-        except shapely.errors.GEOSException:
+            # The caller pinned the snapping precision; degrade instead of
+            # overriding it.
             tessellation, include_tess_id = _degrade_to_empty_tessellation()
-        except TypeError as te:
-            if "incorrect geometry type" not in str(te) or "simplify" in kwargs:
-                raise
-            overrides["simplify"] = False
+        else:
             logger.warning(
-                "Tessellation retry failed boundary simplification (%s); retrying with "
-                "simplify=False.",
-                te,
+                "Tessellation hit a GEOS topology error (%s); retrying with coarser "
+                "grid_size=1e-3.",
+                e,
             )
-            try:
-                tessellation = run_tessellation(**overrides)
-            except shapely.errors.GEOSException:
-                tessellation, include_tess_id = _degrade_to_empty_tessellation()
+            overrides = {"grid_size": 1e-3}
+            tessellation, overrides, include_tess_id = _retry_at_coarser_grid(
+                run_tessellation,
+                kwargs,
+                overrides,
+            )
     return tessellation, overrides, include_tess_id
 
 
@@ -4500,8 +4634,9 @@ def _repair_or_drop_degenerate_enclosures(
     under ``simplify=False``), so the cells are validated against the
     enclosure areas before they can poison downstream spatial joins. A broken
     partition is retried once with a coarser ``grid_size`` (unless one is
-    already in effect); enclosures that stay degenerate have their cells
-    dropped with a warning.
+    already in effect); when the retry itself fails with a known error the
+    original cells are kept, and enclosures that stay degenerate have their
+    cells dropped with a warning.
 
     Parameters
     ----------
@@ -4530,18 +4665,30 @@ def _repair_or_drop_degenerate_enclosures(
             len(broken),
         )
         retry_overrides = {**overrides, "grid_size": 1e-3}
+        retried: gpd.GeoDataFrame | None = None
         try:
-            tessellation = run_tessellation(**retry_overrides)
-        except TypeError as e:
-            if "incorrect geometry type" not in str(e) or "simplify" in kwargs:
+            retried = run_tessellation(**retry_overrides)
+        except (ValueError, TypeError, shapely.errors.GEOSException) as error:
+            if not _is_known_tessellation_error(error):
                 raise
-            logger.warning(
-                "Tessellation retry failed boundary simplification (%s); retrying with "
-                "simplify=False.",
-                e,
-            )
-            tessellation = run_tessellation(**{**retry_overrides, "simplify": False})
-        broken = _overfilled_enclosures(tessellation, enclosures)
+            if isinstance(error, TypeError) and "simplify" not in kwargs:
+                logger.warning(
+                    "Tessellation retry failed boundary simplification (%s); retrying with "
+                    "simplify=False.",
+                    error,
+                )
+                try:
+                    retried = run_tessellation(**{**retry_overrides, "simplify": False})
+                except (ValueError, TypeError, shapely.errors.GEOSException) as final_error:
+                    if not _is_known_tessellation_error(final_error):
+                        raise
+            if retried is None:
+                logger.warning(
+                    "Tessellation retry at coarser precision failed; keeping the original cells.",
+                )
+        if retried is not None:
+            tessellation = retried
+            broken = _overfilled_enclosures(tessellation, enclosures)
     if broken:
         logger.warning(
             "Dropping %d enclosure(s) whose tessellation cells overlap instead of "

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -4358,9 +4358,14 @@ def _overfilled_enclosures(
     return list(cell_areas.index[broken])
 
 
-def _is_known_tessellation_error(error: Exception) -> bool:
+# Coarser snapping precision used by the tessellation retry ladder; momepy's
+# default (1e-5) can degenerate numerically inside fragile enclosures.
+_COARSE_GRID_SIZE: float = 1e-3
+
+
+def _classify_tessellation_failure(error: Exception) -> str | None:
     """
-    Report whether a tessellation failure belongs to the known retry ladder.
+    Classify a tessellation failure for the retry ladder.
 
     Known failures are the errors the retry ladder in
     :func:`_run_tessellation_with_retries` recovers from: the ``ValueError``
@@ -4375,14 +4380,91 @@ def _is_known_tessellation_error(error: Exception) -> bool:
 
     Returns
     -------
-    bool
-        True when the failure is a known, recoverable tessellation failure.
+    str or None
+        ``"empty"``, ``"simplify"`` or ``"geos"`` for known failures, or
+        ``None`` for unknown errors that must propagate.
     """
     if isinstance(error, ValueError):
-        return "No objects to concatenate" in str(error)
+        return "empty" if "No objects to concatenate" in str(error) else None
     if isinstance(error, TypeError):
-        return "incorrect geometry type" in str(error)
-    return isinstance(error, shapely.errors.GEOSException)
+        return "simplify" if "incorrect geometry type" in str(error) else None
+    return "geos" if isinstance(error, shapely.errors.GEOSException) else None
+
+
+def _next_retry_overrides(
+    kind: str,
+    overrides: dict[str, object],
+    kwargs: dict[str, object],
+) -> dict[str, object] | None:
+    """
+    Return the next retry overrides for a classified tessellation failure.
+
+    A coarser ``grid_size`` repairs the underlying voronoi partition, so it
+    is always tried before ``simplify=False``, which would keep degenerate
+    cells; the ``simplify=False`` rung only applies to ``coverage_simplify``
+    failures. Options pinned by the caller in ``kwargs`` (or already applied
+    via ``overrides``) are never overridden, and the momepy concat failure
+    has no remedy at all.
+
+    Parameters
+    ----------
+    kind : str
+        The failure kind from :func:`_classify_tessellation_failure`.
+    overrides : dict[str, object]
+        Retry overrides already in effect for the failed attempt.
+    kwargs : dict[str, object]
+        The caller-supplied momepy options (used to respect pinned values).
+
+    Returns
+    -------
+    dict[str, object] or None
+        The overrides for the next attempt, or ``None`` when the ladder is
+        exhausted and the unit must degrade to an empty tessellation.
+    """
+    if kind != "empty":
+        if "grid_size" not in kwargs and "grid_size" not in overrides:
+            return {**overrides, "grid_size": _COARSE_GRID_SIZE}
+        if kind == "simplify" and "simplify" not in kwargs and "simplify" not in overrides:
+            return {**overrides, "simplify": False}
+    return None
+
+
+def _log_tessellation_retry(
+    kind: str,
+    error: Exception,
+    adds_grid_size: bool,
+) -> None:
+    """
+    Log the retry decision for a known tessellation failure.
+
+    The wording mirrors the failure kind and the option added by the next
+    rung so operators can follow the ladder in the logs.
+
+    Parameters
+    ----------
+    kind : str
+        The failure kind from :func:`_classify_tessellation_failure`.
+    error : Exception
+        The failure that triggered the retry.
+    adds_grid_size : bool
+        Whether the next rung adds the coarser ``grid_size`` (as opposed to
+        disabling boundary simplification).
+    """
+    if adds_grid_size and kind == "geos":
+        logger.warning(
+            "Tessellation hit a GEOS topology error (%s); retrying with coarser grid_size=1e-3.",
+            error,
+        )
+    elif adds_grid_size:
+        logger.warning(
+            "Tessellation boundary simplification failed (%s); retrying with grid_size=1e-3.",
+            error,
+        )
+    else:
+        logger.warning(
+            "Tessellation boundary simplification failed (%s); retrying with simplify=False.",
+            error,
+        )
 
 
 def _log_tessellation_degradation(error: Exception) -> None:
@@ -4396,7 +4478,7 @@ def _log_tessellation_degradation(error: Exception) -> None:
     Parameters
     ----------
     error : Exception
-        The known failure (see :func:`_is_known_tessellation_error`) that
+        The known failure (see :func:`_classify_tessellation_failure`) that
         exhausted the retry ladder.
     """
     if isinstance(error, ValueError):
@@ -4408,89 +4490,30 @@ def _log_tessellation_degradation(error: Exception) -> None:
     )
 
 
-def _run_final_tessellation_attempt(
-    run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
-    overrides: dict[str, object],
-) -> gpd.GeoDataFrame | None:
+def _log_repair_retry_failure(error: Exception) -> None:
     """
-    Run the last rung of the retry ladder, degrading known failures to empty.
+    Log an exhausted overlap-repair retry.
 
-    No further retry options remain at this point, so any known failure (see
-    :func:`_is_known_tessellation_error`) is logged and converted into an
-    empty result instead of aborting the run; unknown errors propagate.
+    Unlike the main ladder, a failed repair retry does not degrade the unit
+    to empty output: the original cells are kept and only the degenerate
+    enclosures are dropped by :func:`_repair_or_drop_degenerate_enclosures`.
 
     Parameters
     ----------
-    run_tessellation : Callable[..., geopandas.GeoDataFrame]
-        Closure invoking ``momepy.enclosed_tessellation``.
-    overrides : dict[str, object]
-        Retry overrides to apply on top of the caller-supplied options.
-
-    Returns
-    -------
-    geopandas.GeoDataFrame or None
-        The tessellation, or ``None`` when the attempt failed with another
-        known error.
+    error : Exception
+        The known failure that exhausted the repair retry.
     """
-    try:
-        return run_tessellation(**overrides)
-    except (ValueError, TypeError, shapely.errors.GEOSException) as error:
-        if not _is_known_tessellation_error(error):
-            raise
-        _log_tessellation_degradation(error)
-        return None
-
-
-def _retry_at_coarser_grid(
-    run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
-    kwargs: dict[str, object],
-    overrides: dict[str, object],
-) -> tuple[gpd.GeoDataFrame | None, dict[str, object]]:
-    """
-    Run the coarser-grid retry rung, escalating to ``simplify=False`` if needed.
-
-    The coarser grid can snap cells non-polygonal and fail
-    ``shapely.coverage_simplify`` with a ``TypeError``, in which case the rung
-    escalates to ``simplify=False`` (unless pinned by the caller). Any other
-    known failure degrades the unit to an empty tessellation.
-
-    Parameters
-    ----------
-    run_tessellation : Callable[..., geopandas.GeoDataFrame]
-        Closure invoking ``momepy.enclosed_tessellation``.
-    kwargs : dict[str, object]
-        The caller-supplied momepy options (used to respect pinned values).
-    overrides : dict[str, object]
-        Retry overrides including the coarser ``grid_size``.
-
-    Returns
-    -------
-    tuple[geopandas.GeoDataFrame or None, dict[str, object]]
-        ``(tessellation, overrides)`` mirroring
-        :func:`_run_tessellation_with_retries`.
-    """
-    try:
-        return run_tessellation(**overrides), overrides
-    except (ValueError, TypeError, shapely.errors.GEOSException) as retry_error:
-        if not _is_known_tessellation_error(retry_error):
-            raise
-        if isinstance(retry_error, TypeError) and "simplify" not in kwargs:
-            overrides = {**overrides, "simplify": False}
-            logger.warning(
-                "Tessellation retry failed boundary simplification (%s); retrying with "
-                "simplify=False.",
-                retry_error,
-            )
-            tessellation = _run_final_tessellation_attempt(run_tessellation, overrides)
-        else:
-            _log_tessellation_degradation(retry_error)
-            tessellation = None
-        return tessellation, overrides
+    logger.warning(
+        "Tessellation retry at coarser precision failed (%s); keeping the original cells.",
+        error,
+    )
 
 
 def _run_tessellation_with_retries(
     run_tessellation: typing.Callable[..., gpd.GeoDataFrame],
     kwargs: dict[str, object],
+    overrides: dict[str, object] | None = None,
+    log_exhausted: typing.Callable[[Exception], None] = _log_tessellation_degradation,
 ) -> tuple[gpd.GeoDataFrame | None, dict[str, object]]:
     """
     Run momepy enclosed tessellation through the known-failure retry ladder.
@@ -4499,17 +4522,12 @@ def _run_tessellation_with_retries(
     momepy's default snapping precision; depending on the options this
     surfaces as a ``TypeError`` from ``shapely.coverage_simplify``, a
     ``GEOSException``, or as a silently degenerate partition (handled
-    separately by :func:`_repair_or_drop_degenerate_enclosures`). A coarser
-    ``grid_size`` repairs the underlying partition, so it is preferred over
-    ``simplify=False``, which would keep the degenerate cells. The coarser
-    grid can itself snap cells non-polygonal, so a ``GEOSException`` retry may
-    in turn hit the ``coverage_simplify`` ``TypeError`` and falls back to
-    ``simplify=False``. Caller-pinned ``simplify``/``grid_size`` values are
-    never overridden; when the remaining options are exhausted the unit
-    degrades to an empty tessellation. Any known failure (see
-    :func:`_is_known_tessellation_error`) at any rung ends in a warning and
-    an empty result instead of aborting the whole run; only unknown errors
-    propagate.
+    separately by :func:`_repair_or_drop_degenerate_enclosures`). Each known
+    failure escalates to the next rung chosen by
+    :func:`_next_retry_overrides` — the coarser grid first, then
+    ``simplify=False`` — until the options are exhausted and the unit
+    degrades to an empty tessellation. Caller-pinned ``simplify``/
+    ``grid_size`` values are never overridden; only unknown errors propagate.
 
     Parameters
     ----------
@@ -4518,6 +4536,13 @@ def _run_tessellation_with_retries(
         are applied as retry overrides on top of the caller-supplied options.
     kwargs : dict[str, object]
         The caller-supplied momepy options (used to respect pinned values).
+    overrides : dict[str, object], optional
+        Retry overrides to start the ladder from (e.g. the coarser
+        ``grid_size`` for the overlap repair); the first attempt runs with
+        them applied.
+    log_exhausted : Callable[[Exception], None], optional
+        Warning emitted when the ladder is exhausted, receiving the terminal
+        failure. Defaults to :func:`_log_tessellation_degradation`.
 
     Returns
     -------
@@ -4527,57 +4552,24 @@ def _run_tessellation_with_retries(
         tessellation, and ``overrides`` records the retry options that
         produced the result.
     """
-    overrides: dict[str, object] = {}
-    tessellation: gpd.GeoDataFrame | None
-    try:
-        tessellation = run_tessellation()
-    except ValueError as e:
-        if "No objects to concatenate" not in str(e):
-            raise
-        logger.warning("Momepy could not generate tessellation, returning empty GeoDataFrame.")
-        tessellation = None
-    except TypeError as e:
-        if "incorrect geometry type" not in str(e):
-            raise
-        if "grid_size" in kwargs:
-            if "simplify" in kwargs:
-                # Both retry options are pinned by the caller; nothing left.
-                _log_tessellation_degradation(e)
-                tessellation = None
-            else:
-                overrides = {"simplify": False}
-                logger.warning(
-                    "Tessellation boundary simplification failed (%s); retrying with "
-                    "simplify=False.",
-                    e,
-                )
-                tessellation = _run_final_tessellation_attempt(run_tessellation, overrides)
-        else:
-            overrides = {"grid_size": 1e-3}
-            logger.warning(
-                "Tessellation boundary simplification failed (%s); retrying with grid_size=1e-3.",
-                e,
+    overrides = dict(overrides or {})
+    while True:
+        try:
+            return run_tessellation(**overrides), overrides
+        except (ValueError, TypeError, shapely.errors.GEOSException) as error:
+            kind = _classify_tessellation_failure(error)
+            if kind is None:
+                raise
+            next_overrides = _next_retry_overrides(kind, overrides, kwargs)
+            if next_overrides is None:
+                log_exhausted(error)
+                return None, overrides
+            _log_tessellation_retry(
+                kind,
+                error,
+                adds_grid_size="grid_size" not in overrides and "grid_size" in next_overrides,
             )
-            tessellation, overrides = _retry_at_coarser_grid(run_tessellation, kwargs, overrides)
-    except shapely.errors.GEOSException as e:
-        # e.g. ``TopologyException: side location conflict`` on numerically
-        # fragile footprints; ``voronoi_frames`` snaps coordinates at
-        # ``grid_size`` (default 1e-5) and a single failing enclosure aborts
-        # the whole parallel run.
-        if "grid_size" in kwargs:
-            # The caller pinned the snapping precision; degrade instead of
-            # overriding it.
-            _log_tessellation_degradation(e)
-            tessellation = None
-        else:
-            logger.warning(
-                "Tessellation hit a GEOS topology error (%s); retrying with coarser "
-                "grid_size=1e-3.",
-                e,
-            )
-            overrides = {"grid_size": 1e-3}
-            tessellation, overrides = _retry_at_coarser_grid(run_tessellation, kwargs, overrides)
-    return tessellation, overrides
+            overrides = next_overrides
 
 
 def _repair_or_drop_degenerate_enclosures(
@@ -4624,28 +4616,12 @@ def _repair_or_drop_degenerate_enclosures(
             "grid_size=1e-3.",
             len(broken),
         )
-        retry_overrides = {**overrides, "grid_size": 1e-3}
-        retried: gpd.GeoDataFrame | None = None
-        try:
-            retried = run_tessellation(**retry_overrides)
-        except (ValueError, TypeError, shapely.errors.GEOSException) as error:
-            if not _is_known_tessellation_error(error):
-                raise
-            if isinstance(error, TypeError) and "simplify" not in kwargs:
-                logger.warning(
-                    "Tessellation retry failed boundary simplification (%s); retrying with "
-                    "simplify=False.",
-                    error,
-                )
-                try:
-                    retried = run_tessellation(**{**retry_overrides, "simplify": False})
-                except (ValueError, TypeError, shapely.errors.GEOSException) as final_error:
-                    if not _is_known_tessellation_error(final_error):
-                        raise
-            if retried is None:
-                logger.warning(
-                    "Tessellation retry at coarser precision failed; keeping the original cells.",
-                )
+        retried, _ = _run_tessellation_with_retries(
+            run_tessellation,
+            kwargs,
+            overrides={**overrides, "grid_size": _COARSE_GRID_SIZE},
+            log_exhausted=_log_repair_retry_failure,
+        )
         if retried is not None:
             tessellation = retried
             broken = _overfilled_enclosures(tessellation, enclosures)

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1159,6 +1159,119 @@ class TestMorphologicalGraphBarrierAndFallback(TestMorphologyBase):
         assert default_nodes["place"].empty
         assert len(fallback_nodes["place"]) == 1
 
+    def test_fallback_cells_match_source_buildings_exactly(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Whole-tessellation fallback cells join their own building, not sjoin matches."""
+        # The small building sits inside the large footprint, so the large
+        # fallback cell contains both representative points and the spatial
+        # join alone would duplicate its row and mis-assign the buildings.
+        buildings = gpd.GeoDataFrame(
+            {"name": ["large", "small"]},
+            geometry=[
+                Polygon([(0, 0), (4, 0), (4, 4), (0, 4)]),
+                Polygon([(1, 1), (2, 1), (2, 2), (1, 2)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(geometry=[LineString([(0, -1), (4, -1)])], crs=sample_crs)
+
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _raise_no_objects_tessellation,
+        )
+
+        nodes, _ = morphological_graph(
+            buildings,
+            segments,
+            tessellation_fallback=True,
+            keep_buildings=True,
+        )
+
+        place = nodes["place"]
+        assert sorted(place.index) == ["fallback_0", "fallback_1"]
+        assert place.loc["fallback_0", "building_geometry"].equals(buildings.geometry.iloc[0])
+        assert place.loc["fallback_1", "building_geometry"].equals(buildings.geometry.iloc[1])
+        assert list(place["name"]) == ["large", "small"]
+        assert "_source_building_index" not in place.columns
+
+    def test_fallback_tessellation_empty_return_keeps_place_schema(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An empty whole-tessellation fallback still returns the place schema."""
+        # The building lies far beyond the network distance budget, so the
+        # fallback retains no cells at all.
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(100, 100), (101, 100), (101, 101), (100, 101)])],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(geometry=[LineString([(0, 0), (1, 0)])], crs=sample_crs)
+
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _raise_no_objects_tessellation,
+        )
+
+        nodes, _ = morphological_graph(
+            buildings,
+            segments,
+            center_point=Point(0, 0),
+            distance=5.0,
+            extent_buffer=1.0,
+            tessellation_fallback=True,
+        )
+
+        place = nodes["place"]
+        assert place.empty
+        assert "place_id" in place.columns
+        assert "_source_building_index" not in place.columns
+
+    def test_unenclosed_fallback_does_not_leak_source_index_column(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Unenclosed-building fallback cells keep the source column internal."""
+        # The stub tessellation covers only the first building, so the second
+        # one is appended as an unenclosed fallback cell.
+        buildings = gpd.GeoDataFrame(
+            geometry=[
+                Polygon([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)]),
+                Polygon([(10, 0.2), (10.5, 0.2), (10.5, 0.7), (10, 0.7)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(geometry=[LineString([(0, 0), (11, 0)])], crs=sample_crs)
+
+        def one_cell_tessellation(
+            geometry: gpd.GeoDataFrame,
+            primary_barriers: gpd.GeoDataFrame | None = None,
+            **kwargs: object,
+        ) -> gpd.GeoDataFrame:
+            _ = (primary_barriers, kwargs)
+            return gpd.GeoDataFrame(
+                {"tess_id": ["cell"], "enclosure_index": [0]},
+                geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+                crs=geometry.crs,
+            )
+
+        monkeypatch.setattr("city2graph.morphology.create_tessellation", one_cell_tessellation)
+
+        nodes, _ = morphological_graph(
+            buildings,
+            segments,
+            include_unenclosed_buildings=True,
+            keep_buildings=False,
+        )
+
+        place = nodes["place"]
+        assert any(str(idx).startswith("fallback_") for idx in place.index)
+        assert "_source_building_index" not in place.columns
+
     def test_tessellation_n_jobs_forwarded(
         self,
         sample_crs: str,

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1060,6 +1060,56 @@ class TestMorphologicalGraphBarrierAndFallback(TestMorphologyBase):
 
         assert len(nodes["movement"]) == 2
 
+    def test_none_barrier_geometry_keeps_movement_but_not_barrier(self, sample_crs: str) -> None:
+        """A segment with a null barrier geometry stays a movement node but never cuts cells."""
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(2, 2), (4, 2), (4, 4), (2, 4)])],
+            crs=sample_crs,
+        )
+        # A closed street loop enclosing the building, plus a "tunnel" segment
+        # crossing the enclosure that must not act as a tessellation barrier.
+        loop = [
+            LineString([(0, 0), (10, 0)]),
+            LineString([(10, 0), (10, 10)]),
+            LineString([(10, 10), (0, 10)]),
+            LineString([(0, 10), (0, 0)]),
+        ]
+        tunnel = LineString([(5, 0), (5, 10)])
+        segments = gpd.GeoDataFrame(
+            {"is_tunnel": [False] * 4 + [True]},
+            geometry=[*loop, tunnel],
+            crs=sample_crs,
+        )
+        segments["barrier_geometry"] = segments.geometry
+        segments.loc[segments["is_tunnel"], "barrier_geometry"] = None
+
+        nodes, edges = morphological_graph(
+            buildings,
+            segments,
+            primary_barrier_col="barrier_geometry",
+        )
+        reference_nodes, _ = morphological_graph(
+            buildings,
+            segments.loc[~segments["is_tunnel"]].copy(),
+            primary_barrier_col="barrier_geometry",
+        )
+
+        # The tunnel is still a movement node.
+        assert len(nodes["movement"]) == 5
+        assert nodes["movement"]["is_tunnel"].sum() == 1
+
+        # The tessellation matches the one built without the tunnel row: the
+        # enclosure is not cut at x=5, so the cells span the full loop.
+        assert len(nodes["place"]) == len(reference_nodes["place"])
+        assert nodes["place"].geometry.area.sum() == pytest.approx(
+            reference_nodes["place"].geometry.area.sum()
+        )
+
+        # The tunnel has no barrier geometry, so it receives no faced_to edges.
+        tunnel_ids = set(nodes["movement"].loc[nodes["movement"]["is_tunnel"]].index)
+        faced_to = edges[("place", "faced_to", "movement")]
+        assert not tunnel_ids & set(faced_to.index.get_level_values("movement_id"))
+
     def test_tessellation_fallback_on_enclosure_error(
         self,
         sample_crs: str,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -607,6 +607,55 @@ class TestTessellation(BaseGraphTest):
         assert result.empty
         assert "returning empty" in caplog.text
 
+    def test_enclosed_tessellation_geos_retry_falls_back_to_simplify_false(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A coarser-grid retry after a GEOS error may fail simplification instead."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        calls: list[tuple[object, object]] = []
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append((kwargs.get("grid_size"), kwargs.get("simplify")))
+            if kwargs.get("grid_size") is None:
+                msg = "TopologyException: side location conflict at 0 0"
+                raise shapely.errors.GEOSException(msg)
+            if kwargs.get("simplify") is not False:
+                msg = "One of the Geometry inputs is of incorrect geometry type."
+                raise TypeError(msg)
+            return gpd.GeoDataFrame(
+                {"enclosure_index": [1]},
+                geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+                index=[0],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert not result.empty
+        assert "tess_id" in result.columns
+        assert calls[-1] == (1e-3, False)
+        assert "retrying with coarser" in caplog.text
+        assert "retrying with simplify=False" in caplog.text
+
     def test_enclosed_tessellation_reraises_geos_error_with_explicit_grid_size(
         self,
         sample_buildings_gdf: gpd.GeoDataFrame,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -656,13 +656,14 @@ class TestTessellation(BaseGraphTest):
         assert "retrying with coarser" in caplog.text
         assert "retrying with simplify=False" in caplog.text
 
-    def test_enclosed_tessellation_reraises_geos_error_with_explicit_grid_size(
+    def test_enclosed_tessellation_degrades_to_empty_with_pinned_grid_size(
         self,
         sample_buildings_gdf: gpd.GeoDataFrame,
         sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When the caller pins grid_size, a GEOS error must propagate unchanged."""
+        """A GEOS error with a caller-pinned grid_size degrades without overriding it."""
         monkeypatch.setattr(
             momepy,
             "enclosures",
@@ -673,18 +674,352 @@ class TestTessellation(BaseGraphTest):
             ),
         )
 
-        def raise_geos(**_kwargs: object) -> gpd.GeoDataFrame:
+        calls: list[object] = []
+
+        def raise_geos(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append(kwargs.get("grid_size"))
             msg = "TopologyException: side location conflict at 0 0"
             raise shapely.errors.GEOSException(msg)
 
         monkeypatch.setattr(momepy, "enclosed_tessellation", raise_geos)
 
-        with pytest.raises(shapely.errors.GEOSException, match="side location conflict"):
-            utils.create_tessellation(
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
                 sample_buildings_gdf,
                 primary_barriers=sample_segments_gdf,
                 grid_size=1e-5,
             )
+
+        assert result.empty
+        assert calls == [1e-5]  # the pinned precision is never overridden
+        assert "returning empty" in caplog.text
+
+    def test_enclosed_tessellation_pinned_grid_size_retries_simplify_false(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With a pinned grid_size, a coverage_simplify TypeError retries simplify=False."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        calls: list[tuple[object, object]] = []
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append((kwargs.get("simplify"), kwargs.get("grid_size")))
+            if kwargs.get("simplify") is not False:
+                msg = "One of the Geometry inputs is of incorrect geometry type."
+                raise TypeError(msg)
+            return gpd.GeoDataFrame(
+                {"enclosure_index": [1]},
+                geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+                index=[0],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+                grid_size=1e-5,
+            )
+
+        assert not result.empty
+        assert calls == [(None, 1e-5), (False, 1e-5)]  # pinned grid_size kept
+        assert "retrying with simplify=False" in caplog.text
+
+    def test_enclosed_tessellation_degrades_when_both_retry_options_pinned(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With grid_size and simplify both pinned, a known failure degrades to empty."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        calls: list[tuple[object, object]] = []
+
+        def raise_type_error(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append((kwargs.get("simplify"), kwargs.get("grid_size")))
+            msg = "One of the Geometry inputs is of incorrect geometry type."
+            raise TypeError(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", raise_type_error)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+                grid_size=1e-5,
+                simplify=True,
+            )
+
+        assert result.empty
+        assert calls == [(True, 1e-5)]  # pinned options are never overridden
+        assert "returning empty" in caplog.text
+
+    def test_enclosed_tessellation_reraises_unknown_error_on_retry(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unknown error raised during a retry must propagate."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            if kwargs.get("grid_size") is None:
+                msg = "One of the Geometry inputs is of incorrect geometry type."
+                raise TypeError(msg)
+            msg = "something else entirely"
+            raise TypeError(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with pytest.raises(TypeError, match="something else entirely"):
+            utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+    def test_enclosed_tessellation_overlap_repair_simplify_retry_failure_keeps_cells(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A GEOS crash in the repair simplify=False retry keeps the original cells."""
+        bad_enclosure = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+        good_enclosure = Polygon([(20, 0), (25, 0), (25, 5), (20, 5)])
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [0, 1]},
+                geometry=[bad_enclosure, good_enclosure],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            # The first run silently degenerates in enclosure 0; the repair
+            # retry fails coverage_simplify and its simplify=False retry
+            # crashes in GEOS.
+            if kwargs.get("grid_size") and kwargs.get("simplify") is not False:
+                msg = "One of the Geometry inputs is of incorrect geometry type."
+                raise TypeError(msg)
+            if kwargs.get("grid_size"):
+                msg = "TopologyException: side location conflict at 0 0"
+                raise shapely.errors.GEOSException(msg)
+            return gpd.GeoDataFrame(
+                {"enclosure_index": [0, 0, 1]},
+                geometry=[bad_enclosure, bad_enclosure, good_enclosure],
+                index=[0, 1, 2],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert set(result["enclosure_index"]) == {1}
+        assert "keeping the original cells" in caplog.text
+        assert "Dropping 1 enclosure(s)" in caplog.text
+
+    def test_enclosed_tessellation_degrades_when_concat_error_on_retry(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A concat failure during the grid_size retry degrades to empty output."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        calls: list[tuple[object, object]] = []
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append((kwargs.get("simplify"), kwargs.get("grid_size")))
+            if kwargs.get("grid_size") is None:
+                msg = "One of the Geometry inputs is of incorrect geometry type."
+                raise TypeError(msg)
+            msg = "No objects to concatenate"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert result.empty
+        assert calls == [(None, None), (None, 1e-3)]
+        assert "returning empty GeoDataFrame" in caplog.text
+
+    def test_enclosed_tessellation_degrades_when_geos_error_during_simplify_retry(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A GEOS error during the grid_size retry of a TypeError degrades to empty."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        calls: list[tuple[object, object]] = []
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append((kwargs.get("simplify"), kwargs.get("grid_size")))
+            if kwargs.get("grid_size") is None:
+                msg = "One of the Geometry inputs is of incorrect geometry type."
+                raise TypeError(msg)
+            msg = "TopologyException: side location conflict at 0 0"
+            raise shapely.errors.GEOSException(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert result.empty
+        assert calls == [(None, None), (None, 1e-3)]
+        assert "returning empty" in caplog.text
+
+    def test_enclosed_tessellation_degrades_when_type_error_persists(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A coverage_simplify TypeError persisting through every rung degrades to empty."""
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        calls: list[tuple[object, object]] = []
+
+        def raise_type_error(**kwargs: object) -> gpd.GeoDataFrame:
+            calls.append((kwargs.get("simplify"), kwargs.get("grid_size")))
+            msg = "One of the Geometry inputs is of incorrect geometry type."
+            raise TypeError(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", raise_type_error)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert result.empty
+        assert calls == [(None, None), (None, 1e-3), (False, 1e-3)]
+        assert "returning empty" in caplog.text
+
+    def test_enclosed_tessellation_overlap_retry_failure_drops_enclosures(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failing overlap-repair retry keeps the good enclosures and drops the broken."""
+        bad_enclosure = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+        good_enclosure = Polygon([(20, 0), (25, 0), (25, 5), (20, 5)])
+        monkeypatch.setattr(
+            momepy,
+            "enclosures",
+            lambda **_kwargs: gpd.GeoDataFrame(
+                {"eID": [0, 1]},
+                geometry=[bad_enclosure, good_enclosure],
+                crs=sample_buildings_gdf.crs,
+            ),
+        )
+
+        def fake_enclosed_tessellation(**kwargs: object) -> gpd.GeoDataFrame:
+            # The first run silently degenerates in enclosure 0; the repair
+            # retry at a coarser grid_size crashes in GEOS instead.
+            if kwargs.get("grid_size"):
+                msg = "TopologyException: side location conflict at 0 0"
+                raise shapely.errors.GEOSException(msg)
+            return gpd.GeoDataFrame(
+                {"enclosure_index": [0, 0, 1]},
+                geometry=[bad_enclosure, bad_enclosure, good_enclosure],
+                index=[0, 1, 2],
+                crs=sample_buildings_gdf.crs,
+            )
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", fake_enclosed_tessellation)
+
+        with caplog.at_level("WARNING"):
+            result = utils.create_tessellation(
+                sample_buildings_gdf,
+                primary_barriers=sample_segments_gdf,
+            )
+
+        assert set(result["enclosure_index"]) == {1}
+        assert "keeping the original cells" in caplog.text
+        assert "Dropping 1 enclosure(s)" in caplog.text
 
     def test_enclosed_tessellation_passes_explicit_limit(
         self,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -150,15 +150,45 @@ class TestTessellation(BaseGraphTest):
         )
         result = utils.create_tessellation(empty_gdf, primary_barriers=barriers)
         self.assert_valid_gdf(result, expected_empty=True)
-        helpers.assert_has_columns(result, ["enclosure_index"])
+        assert list(result.columns) == ["geometry", "enclosure_index", "tess_id"]
 
-    def test_empty_tessellation_with_tess_id(self, sample_crs: str) -> None:
-        """Test _create_empty_tessellation with tess_id column (line 2422)."""
-        result = utils._create_empty_tessellation(sample_crs, include_tess_id=True)
-        assert isinstance(result, gpd.GeoDataFrame)
+    @pytest.mark.parametrize("failure_mode", ["geos_error", "concat_error", "no_enclosures"])
+    def test_empty_enclosed_tessellation_schema_is_uniform(
+        self,
+        failure_mode: str,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Every degrade path must produce the same empty enclosed-tessellation schema."""
+        enclosures = (
+            gpd.GeoDataFrame({"eID": []}, geometry=[], crs=sample_buildings_gdf.crs)
+            if failure_mode == "no_enclosures"
+            else gpd.GeoDataFrame(
+                {"eID": [1]},
+                geometry=[Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])],
+                crs=sample_buildings_gdf.crs,
+            )
+        )
+        monkeypatch.setattr(momepy, "enclosures", lambda **_kwargs: enclosures)
+
+        def raise_failure(**_kwargs: object) -> gpd.GeoDataFrame:
+            if failure_mode == "geos_error":
+                msg = "TopologyException: side location conflict at 0 0"
+                raise shapely.errors.GEOSException(msg)
+            msg = "No objects to concatenate"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(momepy, "enclosed_tessellation", raise_failure)
+
+        result = utils.create_tessellation(
+            sample_buildings_gdf,
+            primary_barriers=sample_segments_gdf,
+        )
+
         assert result.empty
-        assert "tess_id" in result.columns
-        assert "enclosure_index" in result.columns
+        assert list(result.columns) == ["geometry", "enclosure_index", "tess_id"]
+        assert result.crs == sample_buildings_gdf.crs
 
     def test_tessellation_momepy_error_handling(self, sample_crs: str) -> None:
         """Test tessellation error handling for momepy ValueError (lines 2393-2399)."""


### PR DESCRIPTION
## Description

This PR improves enclosed tessellation robustness around known `momepy` / Shapely failure modes and makes fallback behavior more consistent.

- Adds a retry ladder for enclosed tessellation failures, including GEOS topology errors, `coverage_simplify` geometry-type errors, and `No objects to concatenate` failures.
- Uses a consistent empty enclosed-tessellation schema: `geometry`, `enclosure_index`, and `tess_id`.
- Drops null or empty barrier geometries from tessellation barriers while keeping those rows as movement segments.
- Unifies building-footprint fallback cell generation for full tessellation fallback and unenclosed-building fallback.
- Ensures fallback cells match their source buildings exactly when `keep_buildings=True`, avoiding duplicate or incorrect spatial-join matches.
- Adds regression coverage for retry/degradation paths, fallback metadata handling, null barrier geometries, and empty fallback schemas.
- Clarifies documentation around when `suppress_empty_error` applies.

## Related Issues

N/A

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.