### PR TITLE
Fix enclosed tessellation robustness for fragile geometry cases

### DIFF
--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -1751,6 +1751,7 @@ def _create_and_filter_tessellation(
                 context,
                 distance,
                 segments_filtered,
+                reason="could not be created (barriers enclose no area)",
             )
 
     tessellation = tessellation.rename(columns={"tess_id": _PLACE_ID_COL})
@@ -1818,6 +1819,7 @@ def _create_and_filter_tessellation(
             context,
             distance,
             segments_filtered,
+            reason="retained no cells after filtering",
         )
 
     return tessellation
@@ -1851,6 +1853,12 @@ def _include_unenclosed_building_tessellation(
     if missing_buildings.empty:
         return tessellation
 
+    logger.warning(
+        "Enclosed tessellation covers no cell for %d of %d eligible buildings; "
+        "adding building-footprint fallback cells.",
+        len(missing_buildings),
+        len(buildings_gdf),
+    )
     tessellation = tessellation.copy()
     if "enclosure_index" in tessellation.columns:
         tessellation["enclosure_index"] = tessellation["enclosure_index"].astype(str)
@@ -1987,6 +1995,7 @@ def _fallback_tessellation_without_enclosures(
     context: _MorphologyContext,
     distance: float | None,
     segments_filtered: gpd.GeoDataFrame,
+    reason: str = "produced no usable cells",
 ) -> gpd.GeoDataFrame:
     """
     Build place cells from building footprints when enclosed tessellation fails.
@@ -2005,6 +2014,9 @@ def _fallback_tessellation_without_enclosures(
         Maximum network distance for a cell to be retained.
     segments_filtered : geopandas.GeoDataFrame
         Reachable movement segments used for the network-distance filters.
+    reason : str, optional
+        Why the enclosed tessellation is unavailable, used in the warning log
+        so operators can tell the failure paths apart.
 
     Returns
     -------
@@ -2034,6 +2046,11 @@ def _fallback_tessellation_without_enclosures(
             context.extent_buffer,
             field=context.field,
         )
+    logger.warning(
+        "Enclosed tessellation %s; using %d building-footprint fallback cells.",
+        reason,
+        len(tessellation),
+    )
     if context.keep_buildings:
         tessellation = _add_building_info(tessellation, buildings)
     else:
@@ -2245,9 +2262,18 @@ def _prepare_barriers(
     if geom_col and geom_col in segments.columns and geom_col != "geometry":
         # The alternative column may be object-dtype (e.g. after assigning
         # None values or a parquet round trip), so coerce it to a GeoSeries.
+        barrier_series = gpd.GeoSeries(segments[geom_col], index=segments.index)
+        if segments.crs is not None:
+            if barrier_series.crs is None:
+                barrier_series = barrier_series.set_crs(segments.crs)
+            elif barrier_series.crs != segments.crs:
+                # to_crs() on a GeoDataFrame only reprojects the active
+                # geometry column, so a barrier column created before the
+                # reprojection keeps its original CRS.
+                barrier_series = barrier_series.to_crs(segments.crs)
         barriers = gpd.GeoDataFrame(
             segments.drop(columns=["geometry"]),
-            geometry=gpd.GeoSeries(segments[geom_col], index=segments.index, crs=segments.crs),
+            geometry=barrier_series,
             crs=segments.crs,
         )
     else:

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from collections.abc import Sequence
 from dataclasses import dataclass
+from functools import partial
 from itertools import combinations
 from typing import TYPE_CHECKING
 from typing import Any
@@ -4362,6 +4363,101 @@ def _overfilled_enclosures(
 # default (1e-5) can degenerate numerically inside fragile enclosures.
 _COARSE_GRID_SIZE: float = 1e-3
 
+# Magnitude (map units, i.e. ~1 cm in projected CRS) of the deterministic
+# coordinate jitter used as the last tessellation retry rung. Perfectly
+# rectilinear, grid-aligned footprints produce exactly collinear/cocircular
+# voronoi generator points on which ``shapely.voronoi_polygons`` degenerates
+# (GeometryCollection cells, overlapping partitions); a sub-centimetre jitter
+# breaks the ties without materially moving any geometry.
+_JITTER_MAGNITUDE: float = 0.01
+
+
+def _jitter_hash_unit(coords: np.ndarray, salt: float) -> np.ndarray:
+    """
+    Map coordinate pairs to deterministic pseudo-random values in [0, 1).
+
+    The value is a pure function of the coordinates and the salt, so repeated
+    calls with the same input produce identical output. This keeps the
+    geometry jitter reproducible across runs and consistent for vertices
+    shared between geometries.
+
+    Parameters
+    ----------
+    coords : numpy.ndarray
+        Array of shape (n, 2) with x/y coordinates.
+    salt : float
+        Salt distinguishing independent channels (e.g. x- and y-offsets).
+
+    Returns
+    -------
+    numpy.ndarray
+        One value in [0, 1) per coordinate pair, identical for identical
+        input pairs.
+    """
+    return np.abs(np.sin(coords[:, 0] * 12.9898 + coords[:, 1] * 78.233 + salt) * 43758.5453) % 1.0
+
+
+def _shift_jittered_coordinates(coords: np.ndarray, magnitude: float) -> np.ndarray:
+    """
+    Offset an (n, 2) coordinate array by the deterministic jitter.
+
+    Both offset channels derive from :func:`_jitter_hash_unit`, so the shift
+    is reproducible and identical for identical coordinates.
+
+    Parameters
+    ----------
+    coords : numpy.ndarray
+        Array of shape (n, 2) with x/y coordinates.
+    magnitude : float
+        Maximum absolute offset per axis in map units.
+
+    Returns
+    -------
+    numpy.ndarray
+        The offset coordinates.
+    """
+    dx = (_jitter_hash_unit(coords, 0.0) - 0.5) * 2.0 * magnitude
+    dy = (_jitter_hash_unit(coords, 1.0) - 0.5) * 2.0 * magnitude
+    return coords + np.column_stack([dx, dy])
+
+
+def _jitter_geometry(
+    geometry: gpd.GeoDataFrame | gpd.GeoSeries,
+    magnitude: float = _JITTER_MAGNITUDE,
+) -> gpd.GeoDataFrame | gpd.GeoSeries:
+    """
+    Displace every vertex by a deterministic sub-centimetre offset.
+
+    The offset is a pure function of the vertex coordinates, so identical
+    vertices move identically: rings stay closed, shared party walls stay
+    coincident, and repeated runs produce identical output. Used by the
+    tessellation retry ladder to break the exact collinearity that makes
+    ``shapely.voronoi_polygons`` degenerate on rectilinear footprints.
+
+    Parameters
+    ----------
+    geometry : geopandas.GeoDataFrame or geopandas.GeoSeries
+        Geometries to jitter.
+    magnitude : float, default _JITTER_MAGNITUDE
+        Maximum absolute offset per axis in map units.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame or geopandas.GeoSeries
+        A copy with jittered vertex coordinates.
+    """
+    shift = partial(_shift_jittered_coordinates, magnitude=magnitude)
+    jittered = geometry.copy()
+    if isinstance(jittered, gpd.GeoDataFrame):
+        jittered.geometry = shapely.transform(geometry.geometry, shift)
+    else:
+        jittered = gpd.GeoSeries(
+            shapely.transform(geometry, shift),
+            index=geometry.index,
+            crs=geometry.crs,
+        )
+    return jittered
+
 
 def _classify_tessellation_failure(error: Exception) -> str | None:
     """
@@ -4421,18 +4517,22 @@ def _next_retry_overrides(
         The overrides for the next attempt, or ``None`` when the ladder is
         exhausted and the unit must degrade to an empty tessellation.
     """
-    if kind != "empty":
+    if kind != "empty" and "_jitter" not in overrides:
         if "grid_size" not in kwargs and "grid_size" not in overrides:
             return {**overrides, "grid_size": _COARSE_GRID_SIZE}
         if kind == "simplify" and "simplify" not in kwargs and "simplify" not in overrides:
             return {**overrides, "simplify": False}
+        # The final jitter rung replaces the earlier workarounds instead of
+        # stacking on them: snapping to the coarse grid would re-align the
+        # jittered coordinates and reintroduce the degeneracy.
+        return {"_jitter": True}
     return None
 
 
 def _log_tessellation_retry(
     kind: str,
     error: Exception,
-    adds_grid_size: bool,
+    added_option: str,
 ) -> None:
     """
     Log the retry decision for a known tessellation failure.
@@ -4446,18 +4546,23 @@ def _log_tessellation_retry(
         The failure kind from :func:`_classify_tessellation_failure`.
     error : Exception
         The failure that triggered the retry.
-    adds_grid_size : bool
-        Whether the next rung adds the coarser ``grid_size`` (as opposed to
-        disabling boundary simplification).
+    added_option : str
+        The option the next rung adds: ``"grid_size"``, ``"simplify"`` or
+        ``"_jitter"``.
     """
-    if adds_grid_size and kind == "geos":
+    if added_option == "grid_size" and kind == "geos":
         logger.warning(
             "Tessellation hit a GEOS topology error (%s); retrying with coarser grid_size=1e-3.",
             error,
         )
-    elif adds_grid_size:
+    elif added_option == "grid_size":
         logger.warning(
             "Tessellation boundary simplification failed (%s); retrying with grid_size=1e-3.",
+            error,
+        )
+    elif added_option == "_jitter":
+        logger.warning(
+            "Tessellation stayed degenerate (%s); retrying with jittered geometry.",
             error,
         )
     else:
@@ -4564,11 +4669,8 @@ def _run_tessellation_with_retries(
             if next_overrides is None:
                 log_exhausted(error)
                 return None, overrides
-            _log_tessellation_retry(
-                kind,
-                error,
-                adds_grid_size="grid_size" not in overrides and "grid_size" in next_overrides,
-            )
+            added_option = next(key for key in next_overrides if key not in overrides)
+            _log_tessellation_retry(kind, error, added_option)
             overrides = next_overrides
 
 
@@ -4586,9 +4688,11 @@ def _repair_or_drop_degenerate_enclosures(
     under ``simplify=False``), so the cells are validated against the
     enclosure areas before they can poison downstream spatial joins. A broken
     partition is retried once with a coarser ``grid_size`` (unless one is
-    already in effect); when the retry itself fails with a known error the
-    original cells are kept, and enclosures that stay degenerate have their
-    cells dropped with a warning.
+    already in effect) and then once with deterministically jittered geometry
+    (which breaks the exact collinearity that degenerates the voronoi
+    partition of rectilinear footprints); when a retry itself fails with a
+    known error the original cells are kept, and enclosures that stay
+    degenerate have their cells dropped with a warning.
 
     Parameters
     ----------
@@ -4616,7 +4720,7 @@ def _repair_or_drop_degenerate_enclosures(
             "grid_size=1e-3.",
             len(broken),
         )
-        retried, _ = _run_tessellation_with_retries(
+        retried, overrides = _run_tessellation_with_retries(
             run_tessellation,
             kwargs,
             overrides={**overrides, "grid_size": _COARSE_GRID_SIZE},
@@ -4625,14 +4729,90 @@ def _repair_or_drop_degenerate_enclosures(
         if retried is not None:
             tessellation = retried
             broken = _overfilled_enclosures(tessellation, enclosures)
-    if broken:
+    if broken and "_jitter" not in overrides:
         logger.warning(
-            "Dropping %d enclosure(s) whose tessellation cells overlap instead of "
-            "partitioning the enclosure.",
+            "Tessellation kept overlapping cells in %d enclosure(s); retrying with "
+            "jittered geometry.",
             len(broken),
         )
-        tessellation = tessellation.loc[~tessellation["enclosure_index"].isin(broken)]
+        # Jitter replaces the earlier workarounds (see _next_retry_overrides):
+        # the coarse grid would re-align the jittered coordinates.
+        retried, _ = _run_tessellation_with_retries(
+            run_tessellation,
+            kwargs,
+            overrides={"_jitter": True},
+            log_exhausted=_log_repair_retry_failure,
+        )
+        if retried is not None:
+            tessellation = retried
+            broken = _overfilled_enclosures(tessellation, enclosures)
+    if broken:
+        dropped = tessellation["enclosure_index"].isin(broken)
+        logger.warning(
+            "Dropping %d enclosure(s) whose tessellation cells overlap instead of "
+            "partitioning the enclosure; %d cell(s) removed and their buildings "
+            "degrade to footprint fallback cells.",
+            len(broken),
+            int(dropped.sum()),
+        )
+        tessellation = tessellation.loc[~dropped]
     return tessellation
+
+
+def _run_enclosed_tessellation(
+    *,
+    geometry: gpd.GeoDataFrame | gpd.GeoSeries,
+    enclosures: gpd.GeoDataFrame,
+    shrink: float,
+    segment: float,
+    threshold: float,
+    n_jobs: int,
+    kwargs: dict[str, object],
+    **extra_kwargs: object,
+) -> gpd.GeoDataFrame:
+    """
+    Run momepy enclosed tessellation with retry-specific option overrides.
+
+    The retry ladder passes only override options into this helper. This
+    function merges those options with the caller-supplied momepy options and
+    handles the internal ``_jitter`` marker before dispatching to momepy.
+
+    Parameters
+    ----------
+    geometry : geopandas.GeoDataFrame or geopandas.GeoSeries
+        The geometries to tessellate around.
+    enclosures : geopandas.GeoDataFrame
+        The enclosures to tessellate within.
+    shrink : float
+        The distance to shrink the geometry.
+    segment : float
+        The segment length for discretizing the geometry.
+    threshold : float
+        The threshold for snapping skeleton endpoints.
+    n_jobs : int
+        The number of jobs to use for parallel processing.
+    kwargs : dict[str, object]
+        Caller-supplied momepy options.
+    **extra_kwargs : object
+        Retry overrides, such as ``simplify``, ``grid_size`` or the internal
+        ``_jitter`` marker.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The enclosed tessellation.
+    """
+    options = {**kwargs, **extra_kwargs}
+    tess_geometry = _jitter_geometry(geometry) if options.pop("_jitter", False) else geometry
+    return momepy.enclosed_tessellation(
+        geometry=tess_geometry,
+        enclosures=enclosures,
+        shrink=shrink,
+        segment=segment,
+        threshold=threshold,
+        n_jobs=n_jobs,
+        **options,
+    )
 
 
 def _create_enclosed_tessellation(
@@ -4689,33 +4869,36 @@ def _create_enclosed_tessellation(
     )
 
     if not enclosures.empty:
-
-        def _run_enclosed_tessellation(**extra_kwargs: object) -> gpd.GeoDataFrame:
-            # ``extra_kwargs`` (e.g. ``simplify`` or a coarser ``grid_size``) are
-            # applied as retry overrides on top of the caller-supplied ``kwargs``.
-            return momepy.enclosed_tessellation(
-                geometry=geometry,
-                enclosures=enclosures,
-                shrink=shrink,
-                segment=segment,
-                threshold=threshold,
-                n_jobs=n_jobs,
-                **{**kwargs, **extra_kwargs},
-            )
-
-        tessellation, overrides = _run_tessellation_with_retries(
+        run_enclosed_tessellation = partial(
             _run_enclosed_tessellation,
+            geometry=geometry,
+            enclosures=enclosures,
+            shrink=shrink,
+            segment=segment,
+            threshold=threshold,
+            n_jobs=n_jobs,
+            kwargs=kwargs,
+        )
+        tessellation, overrides = _run_tessellation_with_retries(
+            run_enclosed_tessellation,
             kwargs,
         )
         if tessellation is None:
-            return _create_empty_tessellation(geometry.crs)
-        tessellation = _repair_or_drop_degenerate_enclosures(
-            tessellation,
-            enclosures,
-            _run_enclosed_tessellation,
-            kwargs,
-            overrides,
-        )
+            # ``momepy.enclosed_tessellation`` crashes with "No objects to
+            # concatenate" when no enclosure holds two or more buildings,
+            # although every single-building enclosure is a perfectly valid
+            # cell; recover those units instead of degrading them to empty.
+            tessellation = _recover_tessellation_without_splits(geometry, enclosures)
+            if tessellation is None:
+                return _create_empty_tessellation(geometry.crs)
+        else:
+            tessellation = _repair_or_drop_degenerate_enclosures(
+                tessellation,
+                enclosures,
+                run_enclosed_tessellation,
+                kwargs,
+                overrides,
+            )
     else:
         tessellation = _create_empty_tessellation(geometry.crs)
 
@@ -4728,6 +4911,99 @@ def _create_enclosed_tessellation(
         for i, j in zip(tessellation["enclosure_index"], tessellation.index, strict=False)
     ]
     return tessellation.reset_index(drop=True)
+
+
+def _recover_tessellation_without_splits(
+    geometry: gpd.GeoDataFrame | gpd.GeoSeries,
+    enclosures: gpd.GeoDataFrame,
+) -> gpd.GeoDataFrame | None:
+    """
+    Recover the tessellation after momepy's empty-concatenation crash.
+
+    ``momepy.enclosed_tessellation`` voronoi-partitions only enclosures that
+    intersect two or more buildings and crashes with "No objects to
+    concatenate" when none exist, although single-building and empty
+    enclosures are perfectly valid cells. When that precondition holds (and
+    at least one polygonal building sits in an enclosure) the equivalent
+    output is built directly; otherwise ``None`` signals that the failure was
+    genuine and the unit must degrade to an empty tessellation.
+
+    Parameters
+    ----------
+    geometry : geopandas.GeoDataFrame or geopandas.GeoSeries
+        Building footprints passed to the tessellation.
+    enclosures : geopandas.GeoDataFrame
+        Enclosure polygons produced by ``momepy.enclosures``.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame or None
+        The recovered tessellation, or ``None`` when recovery does not apply.
+    """
+    polygonal = geometry.geometry.notna() & geometry.geometry.geom_type.isin(
+        ["Polygon", "MultiPolygon"],
+    )
+    buildings = geometry[polygonal]
+    if buildings.empty:
+        return None
+    enclosure_positions, _ = buildings.sindex.query(
+        enclosures.geometry,
+        predicate="intersects",
+    )
+    if len(enclosure_positions) == 0:
+        return None
+    _, counts = np.unique(enclosure_positions, return_counts=True)
+    if (counts > 1).any():
+        # Some enclosure did need splitting, so the crash came from elsewhere.
+        return None
+    logger.warning(
+        "Momepy could not tessellate because no enclosure holds two or more "
+        "buildings; assigning single-building enclosures as cells directly.",
+    )
+    return _enclosure_cells_without_splits(buildings, enclosures)
+
+
+def _enclosure_cells_without_splits(
+    geometry: gpd.GeoDataFrame | gpd.GeoSeries,
+    enclosures: gpd.GeoDataFrame,
+) -> gpd.GeoDataFrame:
+    """
+    Build the enclosed tessellation when no enclosure needs splitting.
+
+    Equivalent of the ``momepy.enclosed_tessellation`` output for the case its
+    own implementation crashes on: every enclosure intersecting exactly one
+    building becomes that building's cell (indexed by the building), and
+    enclosures without buildings keep momepy's negative-index convention.
+
+    Parameters
+    ----------
+    geometry : geopandas.GeoDataFrame or geopandas.GeoSeries
+        Building footprints.
+    enclosures : geopandas.GeoDataFrame
+        Enclosure polygons produced by ``momepy.enclosures``.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        One cell per enclosure with the ``enclosure_index`` column set,
+        matching the raw momepy output schema.
+    """
+    enclosure_positions, building_positions = geometry.sindex.query(
+        enclosures.geometry,
+        predicate="intersects",
+    )
+    cell_index = np.full(len(enclosures), None, dtype=object)
+    cell_index[enclosure_positions] = geometry.geometry.index.to_numpy()[building_positions]
+    empty_mask = np.array([index is None for index in cell_index])
+    cell_index[empty_mask] = range(-int(empty_mask.sum()), 0)
+    cells = gpd.GeoDataFrame(
+        {"enclosure_index": enclosures.index},
+        geometry=enclosures.geometry.to_numpy(),
+        index=pd.Index(cell_index),
+        crs=enclosures.crs,
+    )
+    # Match the raw momepy output column order (geometry first).
+    return cells[["geometry", "enclosure_index"]]
 
 
 def _compute_enclosure_limit(
@@ -5528,6 +5804,58 @@ def _resolve_type_parameter(
     return param.get(type_key) if isinstance(param, dict) else param
 
 
+def _get_style_param(
+    global_kwargs: dict[str, Any],
+    name: str,
+    type_key: str | tuple[str, str, str] | None,
+) -> Any:  # noqa: ANN401
+    """
+    Get a style parameter value with optional type-specific lookup.
+
+    Type-specific plotting options are stored as dictionaries keyed by node or
+    edge type. This helper resolves those dictionaries when a type key is
+    available and otherwise returns the raw parameter value.
+
+    Parameters
+    ----------
+    global_kwargs : dict[str, Any]
+        The kwargs passed to the main plot_graph function.
+    name : str
+        Parameter name to look up.
+    type_key : str or tuple or None
+        The key identifying the node or edge type.
+
+    Returns
+    -------
+    Any
+        The parameter value, or type-specific value if ``type_key`` is set.
+    """
+    val = global_kwargs.get(name)
+    return _resolve_type_parameter(val, type_key) if type_key else val
+
+
+def _or_default(val: Any, default: Any) -> Any:  # noqa: ANN401
+    """
+    Return a fallback value when the resolved style value is None.
+
+    Plotting defaults should replace missing values while preserving explicit
+    falsy values such as ``0`` or ``False``.
+
+    Parameters
+    ----------
+    val : Any
+        Value to check.
+    default : Any
+        Default value to use if ``val`` is None.
+
+    Returns
+    -------
+    Any
+        ``val`` if not None, otherwise ``default``.
+    """
+    return val if val is not None else default
+
+
 def _resolve_style_kwargs(
     global_kwargs: dict[str, Any],
     type_key: str | tuple[str, str, str] | None,
@@ -5556,48 +5884,6 @@ def _resolve_style_kwargs(
     dict
         Resolved style arguments ready for _plot_gdf.
     """
-
-    def _get_param(name: str) -> Any:  # noqa: ANN401
-        """
-        Get parameter value from kwargs with optional type-specific lookup.
-
-        This helper looks up a parameter by name from the enclosing function's
-        global_kwargs dict, applying type-specific resolution if a type_key is set.
-
-        Parameters
-        ----------
-        name : str
-            Parameter name to look up.
-
-        Returns
-        -------
-        Any
-            The parameter value, or type-specific value if type_key is set.
-        """
-        val = global_kwargs.get(name)
-        return _resolve_type_parameter(val, type_key) if type_key else val
-
-    def _or_default(val: Any, default: Any) -> Any:  # noqa: ANN401
-        """
-        Return val if not None, otherwise return default.
-
-        This helper provides a None-safe default value fallback, ensuring that
-        explicit None values are replaced with the specified default.
-
-        Parameters
-        ----------
-        val : Any
-            Value to check.
-        default : Any
-            Default value to use if val is None.
-
-        Returns
-        -------
-        Any
-            Val if not None, otherwise default.
-        """
-        return val if val is not None else default
-
     # Keys reserved for C2G-specific styling logic
     c2g_keys = {
         "node_color",
@@ -5627,25 +5913,46 @@ def _resolve_style_kwargs(
         resolved.update(
             {
                 "linewidth": _or_default(
-                    _get_param("edge_linewidth"), PLOT_DEFAULTS["edge_linewidth"]
+                    _get_style_param(global_kwargs, "edge_linewidth", type_key),
+                    PLOT_DEFAULTS["edge_linewidth"],
                 ),
-                "alpha": _or_default(_get_param("edge_alpha"), PLOT_DEFAULTS["edge_alpha"]),
-                "zorder": _or_default(_get_param("edge_zorder"), PLOT_DEFAULTS["edge_zorder"]),
-                "color": _or_default(_get_param("edge_color"), default_color),
+                "alpha": _or_default(
+                    _get_style_param(global_kwargs, "edge_alpha", type_key),
+                    PLOT_DEFAULTS["edge_alpha"],
+                ),
+                "zorder": _or_default(
+                    _get_style_param(global_kwargs, "edge_zorder", type_key),
+                    PLOT_DEFAULTS["edge_zorder"],
+                ),
+                "color": _or_default(
+                    _get_style_param(global_kwargs, "edge_color", type_key),
+                    default_color,
+                ),
             }
         )
     else:
         resolved.update(
             {
                 "color": _or_default(
-                    _get_param("node_color"), default_color or PLOT_DEFAULTS["node_color"]
+                    _get_style_param(global_kwargs, "node_color", type_key),
+                    default_color or PLOT_DEFAULTS["node_color"],
                 ),
-                "alpha": _or_default(_get_param("node_alpha"), PLOT_DEFAULTS["node_alpha"]),
-                "zorder": _or_default(_get_param("node_zorder"), PLOT_DEFAULTS["node_zorder"]),
+                "alpha": _or_default(
+                    _get_style_param(global_kwargs, "node_alpha", type_key),
+                    PLOT_DEFAULTS["node_alpha"],
+                ),
+                "zorder": _or_default(
+                    _get_style_param(global_kwargs, "node_zorder", type_key),
+                    PLOT_DEFAULTS["node_zorder"],
+                ),
                 "edgecolor": _or_default(
-                    _get_param("node_edgecolor"), PLOT_DEFAULTS["node_edgecolor"]
+                    _get_style_param(global_kwargs, "node_edgecolor", type_key),
+                    PLOT_DEFAULTS["node_edgecolor"],
                 ),
-                "markersize": _or_default(_get_param("markersize"), PLOT_DEFAULTS["markersize"]),
+                "markersize": _or_default(
+                    _get_style_param(global_kwargs, "markersize", type_key),
+                    PLOT_DEFAULTS["markersize"],
+                ),
             }
         )
     return resolved

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1060,6 +1060,77 @@ class TestMorphologicalGraphBarrierAndFallback(TestMorphologyBase):
 
         assert len(nodes["movement"]) == 2
 
+    def test_barrier_geometry_with_stale_crs_is_reprojected(self, sample_crs: str) -> None:
+        """A barrier column left in a pre-``to_crs()`` CRS is reprojected, not rejected.
+
+        ``GeoDataFrame.to_crs()`` only reprojects the active geometry column,
+        so a ``barrier_geometry`` column created beforehand (e.g. by
+        ``process_overture_segments`` on WGS84 data) keeps the original CRS.
+        """
+        lon, lat = -0.12, 51.5  # projects into the EPSG:27700 sample CRS
+        step = 1e-4
+        buildings = gpd.GeoDataFrame(
+            geometry=[
+                Polygon(
+                    [
+                        (lon + 2 * step, lat + 2 * step),
+                        (lon + 4 * step, lat + 2 * step),
+                        (lon + 4 * step, lat + 4 * step),
+                        (lon + 2 * step, lat + 4 * step),
+                    ]
+                )
+            ],
+            crs="EPSG:4326",
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[
+                LineString([(lon, lat), (lon + 10 * step, lat)]),
+                LineString([(lon + 10 * step, lat), (lon + 10 * step, lat + 10 * step)]),
+                LineString([(lon + 10 * step, lat + 10 * step), (lon, lat + 10 * step)]),
+                LineString([(lon, lat + 10 * step), (lon, lat)]),
+            ],
+            crs="EPSG:4326",
+        )
+        segments["barrier_geometry"] = segments.geometry
+
+        buildings = buildings.to_crs(sample_crs)
+        # Only the active geometry column is reprojected; barrier_geometry
+        # stays in EPSG:4326.
+        stale_segments = segments.to_crs(sample_crs)
+
+        nodes, edges = morphological_graph(
+            buildings,
+            stale_segments,
+            primary_barrier_col="barrier_geometry",
+        )
+
+        fresh_segments = stale_segments.copy()
+        fresh_segments["barrier_geometry"] = fresh_segments.geometry
+        reference_nodes, _ = morphological_graph(
+            buildings,
+            fresh_segments,
+            primary_barrier_col="barrier_geometry",
+        )
+
+        self.validate_basic_output(nodes, edges, ["place", "movement"])
+        assert len(nodes["place"]) == len(reference_nodes["place"])
+        assert nodes["place"].geometry.area.sum() == pytest.approx(
+            reference_nodes["place"].geometry.area.sum()
+        )
+
+        # A CRS-less barrier column (e.g. plain shapely objects) adopts the
+        # segments CRS instead of failing.
+        naive_segments = fresh_segments.copy()
+        naive_segments["barrier_geometry"] = pd.Series(
+            [*fresh_segments.geometry], index=fresh_segments.index, dtype=object
+        )
+        naive_nodes, _ = morphological_graph(
+            buildings,
+            naive_segments,
+            primary_barrier_col="barrier_geometry",
+        )
+        assert len(naive_nodes["place"]) == len(reference_nodes["place"])
+
     def test_none_barrier_geometry_keeps_movement_but_not_barrier(self, sample_crs: str) -> None:
         """A segment with a null barrier geometry stays a movement node but never cuts cells."""
         buildings = gpd.GeoDataFrame(
@@ -1158,6 +1229,68 @@ class TestMorphologicalGraphBarrierAndFallback(TestMorphologyBase):
 
         assert default_nodes["place"].empty
         assert len(fallback_nodes["place"]) == 1
+
+    def test_tessellation_fallback_logs_reason_and_cell_count(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Whole-tessellation fallback warns with the failure reason and cell count."""
+        buildings = gpd.GeoDataFrame(
+            geometry=[Polygon([(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4)])],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(geometry=[LineString([(0, 0), (1, 0)])], crs=sample_crs)
+
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _raise_no_objects_tessellation,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="city2graph.morphology"):
+            morphological_graph(buildings, segments, tessellation_fallback=True)
+
+        assert any(
+            "could not be created" in message and "1 building-footprint fallback cells" in message
+            for message in caplog.messages
+        )
+
+    def test_include_unenclosed_buildings_logs_missing_count(
+        self,
+        sample_crs: str,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Appending fallback cells for unenclosed buildings warns with the counts."""
+        buildings = gpd.GeoDataFrame(
+            {"building_id": ["inside", "unenclosed"]},
+            geometry=[
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(10, 0), (11, 0), (11, 1), (10, 1)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[LineString([(-1, -1), (2, -1)])],
+            crs=sample_crs,
+        )
+
+        monkeypatch.setattr(
+            "city2graph.morphology.create_tessellation",
+            _enclosed_cell_or_fail_on_fallback,
+        )
+        monkeypatch.setattr(
+            "city2graph.morphology._filter_adjacent_tessellation",
+            _passthrough_adjacent_filter,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="city2graph.morphology"):
+            morphological_graph(buildings, segments, include_unenclosed_buildings=True)
+
+        assert any(
+            "covers no cell for 1 of 2 eligible buildings" in message for message in caplog.messages
+        )
 
     def test_fallback_cells_match_source_buildings_exactly(
         self,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -190,6 +190,69 @@ class TestTessellation(BaseGraphTest):
         assert list(result.columns) == ["geometry", "enclosure_index", "tess_id"]
         assert result.crs == sample_buildings_gdf.crs
 
+    def test_enclosed_tessellation_rectilinear_buildings_not_degenerate(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """Grid-aligned footprints must yield per-building, non-overlapping cells.
+
+        Perfectly rectilinear coordinates make ``shapely.voronoi_polygons``
+        degenerate (GeometryCollection cells, overlapping partitions); the
+        retry ladder must recover via the deterministic jitter rung instead of
+        dropping the enclosure and degrading its buildings to fallback cells.
+        """
+        corners = [(0.0, 0.0), (200.0, 0.0), (200.0, 200.0), (0.0, 200.0), (0.0, 0.0)]
+        barriers = gpd.GeoDataFrame(
+            geometry=[LineString([corners[i], corners[i + 1]]) for i in range(4)],
+            crs=sample_crs,
+        )
+        buildings = gpd.GeoDataFrame(
+            geometry=[
+                Polygon([(40, 40), (80, 40), (80, 80), (40, 80)]),
+                Polygon([(120, 120), (160, 120), (160, 160), (120, 160)]),
+            ],
+            crs=sample_crs,
+        )
+
+        result = utils.create_tessellation(buildings, primary_barriers=barriers, n_jobs=1)
+
+        cells = list(result.geometry)
+        overlap = sum(
+            cells[i].intersection(cells[j]).area
+            for i in range(len(cells))
+            for j in range(i + 1, len(cells))
+        )
+        assert overlap == pytest.approx(0.0, abs=1e-6)
+        for footprint in buildings.geometry:
+            assert result.geometry.contains(footprint.centroid).sum() == 1
+
+    def test_enclosed_tessellation_single_building_enclosures(
+        self,
+        sample_crs: str,
+    ) -> None:
+        """Enclosures holding at most one building each still produce cells.
+
+        ``momepy.enclosed_tessellation`` crashes with "No objects to
+        concatenate" when no enclosure holds two or more buildings; the
+        single-building enclosures must become their buildings' cells instead
+        of degrading the unit to an empty tessellation.
+        """
+        corners = [(0.0, 0.0), (200.0, 0.0), (200.0, 200.0), (0.0, 200.0), (0.0, 0.0)]
+        barriers = gpd.GeoDataFrame(
+            geometry=[LineString([corners[i], corners[i + 1]]) for i in range(4)],
+            crs=sample_crs,
+        )
+        building = gpd.GeoDataFrame(
+            geometry=[Polygon([(80, 80), (120, 80), (120, 120), (80, 120)])],
+            crs=sample_crs,
+        )
+
+        result = utils.create_tessellation(building, primary_barriers=barriers, n_jobs=1)
+
+        assert not result.empty
+        assert list(result.columns) == ["geometry", "enclosure_index", "tess_id"]
+        assert result.geometry.contains(building.geometry.iloc[0].centroid).sum() == 1
+
     def test_tessellation_momepy_error_handling(self, sample_crs: str) -> None:
         """Test tessellation error handling for momepy ValueError (lines 2393-2399)."""
         # Create geometry that might cause momepy to fail with "No objects to concatenate"
@@ -721,7 +784,10 @@ class TestTessellation(BaseGraphTest):
             )
 
         assert result.empty
-        assert calls == [1e-5]  # the pinned precision is never overridden
+        # The pinned precision is never overridden; the final rung retries the
+        # same options once with jittered geometry before degrading.
+        assert calls == [1e-5, 1e-5]
+        assert "retrying with jittered geometry" in caplog.text
         assert "returning empty" in caplog.text
 
     def test_enclosed_tessellation_pinned_grid_size_retries_simplify_false(
@@ -805,7 +871,9 @@ class TestTessellation(BaseGraphTest):
             )
 
         assert result.empty
-        assert calls == [(True, 1e-5)]  # pinned options are never overridden
+        # Pinned options are never overridden; the final rung retries them
+        # once with jittered geometry before degrading.
+        assert calls == [(True, 1e-5), (True, 1e-5)]
         assert "returning empty" in caplog.text
 
     def test_enclosed_tessellation_reraises_unknown_error_on_retry(
@@ -847,7 +915,12 @@ class TestTessellation(BaseGraphTest):
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A GEOS crash in the repair simplify=False retry keeps the original cells."""
+        """A GEOS crash in the repair simplify=False retry still drops only the broken cells.
+
+        The repair retry escalates through the jitter rung, whose (mocked)
+        result stays degenerate, so the broken enclosure is dropped while the
+        good one survives.
+        """
         bad_enclosure = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
         good_enclosure = Polygon([(20, 0), (25, 0), (25, 5), (20, 5)])
         monkeypatch.setattr(
@@ -886,7 +959,7 @@ class TestTessellation(BaseGraphTest):
             )
 
         assert set(result["enclosure_index"]) == {1}
-        assert "keeping the original cells" in caplog.text
+        assert "retrying with jittered geometry" in caplog.text
         assert "Dropping 1 enclosure(s)" in caplog.text
 
     def test_enclosed_tessellation_degrades_when_concat_error_on_retry(
@@ -966,7 +1039,9 @@ class TestTessellation(BaseGraphTest):
             )
 
         assert result.empty
-        assert calls == [(None, None), (None, 1e-3)]
+        # After the coarse-grid rung the ladder resets to a jittered attempt
+        # at default options before degrading.
+        assert calls == [(None, None), (None, 1e-3), (None, None)]
         assert "returning empty" in caplog.text
 
     def test_enclosed_tessellation_degrades_when_type_error_persists(
@@ -1003,7 +1078,9 @@ class TestTessellation(BaseGraphTest):
             )
 
         assert result.empty
-        assert calls == [(None, None), (None, 1e-3), (False, 1e-3)]
+        # grid_size, then simplify=False, then one jittered attempt at
+        # default options before degrading.
+        assert calls == [(None, None), (None, 1e-3), (False, 1e-3), (None, None)]
         assert "returning empty" in caplog.text
 
     def test_enclosed_tessellation_overlap_retry_failure_drops_enclosures(
@@ -1013,7 +1090,12 @@ class TestTessellation(BaseGraphTest):
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A failing overlap-repair retry keeps the good enclosures and drops the broken."""
+        """A failing overlap-repair retry keeps the good enclosures and drops the broken.
+
+        The GEOS crash in the coarser-grid retry escalates to the jitter rung,
+        whose (mocked) result stays degenerate, so the broken enclosure is
+        dropped while the good one survives.
+        """
         bad_enclosure = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
         good_enclosure = Polygon([(20, 0), (25, 0), (25, 5), (20, 5)])
         monkeypatch.setattr(
@@ -1048,7 +1130,7 @@ class TestTessellation(BaseGraphTest):
             )
 
         assert set(result["enclosure_index"]) == {1}
-        assert "keeping the original cells" in caplog.text
+        assert "retrying with jittered geometry" in caplog.text
         assert "Dropping 1 enclosure(s)" in caplog.text
 
     def test_enclosed_tessellation_passes_explicit_limit(


### PR DESCRIPTION
## Description

This change adds a deterministic jitter retry rung for degenerate rectilinear tessellations, recovers valid single-building enclosure cells when `momepy.enclosed_tessellation` crashes with no split candidates, and drops only irreparable overlapping enclosures while allowing affected buildings to fall back to footprint cells.

It also reprojects stale `barrier_geometry` columns to match the active segments CRS, improves warning logs for fallback paths, and extracts plotting style parameter resolution helpers for reuse and testability.

## Related Issues

NA

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.