### PR TITLE
Add GBFS loading support

### DIFF
--- a/city2graph/transportation.py
+++ b/city2graph/transportation.py
@@ -8,6 +8,7 @@ graphs for downstream network analysis.
 
 from __future__ import annotations
 
+import json
 import logging
 import tempfile
 import zipfile
@@ -25,7 +26,7 @@ from shapely import wkt
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-__all__ = ["get_od_pairs", "load_gtfs", "travel_summary_graph"]
+__all__ = ["get_od_pairs", "load_gbfs", "load_gtfs", "travel_summary_graph"]
 
 _ACTIVE_DATES_TABLE_SQL = """
     CREATE OR REPLACE TEMP TABLE _active_dates (
@@ -563,6 +564,79 @@ def load_gtfs(path: str | Path) -> duckdb.DuckDBPyConnection:
     return con
 
 
+def load_gbfs(path: str | Path) -> duckdb.DuckDBPyConnection:
+    """
+    Load GBFS JSON feeds from a directory into an in-memory DuckDB database.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to a GBFS directory containing JSON files.
+
+    Returns
+    -------
+    duckdb.DuckDBPyConnection
+        In-memory DuckDB connection containing imported GBFS tables.
+    """
+    con = duckdb.connect(":memory:")
+    con.execute("INSTALL spatial; LOAD spatial;")
+    path = Path(path)
+    has_files = False
+    try:
+        for file_path in path.rglob("*.json"):
+            with file_path.open(encoding="utf-8") as f:
+                raw = json.load(f)
+            data = raw.get("data", {})
+            if "stations" in data:
+                rows = data["stations"]
+            elif "bikes" in data:
+                rows = data["bikes"]
+            elif "vehicles" in data:
+                rows = data["vehicles"]
+            elif "vehicle_types" in data:
+                rows = data["vehicle_types"]
+            elif "feeds" in data:
+                rows = data["feeds"]
+            else:
+                rows = [data]
+            if not rows:
+                continue
+            has_files = True
+            table_name = file_path.stem.replace("-", "_").lower()
+            df = pd.DataFrame(rows)
+            con.register("_gbfs_tmp", df)
+            con.execute(f"""
+                CREATE OR REPLACE TABLE {table_name} AS
+                SELECT *
+                FROM _gbfs_tmp
+            """) # noqa: S608
+            con.unregister("_gbfs_tmp")
+    except (OSError, json.JSONDecodeError, duckdb.Error):
+        logger.exception("Failed to read GBFS data at %s", path)
+        return con
+    if not has_files:
+        logger.warning("No GBFS JSON files found in %s", path)
+        return con
+
+    tables = sorted(_list_tables(con))
+    for table in tables:
+        columns = {
+            row[1]
+            for row in con.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        if {"lat", "lon"}.issubset(columns):
+            con.execute(f"""
+                ALTER TABLE {table} ADD COLUMN geometry GEOMETRY;
+                UPDATE {table}
+                SET geometry = ST_Point(
+                    CAST(lon AS DOUBLE),
+                    CAST(lat AS DOUBLE)
+                )
+                WHERE try_cast(lon AS DOUBLE) IS NOT NULL
+                  AND try_cast(lat AS DOUBLE) IS NOT NULL
+            """) # noqa: S608
+    logger.info("GBFS loaded: %s", ", ".join(tables))
+    return con
 def _build_frequency_multipliers(
     con: duckdb.DuckDBPyConnection,
     *,

--- a/tests/test_transportation.py
+++ b/tests/test_transportation.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from city2graph.transportation import _time_to_seconds
 from city2graph.transportation import _timestamp
 from city2graph.transportation import get_od_pairs
+from city2graph.transportation import load_gbfs
 from city2graph.transportation import load_gtfs
 from city2graph.transportation import travel_summary_graph
 
@@ -116,6 +117,50 @@ class TestLoadGtfs:
     def test_load_gtfs_nonexistent_file(self) -> None:
         con = load_gtfs("nonexistent.zip")
         assert len(con.execute("SHOW TABLES").fetchall()) == 0
+
+
+class TestLoadGbfs:
+    def test_load_gbfs_basic(self, tmp_path: Path) -> None:
+        gbfs_dir = tmp_path / "gbfs"
+        gbfs_dir.mkdir()
+        (gbfs_dir / "station_information.json").write_text(
+            """
+            {
+                "data": {
+                    "stations": [
+                        {
+                            "station_id": "1",
+                            "name": "Test Station",
+                            "lat": 51.5,
+                            "lon": -0.1,
+                            "capacity": 10
+                        }
+                    ]
+                }
+            }
+            """,
+            encoding="utf-8",
+        )
+        con = load_gbfs(gbfs_dir)
+        assert isinstance(con, duckdb.DuckDBPyConnection)
+        tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
+        assert "station_information" in tables
+        rows = con.execute(
+            "SELECT station_id, name, lat, lon, capacity FROM station_information"
+        ).fetchall()
+        assert rows == [("1", "Test Station", 51.5, -0.1, 10)]
+
+    def test_load_gbfs_empty_directory(self, tmp_path: Path) -> None:
+        gbfs_dir = tmp_path / "empty_gbfs"
+        gbfs_dir.mkdir()
+        con = load_gbfs(gbfs_dir)
+        tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
+        assert len(tables) == 0
+
+    def test_load_gbfs_nonexistent_directory(self) -> None:
+        con = load_gbfs("nonexistent_gbfs")
+        tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
+        assert len(tables) == 0
 
 
 class TestGetOdPairs:


### PR DESCRIPTION
## Summary 
This PR adds support for loading GBFS feeds that was requested. 

## Changes Made
- Added `load_gbfs()` for importing GBFS JSON feeds.
- Creates a DuckDB table for each GBFS feed.
- Automatically creates geometry columns when latitude and longitude are available.
- Added tests covering:
  - basic loading
  - empty directory
  - nonexistent directory
  
## Checklist
- [Y] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [Y] I have updated the documentation, if necessary.
- [Y] I have added tests to cover my changes.
- [Y] All new and existing tests passed.
- [Y] Pre-commit checks passed locally. (61 tests passed) 
