### PR TITLE
Defer metapath path materialization and vectorize reducers

### DIFF
--- a/city2graph/metapath.py
+++ b/city2graph/metapath.py
@@ -492,9 +492,8 @@ def _row_reduce_sum(block: pd.DataFrame) -> pd.Series:
     pandas.Series
         Row-wise sums with missing values treated as zeros.
     """
-    numeric = block.apply(pd.to_numeric, errors="coerce")
-    result = numeric.fillna(0.0).sum(axis=1)
-    return cast("pd.Series", result)
+    values = _coerce_block_to_numpy(block)
+    return pd.Series(np.nansum(values, axis=1), index=block.index)
 
 
 def _row_reduce_mean(block: pd.DataFrame) -> pd.Series:
@@ -513,9 +512,16 @@ def _row_reduce_mean(block: pd.DataFrame) -> pd.Series:
     pandas.Series
         Row-wise means calculated with ``NaN`` values ignored.
     """
-    numeric = block.apply(pd.to_numeric, errors="coerce")
-    result = numeric.mean(axis=1, skipna=True)
-    return cast("pd.Series", result)
+    values = _coerce_block_to_numpy(block)
+    valid_counts = np.sum(~np.isnan(values), axis=1)
+    totals = np.nansum(values, axis=1)
+    means = np.divide(
+        totals,
+        valid_counts,
+        out=np.full(len(values), np.nan),
+        where=valid_counts > 0,
+    )
+    return pd.Series(means, index=block.index)
 
 
 def _row_reduce_callable(
@@ -540,41 +546,35 @@ def _row_reduce_callable(
     pandas.Series
         Row-wise reductions produced by ``func``.
     """
-    numeric = block.apply(pd.to_numeric, errors="coerce")
-    # Avoid passing `func` as a keyword to DataFrame.apply since it clashes with
-    # the DataFrame.apply(func=...) parameter name itself, causing
-    # "multiple values for argument 'func'" TypeError. Use a lambda to forward
-    # the user-supplied reducer to our row helper.
-    result = numeric.apply(lambda row: _apply_callable_row(row, func=func), axis=1)
-    return cast("pd.Series", result)
+    values = _coerce_block_to_numpy(block)
+    valid_mask = ~np.isnan(values)
+    results = np.full(len(values), np.nan)
+    for row_idx in range(len(values)):
+        valid = values[row_idx][valid_mask[row_idx]]
+        if valid.size:
+            results[row_idx] = float(func(valid))
+    return pd.Series(results, index=block.index)
 
 
-def _apply_callable_row(
-    row: pd.Series,
-    *,
-    func: Callable[[np.ndarray], float],
-) -> float:
+def _coerce_block_to_numpy(block: pd.DataFrame) -> np.ndarray:
     """
-    Reduce a single hop row using ``func`` while handling empty inputs.
+    Coerce a hop attribute block to a 2-D float array in a single pass.
 
-    Helper used by :func:`_row_reduce_callable` to evaluate user reducers.
+    Non-numeric values become ``NaN`` so downstream reductions can rely on a
+    homogeneous numeric array instead of per-row pandas dispatch.
 
     Parameters
     ----------
-    row : pandas.Series
-        Hop attribute values for a single metapath traversal.
-    func : Callable[[numpy.ndarray], float]
-        Callable that reduces numeric values to a scalar result.
+    block : pandas.DataFrame
+        Normalised attribute columns for a single hop across multiple paths.
 
     Returns
     -------
-    float
-        Reduced value for the row; ``NaN`` when all values are missing.
+    numpy.ndarray
+        Two-dimensional float array with missing values encoded as ``NaN``.
     """
-    valid = row.dropna().to_numpy()
-    if valid.size == 0:
-        return float("nan")
-    return float(func(valid))
+    numeric = block.apply(pd.to_numeric, errors="coerce")
+    return cast("np.ndarray", numeric.to_numpy(dtype=float, na_value=np.nan))
 
 
 def _group_reduce_callable(
@@ -718,11 +718,16 @@ def _materialize_metapath(
 
     # 1. Build canonical frames for each hop
     frames: list[pd.DataFrame] = []
+    hop_edge_sigs: list[list[object]] | None = None if directed else []
     start_index_name = f"{start_type}_id"
     end_index_name = f"{end_type}_id"
 
     for step_idx, edge_type in enumerate(metapath):
         edge_gdf, reversed_lookup = _get_edge_frame(edges, edge_type, directed)
+        if hop_edge_sigs is not None:
+            hop_edge_sigs.append(
+                [_canonicalize_undirected_edge_id(edge_id) for edge_id in edge_gdf.index]
+            )
 
         # Update index names from the first/last hop
         if step_idx == 0:
@@ -748,7 +753,8 @@ def _materialize_metapath(
             )
         frames.append(frame)
 
-    # 2. Join hops
+    # 2. Join hops, carrying only compact scalar columns; path information is
+    # assembled at most once after the final join (see _aggregate_paths).
     joined = frames[0]
     for idx in range(1, len(frames)):
         joined = joined.merge(
@@ -758,32 +764,9 @@ def _materialize_metapath(
             how="inner",
             suffixes=("", "_right"),
         )
-        joined["path_nodes"] = [
-            left + right[1:]
-            for left, right in zip(
-                joined["path_nodes"],
-                joined["path_nodes_right"],
-                strict=False,
-            )
-        ]
-        joined["path_edges"] = [
-            left + right
-            for left, right in zip(
-                joined["path_edges"],
-                joined["path_edges_right"],
-                strict=False,
-            )
-        ]
-        # Drop intermediate join columns to save memory
-        joined = joined.drop(
-            columns=[
-                f"dst_{idx - 1}",
-                f"src_{idx}",
-                "path_nodes_right",
-                "path_edges_right",
-            ],
-            errors="ignore",
-        )
+        # src_{idx} duplicates dst_{idx - 1}; the dst_* columns are kept as the
+        # intermediate nodes of each path.
+        joined = joined.drop(columns=[f"src_{idx}"])
 
         if joined.empty:
             return (
@@ -803,6 +786,7 @@ def _materialize_metapath(
         start_index_name=start_index_name,
         end_index_name=end_index_name,
         directed=directed,
+        hop_edge_sigs=hop_edge_sigs,
     )
 
     if aggregated.empty:
@@ -866,7 +850,9 @@ def _build_hop_frame(
     """
     Convert one hop into a canonical DataFrame used for joins.
 
-    Extracts source and destination indices and optional attributes.
+    Extracts source and destination indices, the row position within the hop
+    (used to recover edge identifiers after the joins), and optional
+    attributes.
 
     Parameters
     ----------
@@ -897,14 +883,7 @@ def _build_hop_frame(
     data = {
         src_col: edge_gdf.index.get_level_values(src_level).to_numpy(),
         dst_col: edge_gdf.index.get_level_values(dst_level).to_numpy(),
-        "path_nodes": list(
-            zip(
-                edge_gdf.index.get_level_values(src_level).to_numpy(),
-                edge_gdf.index.get_level_values(dst_level).to_numpy(),
-                strict=False,
-            )
-        ),
-        "path_edges": [(index_value,) for index_value in edge_gdf.index.to_list()],
+        f"epos_{step_idx}": np.arange(len(edge_gdf), dtype=np.int64),
     }
 
     if edge_attrs:
@@ -927,11 +906,14 @@ def _aggregate_paths(
     start_index_name: str,
     end_index_name: str,
     directed: bool,
+    hop_edge_sigs: list[list[object]] | None = None,
 ) -> pd.DataFrame:
     """
     Group joined paths into terminal node pairs with aggregated weights.
 
-    Aggregates weights and optional attributes for each path.
+    Aggregates weights and optional attributes for each path. Path node and
+    edge sequences are only materialised here, once, for the undirected
+    deduplication; the directed branch never builds them.
 
     Parameters
     ----------
@@ -949,6 +931,9 @@ def _aggregate_paths(
         Name of the end node index.
     directed : bool
         Whether the metapath should preserve edge orientation.
+    hop_edge_sigs : list[list[object]] or None
+        Canonicalised edge identifiers per hop, indexed by the ``epos_*``
+        columns of ``combined``. Required when ``directed`` is ``False``.
 
     Returns
     -------
@@ -962,7 +947,6 @@ def _aggregate_paths(
     agg_map: dict[str, str | Callable[[pd.Series], float]] = {"weight": "sum"}
 
     # Base workload with path count (weight=1 for each path)
-    path_nodes = cast("list[tuple[object, ...]]", combined["path_nodes"].to_list())
     workload_data: dict[str, object] = {
         "src": combined[src_col].to_numpy(),
         "dst": combined[dst_col].to_numpy(),
@@ -970,12 +954,18 @@ def _aggregate_paths(
     }
 
     if not directed:
+        node_columns = [src_col] + [f"dst_{i}" for i in range(step_count)]
+        path_nodes = zip(*(combined[col].to_numpy() for col in node_columns), strict=False)
         canonical_paths = [_canonicalize_undirected_sequence(path) for path in path_nodes]
+        edge_paths = zip(
+            *(
+                [sigs[pos] for pos in combined[f"epos_{i}"].to_numpy()]
+                for i, sigs in enumerate(hop_edge_sigs or [])
+            ),
+            strict=False,
+        )
         canonical_edge_paths = [
-            _canonicalize_undirected_sequence(
-                tuple(_canonicalize_undirected_edge_id(edge_id) for edge_id in edge_path)
-            )
-            for edge_path in cast("list[tuple[object, ...]]", combined["path_edges"].to_list())
+            _canonicalize_undirected_sequence(edge_path) for edge_path in edge_paths
         ]
         workload_data["src"] = [path[0] for path in canonical_paths]
         workload_data["dst"] = [path[-1] for path in canonical_paths]

--- a/tests/test_metapath.py
+++ b/tests/test_metapath.py
@@ -440,6 +440,142 @@ class TestMetapaths:
         directed_pairs = set(directed_edges[relation].index.tolist())
         assert directed_pairs == {(1, 2), (2, 1)}
 
+    @pytest.mark.parametrize("directed", [True, False])
+    def test_add_metapaths_three_hop_duplicate_routes(self, directed: bool) -> None:
+        """Three-hop metapaths count duplicate intermediate routes and reduce attributes."""
+        buildings = gpd.GeoDataFrame(
+            {"geometry": [Point(0, 0), Point(30, 0)], "node_type": "building"},
+            index=[1, 2],
+            crs="EPSG:4326",
+        )
+        streets = gpd.GeoDataFrame(
+            {
+                "geometry": [Point(0, 1), Point(10, 1), Point(0, 2), Point(10, 2)],
+                "node_type": "street",
+            },
+            index=[101, 102, 103, 104],
+            crs="EPSG:4326",
+        )
+        nodes = {"building": buildings, "street": streets}
+        edges = {
+            ("building", "access", "street"): gpd.GeoDataFrame(
+                {
+                    "travel_time": [10.0, 40.0],
+                    "geometry": [
+                        LineString([(0, 0), (0, 1)]),
+                        LineString([(0, 0), (0, 2)]),
+                    ],
+                },
+                index=pd.MultiIndex.from_tuples([(1, 101), (1, 103)]),
+                crs="EPSG:4326",
+            ),
+            ("street", "road", "street"): gpd.GeoDataFrame(
+                {
+                    "travel_time": [20.0, 50.0],
+                    "geometry": [
+                        LineString([(0, 1), (10, 1)]),
+                        LineString([(0, 2), (10, 2)]),
+                    ],
+                },
+                index=pd.MultiIndex.from_tuples([(101, 102), (103, 104)]),
+                crs="EPSG:4326",
+            ),
+            ("street", "access", "building"): gpd.GeoDataFrame(
+                {
+                    "travel_time": [30.0, 60.0],
+                    "geometry": [
+                        LineString([(10, 1), (30, 0)]),
+                        LineString([(10, 2), (30, 0)]),
+                    ],
+                },
+                index=pd.MultiIndex.from_tuples([(102, 2), (104, 2)]),
+                crs="EPSG:4326",
+            ),
+        }
+        sequence = [
+            ("building", "access", "street"),
+            ("street", "road", "street"),
+            ("street", "access", "building"),
+        ]
+        relation = ("building", "metapath_0", "building")
+
+        _, edges_out = add_metapaths(
+            (nodes, edges),
+            sequence=sequence,
+            edge_attr="travel_time",
+            edge_attr_agg=np.nanmax,
+            directed=directed,
+        )
+
+        result = edges_out[relation]
+        # Two distinct routes (via 101-102 and via 103-104) between the same pair.
+        assert result.loc[(1, 2), "weight"] == 2
+        # Per-path maxima are 30 (route one) and 60 (route two); nanmax across paths.
+        assert result.loc[(1, 2), "travel_time"] == 60.0
+
+    def test_add_metapaths_undirected_parallel_edges_extra_index_level(self) -> None:
+        """Parallel edges on a three-level MultiIndex keep distinct undirected paths."""
+        buildings = gpd.GeoDataFrame(
+            {"geometry": [Point(0, 0), Point(10, 0)], "node_type": "building"},
+            index=[1, 2],
+            crs="EPSG:4326",
+        )
+        streets = gpd.GeoDataFrame(
+            {"geometry": [Point(0, 1), Point(10, 1)], "node_type": "street"},
+            index=[101, 102],
+            crs="EPSG:4326",
+        )
+        nodes = {"building": buildings, "street": streets}
+        edges = {
+            ("building", "access", "street"): gpd.GeoDataFrame(
+                {
+                    "geometry": [
+                        LineString([(0, 0), (0, 1)]),
+                        LineString([(10, 0), (10, 1)]),
+                    ],
+                },
+                index=pd.MultiIndex.from_tuples([(1, 101), (2, 102)]),
+                crs="EPSG:4326",
+            ),
+            ("street", "road", "street"): gpd.GeoDataFrame(
+                {
+                    "geometry": [
+                        LineString([(0, 1), (10, 1)]),
+                        LineString([(0, 1), (5, 2), (10, 1)]),
+                        LineString([(10, 1), (0, 1)]),
+                    ],
+                },
+                index=pd.MultiIndex.from_tuples(
+                    [(101, 102, "a"), (101, 102, "b"), (102, 101, "a")]
+                ),
+                crs="EPSG:4326",
+            ),
+            ("street", "access", "building"): gpd.GeoDataFrame(
+                {
+                    "geometry": [
+                        LineString([(0, 1), (0, 0)]),
+                        LineString([(10, 1), (10, 0)]),
+                    ],
+                },
+                index=pd.MultiIndex.from_tuples([(101, 1), (102, 2)]),
+                crs="EPSG:4326",
+            ),
+        }
+        sequence = [
+            ("building", "access", "street"),
+            ("street", "road", "street"),
+            ("street", "access", "building"),
+        ]
+        relation = ("building", "metapath_0", "building")
+
+        _, edges_out = add_metapaths((nodes, edges), sequence=sequence, directed=False)
+
+        result = edges_out[relation]
+        # Parallel edges "a" and "b" are distinct paths, while the mirrored
+        # traversal of edge "a" collapses onto its forward counterpart.
+        assert set(result.index.tolist()) == {(1, 2)}
+        assert result.loc[(1, 2), "weight"] == 2
+
     @pytest.mark.parametrize(
         "join_case", ["empty_hop", "disjoint", "nan_sources", "index_normalization"]
     )


### PR DESCRIPTION
## Description

`add_metapaths` composed k-hop relations by sequentially merging per-hop DataFrames and, after every merge, rebuilding the `path_nodes`/`path_edges` list columns with Python list concatenation over all intermediate rows. Since intermediate joins grow combinatorially, this per-row work was repeated k−1 times over the largest frames. Custom attribute reducers additionally ran through two pandas dispatch layers (`DataFrame.apply(pd.to_numeric)` followed by `DataFrame.apply(..., axis=1)`).

This PR defers path materialisation and vectorises the reducers, with byte-identical public behaviour:

- **Compact join columns.** `_build_hop_frame` no longer builds per-row `path_nodes`/`path_edges` lists; it carries only scalar `src_*`/`dst_*`/attribute columns plus an integer `epos_*` row-position column per hop. The merge loop performs no per-row Python work.
- **Path assembly at most once.** Path node sequences and canonicalised edge-path signatures are only needed for undirected mirrored-path deduplication, so they are now assembled once in `_aggregate_paths`, after the final join. Edge identifiers are canonicalised per hop (pre-explosion) and looked up via `epos_*`. The directed branch never materialises path sequences at all.
- **Reducers over NumPy.** Attribute blocks are coerced to a float ndarray once; `sum` uses `np.nansum`, `mean` uses a masked division, and custom callables iterate over NumPy rows instead of `DataFrame.apply(axis=1)`, preserving the contract (callable receives the non-null values of each row; all-NaN rows yield NaN).

Sparse (CSR) composition for count-only metapaths was evaluated and deliberately not pursued here: it cannot reproduce the undirected per-path-signature deduplication semantics nor arbitrary per-path reducers, and deferred materialisation already removes the dominant cost.

### Correctness

Beyond the test suite, an equivalence harness compared this branch against `main` on 120 randomised configurations (directed/undirected x sum/mean/custom callable x 2- and 3-level edge MultiIndexes, with NaN attribute values): all outputs were identical (`pandas.testing.assert_frame_equal`).

New tests: a three-hop metapath with duplicate intermediate routes (directed and undirected, custom callable reducer), and an undirected metapath with parallel edges on a three-level MultiIndex.

### Benchmark

Synthetic three-hop metapath, 30-way fan-out per hop: hop sizes 6,000 / 9,000 / 9,000 edges, first intermediate join 180,000 rows, ~5.4M composed paths, 40,000 terminal pairs (Apple Silicon, CPU build).

| Configuration | Time | Peak memory |
| --- | --- | --- |
| directed, `sum` | 15.4 s | 1.21 GB |
| directed, custom callable (`np.nanmax`) | 77.8 s | 1.30 GB |
| undirected, `sum` | 183.0 s | 2.92 GB |
| undirected, custom callable (`np.nanmax`) | 247.9 s | 2.92 GB |

The same benchmark against `main` was stopped after more than 30 minutes without completing, so only the post-change numbers are reported.

## Related Issues

Closes #194

## Checklist

- [x] I have read the [Contributing Guide](https://city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
