### PR TITLE
Reduce GeoDataFrame copy and concat churn in morphology pipelines

### DIFF
--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -12,6 +12,20 @@ The module specializes in three types of spatial relationships:
 1. Place-to-place: Adjacency relationships between building tessellations
 2. Movement-to-movement: Topological connectivity between street segments
 3. Place-to-movement: Interface relationships between place and movement spaces
+
+Notes
+-----
+Frame ownership and copying:
+Public input GeoDataFrames are never mutated. Caller-owned frames are copied at
+most once, at the public boundary: ``_prepare_morphology`` copies
+``segments_gdf`` before assigning movement ids (and ``buildings_gdf`` only to
+flatten a MultiIndex), while ``segments_to_graph`` and
+``movement_to_movement_graph`` copy their input before writing to it. Frames
+created inside the pipeline (rename, filter, join, or concat products) are
+owned by the pipeline and may be mutated without further defensive copies.
+Frames stored on ``_MorphologyContext`` are shared across per-distance runs
+and must be treated as read-only; helpers that need to write to them copy
+first, as late as possible.
 """
 
 from __future__ import annotations
@@ -478,6 +492,10 @@ class _MorphologyContext(typing.NamedTuple):
     reachability cost field, or ``None`` when no distance budget applies.
     The remaining attributes mirror the options of
     :func:`morphological_graph`.
+
+    All frames held by the context are shared across per-distance runs and are
+    read-only: helpers must copy before writing to them. ``buildings`` may
+    alias the caller's GeoDataFrame and must never be mutated.
     """
 
     buildings: gpd.GeoDataFrame

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -617,12 +617,15 @@ def _prepare_morphology(  # noqa: PLR0913
         raise ValueError(msg)
 
     if isinstance(buildings_gdf.index, pd.MultiIndex):
+        # Copy guards the index write below on the caller's frame.
         buildings_gdf = buildings_gdf.copy()
         buildings_gdf.index = buildings_gdf.index.to_flat_index()
 
     # Ensure CRS consistency between buildings and segments
     segments_gdf = _ensure_crs_consistency(buildings_gdf, segments_gdf)
 
+    # The single public-boundary copy of the segments: everything downstream
+    # works on this owned frame.
     segments_gdf = segments_gdf.copy()
     segments_gdf[_MOVEMENT_ID_COL] = segments_gdf.index
 
@@ -631,8 +634,8 @@ def _prepare_morphology(  # noqa: PLR0913
     barrier_segments = None
     if non_movement_barrier_col and non_movement_barrier_col in segments_gdf.columns:
         barrier_mask = segments_gdf[non_movement_barrier_col].fillna(value=False).astype(bool)
-        barrier_segments = segments_gdf.loc[barrier_mask].copy()
-        segments_gdf = segments_gdf.loc[~barrier_mask].copy()
+        barrier_segments = segments_gdf.loc[barrier_mask]
+        segments_gdf = segments_gdf.loc[~barrier_mask]
 
     # Compute the single-source reachability cost field once on the movement network so
     # that streets, buildings and cells are all judged against the same metric on the
@@ -984,7 +987,9 @@ def place_to_place_graph(
         edges_gdf[group_col] = edges_gdf["from_place_id"].map(id_to_group)
         to_group = edges_gdf["to_place_id"].map(id_to_group)
 
-        # Filter edges where source and target are in the same group
+        # Filter edges where source and target are in the same group.
+        # Copy keeps the returned frame free of a pandas 2.x _is_copy flag,
+        # since it leaves this public function.
         edges_gdf = edges_gdf[edges_gdf[group_col] == to_group].copy()
 
     else:
@@ -1533,6 +1538,8 @@ def segments_to_graph(
         from_ids = pd.Series(np.minimum(from_arr, to_arr), index=from_ids.index)
         to_ids = pd.Series(np.maximum(from_arr, to_arr), index=to_ids.index)
 
+    # Public-boundary copy: guards the edge-index writes below on a frame that
+    # may still be the caller's.
     edges_gdf = segments_clean.copy()
 
     if multigraph:
@@ -1877,6 +1884,7 @@ def _include_unenclosed_building_tessellation(
         len(missing_buildings),
         len(buildings_gdf),
     )
+    # Copy guards the enclosure-index write below on a possibly shared frame.
     tessellation = tessellation.copy()
     if "enclosure_index" in tessellation.columns:
         tessellation["enclosure_index"] = tessellation["enclosure_index"].astype(str)
@@ -1962,7 +1970,7 @@ def _filter_buildings_by_network_distance(
         The reachable subset of ``buildings_gdf``.
     """
     if buildings_gdf.empty or segments.empty or center_point is None or max_distance is None:
-        return buildings_gdf.copy()
+        return buildings_gdf
 
     keep_ilocs = _geometry_ilocs_within_network_distance(
         buildings_gdf.geometry.centroid,
@@ -1972,7 +1980,7 @@ def _filter_buildings_by_network_distance(
         extent_buffer,
         field=field,
     )
-    return buildings_gdf.iloc[keep_ilocs].copy()
+    return buildings_gdf.iloc[keep_ilocs]
 
 
 def _valid_polygon_gdf(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -1993,10 +2001,10 @@ def _valid_polygon_gdf(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     geopandas.GeoDataFrame
         The valid polygonal subset of ``gdf``.
     """
-    out = gdf.copy()
-    valid_geom = out.geometry.notna() & ~out.geometry.is_empty
-    valid_geom = valid_geom & out.geometry.geom_type.isin(["Polygon", "MultiPolygon"])
-    out = out.loc[valid_geom].copy()
+    valid_geom = gdf.geometry.notna() & ~gdf.geometry.is_empty
+    valid_geom = valid_geom & gdf.geometry.geom_type.isin(["Polygon", "MultiPolygon"])
+    # Copy guards the geometry-repair write below on a possibly shared frame.
+    out = gdf.loc[valid_geom].copy()
     if out.empty:
         return out
 
@@ -2005,7 +2013,7 @@ def _valid_polygon_gdf(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         out.loc[invalid, out.geometry.name] = out.loc[invalid].geometry.buffer(0)
         valid_geom = out.geometry.notna() & ~out.geometry.is_empty & out.geometry.is_valid
         valid_geom = valid_geom & out.geometry.geom_type.isin(["Polygon", "MultiPolygon"])
-        out = out.loc[valid_geom].copy()
+        out = out.loc[valid_geom]
     return out
 
 
@@ -2099,9 +2107,9 @@ def _buildings_without_tessellation(
         The subset of buildings that intersect no tessellation cell.
     """
     if buildings_gdf.empty:
-        return buildings_gdf.copy()
+        return buildings_gdf
     if tessellation.empty:
-        return buildings_gdf.copy()
+        return buildings_gdf
 
     covered = gpd.sjoin(
         buildings_gdf[[buildings_gdf.geometry.name]],
@@ -2109,7 +2117,7 @@ def _buildings_without_tessellation(
         how="inner",
         predicate="intersects",
     )
-    return buildings_gdf.loc[~buildings_gdf.index.isin(covered.index.unique())].copy()
+    return buildings_gdf.loc[~buildings_gdf.index.isin(covered.index.unique())]
 
 
 def _build_morphological_layers(
@@ -2196,15 +2204,17 @@ def _build_morphological_layers(
         )
         keep_mask = tessellation[_PLACE_ID_COL].isin(connected_place_ids)
         if not keep_mask.all():
-            tessellation = tessellation.loc[keep_mask].copy()
+            tessellation = tessellation.loc[keep_mask]
             if not place_to_place_edges.empty:
                 place_to_place_edges = place_to_place_edges.loc[
                     place_to_place_edges["from_place_id"].isin(connected_place_ids)
                     & place_to_place_edges["to_place_id"].isin(connected_place_ids)
-                ].copy()
+                ]
 
     # Prepare place nodes with Point geometry (centroids)
     # Preserve original tessellation geometry in tessellation_geometry column
+    # Copy is the node-assembly ownership boundary: it guards the column and
+    # centroid writes below on frames that may be shared across distances.
     place_nodes = tessellation.copy()
     place_nodes["tessellation_geometry"] = place_nodes.geometry
     # Convert geometry to centroid for place nodes
@@ -2212,6 +2222,7 @@ def _build_morphological_layers(
 
     # Prepare movement nodes with Point geometry (centroids)
     # Optionally preserve original segment geometry in segment_geometry column
+    # Copy guards the writes below; segments_filtered may alias shared frames.
     movement_nodes = segments_filtered.copy()
     if context.keep_segments:
         movement_nodes["segment_geometry"] = movement_nodes.geometry
@@ -2295,6 +2306,7 @@ def _prepare_barriers(
             crs=segments.crs,
         )
     else:
+        # Copy guards against downstream mutation (momepy receives this frame).
         barriers = segments.copy()
     keep = barriers.geometry.notna() & ~barriers.geometry.is_empty
     if not keep.all():
@@ -2443,6 +2455,7 @@ def _add_building_info(
         The tessellation GeoDataFrame with an added `building_geometry` column.
     """
     if tessellation.empty or buildings.empty:
+        # Copy guards the column write below on a possibly shared frame.
         joined = tessellation.copy()
         joined["building_geometry"] = gpd.GeoSeries(
             [None] * len(joined), index=joined.index, crs=buildings.crs
@@ -2451,7 +2464,7 @@ def _add_building_info(
 
     building_columns = [col for col in buildings.columns if col != buildings.geometry.name]
     points = gpd.GeoDataFrame(
-        buildings[building_columns].copy(),
+        buildings[building_columns],
         geometry=buildings.geometry.representative_point(),
         crs=buildings.crs,
     )
@@ -2508,11 +2521,11 @@ def _filter_adjacent_tessellation(
     """
     # If tessellation is empty, return an empty GeoDataFrame with the same structure
     if tessellation.empty:
-        return tessellation.copy()
+        return tessellation
 
     # If max_distance is infinite, no filtering is needed based on distance
     if math.isinf(max_distance):
-        return tessellation.copy()
+        return tessellation
 
     # Check if 'enclosure_index' column exists for grouped processing
     enclosure_col = "enclosure_index" if "enclosure_index" in tessellation.columns else None
@@ -2556,6 +2569,7 @@ def _filter_adjacent_tessellation(
             filtered_parts.append(filtered_group)
 
     if not filtered_parts:
+        # Copy detaches the empty basic slice (a view) from the parent frame.
         return tessellation.iloc[0:0].copy()
 
     # Concatenate all filtered parts into a single GeoDataFrame
@@ -2601,9 +2615,9 @@ def _filter_tessellation_by_network_distance(
         The filtered tessellation GeoDataFrame, containing only cells within the specified
         network distance from the center point.
     """
-    # Return a copy of tessellation if it or segments are empty
+    # Return the tessellation unchanged if it or segments are empty
     if tessellation.empty or segments.empty:
-        return tessellation.copy()
+        return tessellation
 
     keep_ilocs = _geometry_ilocs_within_network_distance(
         tessellation.geometry.centroid,
@@ -2615,7 +2629,7 @@ def _filter_tessellation_by_network_distance(
     )
 
     # Return the subset of the original tessellation corresponding to the kept ilocs
-    return tessellation.iloc[keep_ilocs].copy()
+    return tessellation.iloc[keep_ilocs]
 
 
 def _extract_center_geometry(
@@ -3074,11 +3088,12 @@ def _segments_within_network_distance(
         The subset of ``segments`` reachable within ``max_distance``.
     """
     if segments.empty:
-        return segments.copy()
+        return segments
 
     if field is None:
         field = _network_reachability_field(segments, center_point)
     if field is None:
+        # Copy detaches the empty basic slice (a view) from the parent frame.
         return segments.iloc[0:0].copy()
 
     keep_ilocs = [
@@ -3086,7 +3101,7 @@ def _segments_within_network_distance(
         for iloc, geometry in enumerate(segments.geometry)
         if _segment_min_reachable_cost(geometry, field.endpoint_lengths) <= max_distance
     ]
-    return segments.iloc[keep_ilocs].copy()
+    return segments.iloc[keep_ilocs]
 
 
 def _segment_min_reachable_cost(

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -496,6 +496,8 @@ class _MorphologyContext(typing.NamedTuple):
     All frames held by the context are shared across per-distance runs and are
     read-only: helpers must copy before writing to them. ``buildings`` may
     alias the caller's GeoDataFrame and must never be mutated.
+    ``segment_graph`` holds the ``(nodes, edges)`` graph derived from
+    ``segments`` once, so per-distance helpers do not rebuild it.
     """
 
     buildings: gpd.GeoDataFrame
@@ -516,6 +518,7 @@ class _MorphologyContext(typing.NamedTuple):
     tessellation_fallback: bool
     tessellation_n_jobs: int
     field: _ReachabilityField | None
+    segment_graph: tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | None = None
 
 
 def _prepare_morphology(  # noqa: PLR0913
@@ -637,13 +640,19 @@ def _prepare_morphology(  # noqa: PLR0913
         barrier_segments = segments_gdf.loc[barrier_mask]
         segments_gdf = segments_gdf.loc[~barrier_mask]
 
+    # Derive the segment graph once; it is shared read-only across distances
+    # instead of being rebuilt (and re-copied) for every distance value.
+    segment_graph = typing.cast(
+        "tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]",
+        segments_to_graph(segments_gdf),
+    )
+
     # Compute the single-source reachability cost field once on the movement network so
     # that streets, buildings and cells are all judged against the same metric on the
     # same network.
     field: _ReachabilityField | None = None
     if center_point is not None and has_distance and not segments_gdf.empty:
-        _, full_segment_edges = segments_to_graph(segments_gdf)
-        field = _network_reachability_field(full_segment_edges, center_point)
+        field = _network_reachability_field(segment_graph[1], center_point)
 
     return _MorphologyContext(
         buildings=buildings_gdf,
@@ -664,6 +673,7 @@ def _prepare_morphology(  # noqa: PLR0913
         tessellation_fallback=tessellation_fallback,
         tessellation_n_jobs=tessellation_n_jobs,
         field=field,
+        segment_graph=segment_graph,
     )
 
 
@@ -755,7 +765,15 @@ def _segments_for_distance(
         ``(segments_filtered, segments_buffer)`` where the buffer already
         includes the barrier-only context segments.
     """
-    segment_nodes, segment_edges = segments_to_graph(context.segments)
+    # Reuse the segment graph derived once in _prepare_morphology; fall back
+    # for contexts constructed without one.
+    segment_graph = context.segment_graph
+    if segment_graph is None:
+        segment_graph = typing.cast(
+            "tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]",
+            segments_to_graph(context.segments),
+        )
+    segment_nodes, segment_edges = segment_graph
 
     if context.center_point is None or distance is None or context.segments.empty:
         segments_filtered = segment_edges
@@ -1095,17 +1113,74 @@ def place_to_movement_graph(
     _validate_single_gdf_input(place_gdf, "place_gdf")
     _validate_single_gdf_input(movement_gdf, "movement_gdf")
 
+    edges_gdf, movement_gdf = _place_to_movement_edges(
+        place_gdf,
+        movement_gdf,
+        primary_barrier_col,
+        tolerance,
+        max_connection_distance,
+    )
+
+    nodes_gdf = pd.concat([place_gdf, movement_gdf], ignore_index=True)
+
+    if as_nx:
+        return gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf)
+
+    if duplicate_edges:
+        edges_gdf = _symmetrize_edge_columns(edges_gdf, "place_id", "movement_id")
+
+    return nodes_gdf, edges_gdf
+
+
+def _place_to_movement_edges(
+    place_gdf: gpd.GeoDataFrame,
+    movement_gdf: gpd.GeoDataFrame,
+    primary_barrier_col: str | None,
+    tolerance: float,
+    max_connection_distance: float,
+) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
+    """
+    Build the place-to-movement edge table without assembling node frames.
+
+    This carries the edge-construction phase of :func:`place_to_movement_graph`
+    so that :func:`_build_morphological_layers` can obtain the edges directly,
+    skipping the full node concatenation whose result it discards.
+
+    Parameters
+    ----------
+    place_gdf : geopandas.GeoDataFrame
+        GeoDataFrame containing place space polygons with a 'place_id' column.
+    movement_gdf : geopandas.GeoDataFrame
+        GeoDataFrame containing movement space geometries with a 'movement_id'
+        column.
+    primary_barrier_col : str or None
+        Column name for alternative movement geometry. If specified and
+        present, this geometry is used instead of the main geometry column.
+    tolerance : float
+        Buffer distance for movement geometries to detect proximity to place
+        spaces.
+    max_connection_distance : float
+        Maximum distance for the nearest-movement fallback connection.
+
+    Returns
+    -------
+    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame]
+        ``(edges_gdf, movement_gdf)`` where ``movement_gdf`` is the input
+        movement frame after CRS harmonisation with ``place_gdf``.
+
+    Raises
+    ------
+    ValueError
+        If 'place_id' or 'movement_id' columns are missing from non-empty
+        input GDFs.
+    """
     place_id_col = _PLACE_ID_COL
     movement_id_col = _MOVEMENT_ID_COL
 
     # Handle empty data: return empty edges GeoDataFrame
     if place_gdf.empty or movement_gdf.empty:
         empty_edges = _create_empty_edges_gdf(place_gdf.crs, place_id_col, movement_id_col)
-        all_nodes = pd.concat([place_gdf, movement_gdf], ignore_index=True)
-
-        return (
-            (all_nodes, empty_edges) if not as_nx else gdf_to_nx(nodes=all_nodes, edges=empty_edges)
-        )
+        return empty_edges, movement_gdf
 
     # Ensure required ID columns exist in the input GeoDataFrames
     if place_id_col not in place_gdf.columns:
@@ -1163,15 +1238,7 @@ def place_to_movement_graph(
         movement_id_col,
     )
 
-    nodes_gdf = pd.concat([place_gdf, movement_gdf], ignore_index=True)
-
-    if as_nx:
-        return gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf)
-
-    if duplicate_edges:
-        edges_gdf = _symmetrize_edge_columns(edges_gdf, "place_id", "movement_id")
-
-    return nodes_gdf, edges_gdf
+    return edges_gdf, movement_gdf
 
 
 def _connect_unmatched_place_to_nearest_movement(
@@ -1760,7 +1827,9 @@ def _create_and_filter_tessellation(
     """
     barriers = _prepare_barriers(segments_buffer, context.primary_barrier_col)
     if base_tessellation is not None:
-        tessellation = base_tessellation.copy()
+        # No copy: the rename below materialises the owned per-distance frame,
+        # so the shared base tessellation is never written to.
+        tessellation = base_tessellation
     else:
         tessellation = _create_enclosed_tessellation(
             context.buildings,
@@ -2181,12 +2250,14 @@ def _build_morphological_layers(
     # extent_buffer caps the nearest-movement fallback faced_to connection: a
     # place cell whose nearest street lies farther receives no fallback edge, so
     # drop_isolated_place can remove it instead of forcing a long star edge.
-    _, place_to_movement_edges = place_to_movement_graph(
+    # The edge helper is called directly to skip assembling a combined node
+    # frame that this function would discard.
+    place_to_movement_edges, _ = _place_to_movement_edges(
         tessellation,
         segments_filtered,
-        primary_barrier_col=context.primary_barrier_col,
-        tolerance=context.tolerance,
-        max_connection_distance=context.extent_buffer,
+        context.primary_barrier_col,
+        context.tolerance,
+        context.extent_buffer,
     )
 
     # Log warning if no place-movement connections found
@@ -2366,7 +2437,6 @@ def _append_barrier_context_segments(
     if barriers.empty:
         return segments_buffer
 
-    barriers = barriers.copy()
     geometry_name = segments_buffer.geometry.name
     if barriers.geometry.name != geometry_name:
         barriers = barriers.rename_geometry(geometry_name)
@@ -2376,6 +2446,11 @@ def _append_barrier_context_segments(
         and primary_barrier_col in segments_buffer.columns
         and primary_barrier_col not in barriers.columns
     ):
+        # Copy guards the column write below; ``barriers`` may still alias the
+        # shared ``context.barrier_segments`` frame. On the internal pipeline
+        # path the barrier frame shares the buffer's columns, so this branch
+        # (and its copy) is not reached.
+        barriers = barriers.copy()
         barriers[primary_barrier_col] = barriers.geometry
 
     merged = (

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -2493,7 +2493,9 @@ def _match_fallback_cells_to_source_buildings(
     source_mask = joined[_SOURCE_BUILDING_INDEX_COL].notna().to_numpy()
     redundant = source_mask & joined.index.duplicated(keep="first")
     if redundant.any():
-        joined = joined.loc[~redundant]
+        # Copy keeps the column writes below warning-free on pandas 2.x
+        # (the boolean take would otherwise carry a chained-assignment flag).
+        joined = joined.loc[~redundant].copy()
         source_mask = joined[_SOURCE_BUILDING_INDEX_COL].notna().to_numpy()
     source_index = joined[_SOURCE_BUILDING_INDEX_COL]
     joined["index_right"] = np.where(source_mask, source_index, joined["index_right"])

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -12,6 +12,7 @@ import geopandas as gpd
 import networkx as nx
 import pandas as pd
 import pytest
+from geopandas.testing import assert_geodataframe_equal
 from shapely.geometry import LineString
 from shapely.geometry import Point
 from shapely.geometry import Polygon
@@ -31,8 +32,23 @@ from city2graph.morphology import place_to_place_graph
 from city2graph.morphology import private_to_private_graph
 from city2graph.morphology import private_to_public_graph
 from city2graph.morphology import public_to_public_graph
+from city2graph.morphology import segments_to_graph
 from tests.helpers import assert_valid_nx_graph
 from tests.helpers import make_grid_polygons_gdf
+
+# Option sets exercised by TestPublicInputImmutability. The ``with_center`` key
+# marks cases that need the ``mg_center_point`` fixture injected as
+# ``center_point`` at test time.
+IMMUTABILITY_OPTION_SETS: list[dict[str, Any]] = [
+    {},
+    {
+        "with_center": True,
+        "distance": 100.0,
+        "keep_buildings": True,
+        "include_unenclosed_buildings": True,
+        "tessellation_fallback": True,
+    },
+]
 
 # ---------------------------------------------------------------------------
 # Module-level monkeypatch stubs.
@@ -2352,6 +2368,107 @@ class TestMorphologicalGraphMultiDistance(TestMorphologyBase):
                 [],
                 center_point=mg_center_point,
             )
+
+
+class TestPublicInputImmutability(TestMorphologyBase):
+    """Public morphology functions must leave their input GeoDataFrames unchanged."""
+
+    @pytest.mark.parametrize("options", IMMUTABILITY_OPTION_SETS)
+    def test_morphological_graph_does_not_mutate_inputs(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        mg_center_point: gpd.GeoSeries,
+        options: dict[str, Any],
+    ) -> None:
+        """morphological_graph leaves the buildings and segments inputs untouched."""
+        kwargs = dict(options)
+        if kwargs.pop("with_center", False):
+            kwargs["center_point"] = mg_center_point
+        buildings_before = sample_buildings_gdf.copy(deep=True)
+        segments_before = sample_segments_gdf.copy(deep=True)
+
+        morphological_graph(sample_buildings_gdf, sample_segments_gdf, **kwargs)
+
+        assert_geodataframe_equal(sample_buildings_gdf, buildings_before)
+        assert_geodataframe_equal(sample_segments_gdf, segments_before)
+
+    def test_morphological_graph_barrier_split_does_not_mutate_input(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """The barrier-only segment split leaves the segments input untouched."""
+        segments = sample_segments_gdf.copy(deep=True)
+        segments["is_barrier"] = [i % 2 == 0 for i in range(len(segments))]
+        segments_before = segments.copy(deep=True)
+
+        morphological_graph(
+            sample_buildings_gdf,
+            segments,
+            non_movement_barrier_col="is_barrier",
+        )
+
+        assert_geodataframe_equal(segments, segments_before)
+
+    def test_morphological_graphs_does_not_mutate_inputs(
+        self,
+        sample_buildings_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+        mg_center_point: gpd.GeoSeries,
+    ) -> None:
+        """The multi-distance pipeline leaves the shared inputs untouched."""
+        buildings_before = sample_buildings_gdf.copy(deep=True)
+        segments_before = sample_segments_gdf.copy(deep=True)
+
+        morphological_graphs(
+            sample_buildings_gdf,
+            sample_segments_gdf,
+            [50.0, 100.0],
+            center_point=mg_center_point,
+        )
+
+        assert_geodataframe_equal(sample_buildings_gdf, buildings_before)
+        assert_geodataframe_equal(sample_segments_gdf, segments_before)
+
+    def test_pairwise_graph_functions_do_not_mutate_inputs(
+        self,
+        sample_tessellation_gdf: gpd.GeoDataFrame,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """place/movement pairwise builders leave their inputs untouched."""
+        tessellation_before = sample_tessellation_gdf.copy(deep=True)
+        segments_before = sample_segments_gdf.copy(deep=True)
+
+        place_to_place_graph(sample_tessellation_gdf)
+        place_to_movement_graph(sample_tessellation_gdf, sample_segments_gdf)
+        movement_to_movement_graph(sample_segments_gdf)
+
+        assert_geodataframe_equal(sample_tessellation_gdf, tessellation_before)
+        assert_geodataframe_equal(sample_segments_gdf, segments_before)
+
+    def test_movement_graph_without_movement_id_does_not_mutate_input(
+        self,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """The edge-id fallback write happens on a copy, not on the input."""
+        segments = sample_segments_gdf.drop(columns=["movement_id"])
+        segments_before = segments.copy(deep=True)
+
+        movement_to_movement_graph(segments)
+
+        assert_geodataframe_equal(segments, segments_before)
+
+    def test_segments_to_graph_does_not_mutate_input(
+        self,
+        sample_segments_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """segments_to_graph builds its edge index on a copy of the input."""
+        segments_before = sample_segments_gdf.copy(deep=True)
+
+        segments_to_graph(sample_segments_gdf)
+
+        assert_geodataframe_equal(sample_segments_gdf, segments_before)
 
 
 class TestDeprecatedAliases:


### PR DESCRIPTION
## Description

This pull request reduces GeoDataFrame copy and concat churn in the morphology pipelines, following the ownership-rule approach proposed in the issue. The change is behaviour-preserving: all existing tests pass unchanged, and a synthetic benchmark produces identical graph outputs before and after.

**Ownership rule (now documented in the module docstring and `_MorphologyContext`):** public inputs are never mutated; caller-owned frames are copied at most once at the public boundary; frames created inside the pipeline are owned and may be mutated; frames stored on `_MorphologyContext` are shared across per-distance runs and are read-only.

Changes, one commit each:

1. **Documentation and safety net.** The ownership rule is documented, and a new `TestPublicInputImmutability` class asserts that every public input GeoDataFrame is unchanged (values, index, dtypes, CRS) after calls to `morphological_graph`, `morphological_graphs`, `place_to_place_graph`, `place_to_movement_graph`, `movement_to_movement_graph`, and `segments_to_graph`, including the barrier-split and edge-id fallback paths.
2. **Removed copies that guard nothing.** Read-only early-return copies (e.g. the full-tessellation copy on the common `max_distance == inf` path in `_filter_adjacent_tessellation`) and trailing `.copy()` calls on already-materialised `iloc`/`loc`/column-selection products are removed. Each removal was checked against pandas 2.x semantics: the result is never written to directly afterwards and is not returned from a public function.
3. **Per-distance invariant work hoisted out of the multi-distance loop.**
   - The segment graph (`segments_to_graph`) is derived once in `_prepare_morphology` and shared read-only via `_MorphologyContext.segment_graph`, instead of being rebuilt (with a full segment-frame copy) for every distance.
   - The shared base tessellation is no longer copied per distance; the unconditional `rename` already materialises the owned per-distance frame on both pandas 2.x and 3.x.
   - The barrier-context frame is no longer copied per distance; the copy moved inside the defensive column-write branch, which the internal pipeline path never reaches.
   - `_build_morphological_layers` now calls a new `_place_to_movement_edges` helper directly, skipping a full tessellation+segments node concatenation per distance whose result was discarded. `place_to_movement_graph` keeps its exact public behaviour as a thin wrapper.
4. **pandas 2.x chained-assignment fix.** `_match_fallback_cells_to_source_buildings` wrote to a boolean-take product, which raises `SettingWithCopyWarning` on pandas 2.x (pre-existing on `main`; surfaced by the new guard run below). The frame is now detached before the writes.

**Copies that remain, and why** (each carries an inline comment):

- Public-boundary copies guarding writes on caller frames: `_prepare_morphology` (segments movement-id write; buildings MultiIndex flatten), `movement_to_movement_graph` (edge-id write), `segments_to_graph` (edge-index write).
- Node-assembly copies in `_build_morphological_layers` (`place_nodes`/`movement_nodes`): the single ownership boundary guarding centroid/column writes on frames that may alias shared context frames.
- `_valid_polygon_gdf`: guards the zero-width-buffer geometry repair.
- `_prepare_barriers`: the frame is handed to momepy, whose mutation behaviour is not guaranteed.
- `place_to_place_graph` group filter: the frame leaves a public function and must not carry a pandas 2.x `_is_copy` flag.
- Empty `.iloc[0:0].copy()` slices: basic slices are views on pandas 2.x; the copy detaches them from the large parent frame.

**Measurements** (synthetic 30×30 street grid, 3,600 buildings, `morphological_graphs` over distances 500/1000/2000 m, pandas 3.0.3):

| | `main` | this branch |
|---|---|---|
| `.copy()` calls inside `city2graph/morphology.py` | 227 | 179 |
| rows copied by those calls | 200,329 | 127,469 (−36%) |
| place-node counts per distance | 75 / 250 / 900 | identical |

Peak `tracemalloc` memory is unchanged at this scale because it is dominated by momepy tessellation internals; the copy reduction scales with tessellation size and distance count.

**Verification**

- `uv run pytest -q`: 843 passed.
- `uv run pre-commit run --all-files`: all hooks pass.
- pandas 2.x guard: `uv run --with "pandas>=2.2,<3" pytest tests/test_morphology.py -q -W error::pandas.errors.SettingWithCopyWarning`: 115 passed (fails on `main`).

## Related Issues

Fixes #196

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
