### PR TITLE
Consolidate shared CRS, centroid, validation, and graph-index helpers

### DIFF
--- a/city2graph/base.py
+++ b/city2graph/base.py
@@ -9,6 +9,7 @@ graph conversion functionality across different formats (NetworkX, PyTorch Geome
 
 # Standard library imports
 import logging
+import warnings
 from abc import ABC
 from abc import abstractmethod
 from typing import TYPE_CHECKING
@@ -790,7 +791,8 @@ class GeoDataProcessor:
         This function calculates the geometric centroid for each geometry in a
         GeoDataFrame. It provides a simple and direct way to get the central point
         of polygons or lines, which is often used to represent the location of a
-        larger geometry in graph-based analyses.
+        larger geometry in graph-based analyses. The CRS of the input is
+        explicitly propagated to the resulting GeoSeries.
 
         Parameters
         ----------
@@ -818,4 +820,304 @@ class GeoDataProcessor:
         0    POINT (0.50000 0.50000)
         dtype: geometry
         """
-        return gdf.geometry.centroid
+        centroids = gdf.geometry.centroid
+        # Explicitly carry CRS (some versions keep it automatically, we enforce)
+        return centroids.set_crs(gdf.crs, allow_override=True)
+
+    @staticmethod
+    def harmonize_crs(
+        source: gpd.GeoDataFrame | gpd.GeoSeries,
+        target_crs: Any,  # noqa: ANN401
+        *,
+        warn: bool = True,
+        stacklevel: int = 2,
+    ) -> gpd.GeoDataFrame | gpd.GeoSeries:
+        """
+        Reproject a GeoDataFrame or GeoSeries to a target CRS when needed.
+
+        This function compares the Coordinate Reference System (CRS) of the
+        source against the target CRS and reprojects the source when they
+        differ. It centralizes the CRS-harmonization behaviour that spatial
+        operations rely on before combining datasets, optionally warning the
+        caller that a reprojection took place.
+
+        Parameters
+        ----------
+        source : geopandas.GeoDataFrame or geopandas.GeoSeries
+            The geospatial data to check and potentially reproject.
+        target_crs : Any
+            The target coordinate reference system to align with.
+        warn : bool, default True
+            Whether to emit a ``RuntimeWarning`` when a reprojection occurs.
+        stacklevel : int, default 2
+            Stack level passed to :func:`warnings.warn` so the warning points
+            at the caller's code.
+
+        Returns
+        -------
+        geopandas.GeoDataFrame or geopandas.GeoSeries
+            The source data, reprojected to the target CRS if necessary.
+
+        Warns
+        -----
+        RuntimeWarning
+            If a CRS mismatch is detected, reprojection is performed, and
+            ``warn`` is True.
+
+        See Also
+        --------
+        ensure_crs_consistency : Validate that GeoDataFrames share one CRS.
+        warn_crs_issues : Warn about missing or geographic CRS values.
+
+        Examples
+        --------
+        >>> import geopandas as gpd
+        >>> from shapely.geometry import Point
+        >>> gdf = gpd.GeoDataFrame(geometry=[Point(0, 0)], crs="EPSG:4326")
+        >>> aligned = GeoDataProcessor.harmonize_crs(gdf, "EPSG:4326")
+        >>> aligned.crs.to_epsg()
+        4326
+        """
+        if source.crs != target_crs:
+            if warn:
+                warnings.warn(
+                    "CRS mismatch detected, reprojecting",
+                    RuntimeWarning,
+                    stacklevel=stacklevel,
+                )
+            source = source.to_crs(target_crs)
+        return source
+
+    @staticmethod
+    def warn_crs_issues(
+        gdf: gpd.GeoDataFrame,
+        *,
+        missing_message: str | None = None,
+        geographic_message: str | None = None,
+        stacklevel: int = 2,
+    ) -> None:
+        """
+        Warn about missing or geographic CRS values on a GeoDataFrame.
+
+        This function inspects the Coordinate Reference System (CRS) of a
+        GeoDataFrame and emits a ``UserWarning`` when the CRS is missing or
+        geographic. Distance- and length-based computations are unreliable in
+        both situations, so callers pass context-specific messages describing
+        the consequences for their own outputs.
+
+        Parameters
+        ----------
+        gdf : geopandas.GeoDataFrame
+            GeoDataFrame whose CRS will be inspected.
+        missing_message : str or None, optional
+            Warning message emitted when the CRS is missing. When None, a
+            missing CRS is silently accepted.
+        geographic_message : str or None, optional
+            Warning message emitted when the CRS is geographic. When None, a
+            geographic CRS is silently accepted.
+        stacklevel : int, default 2
+            Stack level passed to :func:`warnings.warn` so the warning points
+            at the caller's code.
+
+        Returns
+        -------
+        None
+            This function only emits warnings.
+
+        Warns
+        -----
+        UserWarning
+            If the CRS is missing and ``missing_message`` is provided, or if
+            the CRS is geographic and ``geographic_message`` is provided.
+
+        See Also
+        --------
+        harmonize_crs : Reproject data to a target CRS when needed.
+        ensure_crs_consistency : Validate that GeoDataFrames share one CRS.
+
+        Examples
+        --------
+        >>> import geopandas as gpd
+        >>> from shapely.geometry import Point
+        >>> gdf = gpd.GeoDataFrame(geometry=[Point(0, 0)], crs="EPSG:27700")
+        >>> GeoDataProcessor.warn_crs_issues(gdf, geographic_message="Geographic CRS")
+        """
+        crs = gdf.crs
+        if crs is None:
+            if missing_message:
+                warnings.warn(missing_message, UserWarning, stacklevel=stacklevel)
+            return
+
+        # pyproj.CRS exposes is_geographic when available
+        if geographic_message and getattr(crs, "is_geographic", False):
+            warnings.warn(geographic_message, UserWarning, stacklevel=stacklevel)
+
+    @staticmethod
+    def create_empty_edges_gdf(
+        crs: Any,  # noqa: ANN401
+        from_col: str,
+        to_col: str,
+        extra_cols: list[str] | None = None,
+    ) -> gpd.GeoDataFrame:
+        """
+        Create an empty edges GeoDataFrame with specified column structure.
+
+        This helper function generates an empty GeoDataFrame suitable for representing
+        graph edges, ensuring it has the correct column names for 'from' and 'to'
+        node IDs, and optionally additional columns, along with a geometry column
+        and a specified Coordinate Reference System (CRS). This is useful for
+        initializing empty edge GeoDataFrames when no connections are found or
+        when setting up a new graph structure.
+
+        Parameters
+        ----------
+        crs : Any
+            Coordinate reference system.
+        from_col : str
+            Name for the 'from' node ID column.
+        to_col : str
+            Name for the 'to' node ID column.
+        extra_cols : list[str], optional
+            Optional list of additional column names.
+
+        Returns
+        -------
+        geopandas.GeoDataFrame
+            Empty GeoDataFrame with specified columns.
+
+        See Also
+        --------
+        validate_gdf : Validate a GeoDataFrame.
+
+        Examples
+        --------
+        >>> empty = GeoDataProcessor.create_empty_edges_gdf(
+        ...     "EPSG:4326", "from_id", "to_id"
+        ... )
+        >>> list(empty.columns)
+        ['from_id', 'to_id', 'geometry']
+        """
+        # Initialize list of column names with 'from' and 'to' ID columns
+        columns = [from_col, to_col]
+        # Add any extra columns if provided
+        if extra_cols:
+            columns.extend(extra_cols)
+        # Add the 'geometry' column name (standard for GeoDataFrames)
+        columns.append("geometry")
+
+        # Create an empty GeoDataFrame with the defined columns, geometry column, and CRS
+        return gpd.GeoDataFrame(columns=columns, geometry="geometry", crs=crs)
+
+    @staticmethod
+    def wrap_layer_ids(ids: list[Any], layer: str) -> list[tuple[str, Any]]:
+        """
+        Wrap node identifiers as ``(layer, id)`` tuples.
+
+        This function namespaces node identifiers with a layer label so that
+        nodes originating from different input layers remain distinguishable
+        after they are combined into a single graph. The tuples produced here
+        are the values later unwrapped by :meth:`unwrap_layer_edge_index`.
+
+        Parameters
+        ----------
+        ids : list[Any]
+            Node identifiers to wrap.
+        layer : str
+            Layer label used as the first tuple element (e.g., ``"src"``).
+
+        Returns
+        -------
+        list[tuple[str, Any]]
+            List of ``(layer, id)`` tuples in input order.
+
+        See Also
+        --------
+        wrap_layer_index : Wrap a pandas Index into a layered MultiIndex.
+        unwrap_layer_edge_index : Recover original identifiers from wrapped edges.
+
+        Examples
+        --------
+        >>> GeoDataProcessor.wrap_layer_ids([1, 2], "src")
+        [('src', 1), ('src', 2)]
+        """
+        return [(layer, i) for i in ids]
+
+    @staticmethod
+    def wrap_layer_index(index: pd.Index, layer: str) -> pd.MultiIndex:
+        """
+        Wrap a pandas Index into a layered MultiIndex.
+
+        This function converts a flat node index into a two-level MultiIndex
+        whose first level is a constant layer label. It mirrors
+        :meth:`wrap_layer_ids` for node GeoDataFrames so that node and edge
+        identifiers stay aligned when layers are concatenated.
+
+        Parameters
+        ----------
+        index : pandas.Index
+            Node index to wrap.
+        layer : str
+            Layer label used as the first index level (e.g., ``"src"``).
+
+        Returns
+        -------
+        pandas.MultiIndex
+            MultiIndex with levels ``["layer", index.name or "node_id"]``.
+
+        See Also
+        --------
+        wrap_layer_ids : Wrap identifiers as ``(layer, id)`` tuples.
+        unwrap_layer_edge_index : Recover original identifiers from wrapped edges.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> GeoDataProcessor.wrap_layer_index(pd.Index([1, 2]), "src").tolist()
+        [('src', 1), ('src', 2)]
+        """
+        return pd.MultiIndex.from_tuples(
+            [(layer, i) for i in index],
+            names=["layer", index.name or "node_id"],
+        )
+
+    @staticmethod
+    def unwrap_layer_edge_index(
+        index: pd.MultiIndex,
+        names: tuple[str, str] = ("source", "target"),
+    ) -> pd.MultiIndex:
+        """
+        Recover original node identifiers from a layered edge MultiIndex.
+
+        This function strips the ``(layer, id)`` wrappers produced by
+        :meth:`wrap_layer_ids` from both levels of an edge MultiIndex,
+        returning a MultiIndex of the original node identifiers. It is the
+        inverse operation applied when layered edges are handed back to
+        callers that expect the original identifier space.
+
+        Parameters
+        ----------
+        index : pandas.MultiIndex
+            Edge MultiIndex whose level values are ``(layer, id)`` tuples.
+        names : tuple[str, str], default ("source", "target")
+            Names assigned to the resulting MultiIndex levels.
+
+        Returns
+        -------
+        pandas.MultiIndex
+            MultiIndex of original source and target identifiers.
+
+        See Also
+        --------
+        wrap_layer_ids : Wrap identifiers as ``(layer, id)`` tuples.
+        wrap_layer_index : Wrap a pandas Index into a layered MultiIndex.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> idx = pd.MultiIndex.from_tuples([(("src", 1), ("dst", 2))])
+        >>> GeoDataProcessor.unwrap_layer_edge_index(idx).tolist()
+        [(1, 2)]
+        """
+        src_ids = [t[1] for t in index.get_level_values(0)]
+        dst_ids = [t[1] for t in index.get_level_values(1)]
+        return pd.MultiIndex.from_arrays([src_ids, dst_ids], names=list(names))

--- a/city2graph/mobility.py
+++ b/city2graph/mobility.py
@@ -33,6 +33,8 @@ import numpy as np
 import pandas as pd
 from shapely.geometry import LineString
 
+from .base import GeoDataProcessor
+
 # Use city2graph converters for compatibility across the stack
 from .utils import gdf_to_nx
 
@@ -132,7 +134,13 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
     """
     # --- Validation (Task 2) ------------------------------------------------
     _validate_zones_gdf(zones_gdf, zone_id_col)
-    _validate_crs(zones_gdf)
+    GeoDataProcessor.warn_crs_issues(
+        zones_gdf,
+        missing_message="zones_gdf has no CRS set; outputs will have undefined CRS (requirement 3.1)",
+        geographic_message=(
+            "Geographic CRS detected; distance/length measures may be inaccurate (requirement 3.5)"
+        ),
+    )
 
     # Validate matrix_type and that threshold is numeric if provided (Req 2.7)
     if threshold is not None and not isinstance(threshold, numbers.Number):
@@ -1045,65 +1053,6 @@ def _align_edgelist_zones(
 # ---------------------------------------------------------------------------
 # Spatial geometry helpers (centroids and edge geometries)
 # ---------------------------------------------------------------------------
-def _validate_crs(zones_gdf: gpd.GeoDataFrame) -> None:
-    """
-    Warn about CRS issues and ensure CRS info is preserved.
-
-    Emits warnings for missing CRS and geographic CRS to signal potential
-    issues with distance-based computations.
-
-    Parameters
-    ----------
-    zones_gdf : geopandas.GeoDataFrame
-        Zones GeoDataFrame whose CRS will be validated.
-
-    Returns
-    -------
-    None
-        This function validates input and raises on failure.
-    """
-    crs = zones_gdf.crs
-    if crs is None:
-        warnings.warn(
-            "zones_gdf has no CRS set; outputs will have undefined CRS (requirement 3.1)",
-            UserWarning,
-            stacklevel=2,
-        )
-        return
-
-    # pyproj.CRS exposes is_geographic when available
-    if getattr(crs, "is_geographic", False):
-        warnings.warn(
-            "Geographic CRS detected; distance/length measures may be inaccurate (requirement 3.5)",
-            UserWarning,
-            stacklevel=2,
-        )
-
-
-def _compute_centroids(zones_gdf: gpd.GeoDataFrame) -> gpd.GeoSeries:
-    """
-    Compute centroids for zones preserving CRS.
-
-    Calculates feature centroids and explicitly propagates the CRS to the
-    resulting GeoSeries for consistency.
-
-    Parameters
-    ----------
-    zones_gdf : geopandas.GeoDataFrame
-        Zones GeoDataFrame whose feature centroids will be computed.
-
-    Returns
-    -------
-    geopandas.GeoSeries
-        GeoSeries indexed like ``zones_gdf`` with the same CRS.
-    """
-    # GeoPandas returns a GeoSeries with the same CRS as input geometry
-    centroids = zones_gdf.geometry.centroid
-    # Explicitly carry CRS (some versions keep it automatically, we enforce)
-    centroids.set_crs(zones_gdf.crs, allow_override=True, inplace=True)
-    return centroids
-
-
 def _create_edge_geometries(
     edges_df: pd.DataFrame,
     zones_gdf: gpd.GeoDataFrame,
@@ -1154,7 +1103,7 @@ def _create_edge_geometries(
         return gpd.GeoDataFrame(e, geometry=geom, crs=zones_gdf.crs)
 
     # Centroid lookup by ID
-    centroids = _compute_centroids(zones_gdf)
+    centroids = GeoDataProcessor.compute_centroids(zones_gdf)
     if zone_id_col is not None:
         centroids.index = pd.Index(zones_gdf[zone_id_col])
 

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -80,6 +80,14 @@ _SOURCE_BUILDING_INDEX_COL = "_source_building_index"
 _PLACE_ID_COL = "place_id"
 _MOVEMENT_ID_COL = "movement_id"
 
+# Warning emitted when morphological inputs are in a geographic CRS
+_GEOGRAPHIC_CRS_MSG = (
+    "Geometry is in a geographic CRS. Distance parameters "
+    "(distance, extent_buffer, tolerance) are treated as metric and "
+    "'.centroid' results are unreliable. Re-project to a projected CRS "
+    "with 'GeoSeries.to_crs()' before building the morphological graph."
+)
+
 
 def _validate_duplicate_edges(duplicate_edges: bool, as_nx: bool) -> None:
     """
@@ -625,7 +633,10 @@ def _prepare_morphology(  # noqa: PLR0913
         buildings_gdf.index = buildings_gdf.index.to_flat_index()
 
     # Ensure CRS consistency between buildings and segments
-    segments_gdf = _ensure_crs_consistency(buildings_gdf, segments_gdf)
+    segments_gdf = GeoDataProcessor.harmonize_crs(segments_gdf, buildings_gdf.crs, stacklevel=3)
+    GeoDataProcessor.warn_crs_issues(
+        buildings_gdf, geographic_message=_GEOGRAPHIC_CRS_MSG, stacklevel=3
+    )
 
     # The single public-boundary copy of the segments: everything downstream
     # works on this owned frame.
@@ -1179,7 +1190,9 @@ def _place_to_movement_edges(
 
     # Handle empty data: return empty edges GeoDataFrame
     if place_gdf.empty or movement_gdf.empty:
-        empty_edges = _create_empty_edges_gdf(place_gdf.crs, place_id_col, movement_id_col)
+        empty_edges = GeoDataProcessor.create_empty_edges_gdf(
+            place_gdf.crs, place_id_col, movement_id_col
+        )
         return empty_edges, movement_gdf
 
     # Ensure required ID columns exist in the input GeoDataFrames
@@ -1191,7 +1204,10 @@ def _place_to_movement_edges(
         raise ValueError(msg)
 
     # Ensure CRS consistency between place and movement GeoDataFrames
-    movement_gdf = _ensure_crs_consistency(place_gdf, movement_gdf)
+    movement_gdf = GeoDataProcessor.harmonize_crs(movement_gdf, place_gdf.crs, stacklevel=3)
+    GeoDataProcessor.warn_crs_issues(
+        place_gdf, geographic_message=_GEOGRAPHIC_CRS_MSG, stacklevel=3
+    )
 
     # Determine which geometry to use for the query
     query_geometry = (
@@ -1399,7 +1415,7 @@ def movement_to_movement_graph(
 
     # Handle empty or insufficient data: return empty edges GeoDataFrame
     if movement_gdf.empty or len(movement_gdf) < 2:
-        empty_edges = _create_empty_edges_gdf(
+        empty_edges = GeoDataProcessor.create_empty_edges_gdf(
             movement_gdf.crs, "from_movement_id", "to_movement_id"
         )
 
@@ -1727,59 +1743,6 @@ def _validate_single_gdf_input(
     if not isinstance(gdf, gpd.GeoDataFrame):
         msg = f"{gdf_name} must be a GeoDataFrame"
         raise TypeError(msg)
-
-
-def _ensure_crs_consistency(
-    target_gdf: gpd.GeoDataFrame,
-    source_gdf: gpd.GeoDataFrame,
-) -> gpd.GeoDataFrame:
-    """
-    Ensure that the source GeoDataFrame has the same CRS as the target.
-
-    This function checks if the Coordinate Reference System (CRS) of the source
-    GeoDataFrame matches that of the target. If they do not match, it reprojects
-    the source to the target's CRS and issues a warning. This is essential for
-    ensuring that spatial operations between the two GeoDataFrames are valid.
-
-    Parameters
-    ----------
-    target_gdf : geopandas.GeoDataFrame
-        The GeoDataFrame with the target CRS.
-    source_gdf : geopandas.GeoDataFrame
-        The GeoDataFrame to check and potentially reproject.
-
-    Returns
-    -------
-    geopandas.GeoDataFrame
-        The source GeoDataFrame, reprojected to the target CRS if necessary.
-
-    Warns
-    -----
-    RuntimeWarning
-        If a CRS mismatch is detected and reprojection is performed.
-    UserWarning
-        If the resolved CRS is geographic (degrees). Distance parameters
-        (``distance``, ``extent_buffer``, ``tolerance``) are interpreted as
-        metric and ``.centroid`` results are unreliable on such a CRS.
-    """
-    if source_gdf.crs != target_gdf.crs:
-        warnings.warn(
-            "CRS mismatch detected, reprojecting",
-            RuntimeWarning,
-            stacklevel=3,
-        )  # Warn user
-        source_gdf = source_gdf.to_crs(target_gdf.crs)
-
-    if target_gdf.crs is not None and target_gdf.crs.is_geographic:
-        warnings.warn(
-            "Geometry is in a geographic CRS. Distance parameters "
-            "(distance, extent_buffer, tolerance) are treated as metric and "
-            "'.centroid' results are unreliable. Re-project to a projected CRS "
-            "with 'GeoSeries.to_crs()' before building the morphological graph.",
-            UserWarning,
-            stacklevel=3,
-        )
-    return source_gdf
 
 
 # ============================================================================
@@ -3335,57 +3298,13 @@ def _return_empty_place_edges(
         Empty graph structure.
     """
     group_cols = [group_col] if group_col else ["group"]
-    empty_edges = _create_empty_edges_gdf(
+    empty_edges = GeoDataProcessor.create_empty_edges_gdf(
         place_gdf.crs,
         "from_place_id",
         "to_place_id",
         group_cols,
     )
     return (place_gdf, empty_edges) if not as_nx else gdf_to_nx(nodes=place_gdf, edges=empty_edges)
-
-
-def _create_empty_edges_gdf(
-    crs: str | int | None,
-    from_col: str,  # Name for the 'from' node ID column
-    to_col: str,  # Name for the 'to' node ID column
-    extra_cols: list[str] | None = None,  # Optional list of additional column names
-) -> gpd.GeoDataFrame:
-    """
-    Create an empty edges GeoDataFrame with specified column structure.
-
-    This helper function generates an empty GeoDataFrame suitable for representing
-    graph edges, ensuring it has the correct column names for 'from' and 'to'
-    node IDs, and optionally additional columns, along with a geometry column
-    and a specified Coordinate Reference System (CRS). This is useful for
-    initializing empty edge GeoDataFrames when no connections are found or
-    when setting up a new graph structure.
-
-    Parameters
-    ----------
-    crs : str, int, or None
-        Coordinate reference system.
-    from_col : str
-        Name for the 'from' node ID column.
-    to_col : str
-        Name for the 'to' node ID column.
-    extra_cols : list[str], optional
-        Optional list of additional column names.
-
-    Returns
-    -------
-    geopandas.GeoDataFrame
-        Empty GeoDataFrame with specified columns.
-    """
-    # Initialize list of column names with 'from' and 'to' ID columns
-    columns = [from_col, to_col]
-    # Add any extra columns if provided
-    if extra_cols:
-        columns.extend(extra_cols)
-    # Add the 'geometry' column name (standard for GeoDataFrames)
-    columns.append("geometry")
-
-    # Create an empty GeoDataFrame with the defined columns, geometry column, and CRS
-    return gpd.GeoDataFrame(columns=columns, geometry="geometry", crs=crs)
 
 
 def _set_node_index(gdf: gpd.GeoDataFrame, col: str) -> gpd.GeoDataFrame:

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -39,6 +39,7 @@ from scipy.spatial import distance as sdist
 from shapely.geometry import LineString
 
 # Local imports
+from .base import GeoDataProcessor
 from .utils import gdf_to_nx
 from .utils import nx_to_gdf
 from .utils import symmetrize_edges
@@ -1762,11 +1763,7 @@ def bridge_nodes(
 
             # Strip the ("src", id) and ("dst", id) wrappers to return original IDs
             if not edges_gdf.empty:
-                src_ids = [s[1] for s in edges_gdf.index.get_level_values(0)]
-                dst_ids = [d[1] for d in edges_gdf.index.get_level_values(1)]
-                edges_gdf.index = pd.MultiIndex.from_arrays(
-                    [src_ids, dst_ids], names=["source", "target"]
-                )
+                edges_gdf.index = GeoDataProcessor.unwrap_layer_edge_index(edges_gdf.index)
             edge_dict[(src_type, "is_nearby", dst_type)] = edges_gdf
 
     if as_nx:
@@ -2142,8 +2139,8 @@ def _directed_graph(
     )
 
     # Prepare namespaced IDs
-    unique_src_ids = [("src", sid) for sid in src_ids]
-    unique_dst_ids = [("dst", did) for did in dst_ids]
+    unique_src_ids = GeoDataProcessor.wrap_layer_ids(src_ids, "src")
+    unique_dst_ids = GeoDataProcessor.wrap_layer_ids(dst_ids, "dst")
 
     context = DirectedGraphContext(
         src_gdf=src_gdf,
@@ -2214,18 +2211,12 @@ def _directed_graph_gdf(
 
     # Construct nodes GDF
     src_nodes = context.src_gdf.copy()
-    src_nodes.index = pd.MultiIndex.from_tuples(
-        [("src", i) for i in src_nodes.index],
-        names=["layer", context.src_gdf.index.name or "node_id"],
-    )
+    src_nodes.index = GeoDataProcessor.wrap_layer_index(src_nodes.index, "src")
     src_nodes["node_type"] = "src"
     src_nodes["_original_index"] = context.src_gdf.index
 
     dst_nodes = context.dst_gdf.copy()
-    dst_nodes.index = pd.MultiIndex.from_tuples(
-        [("dst", i) for i in dst_nodes.index],
-        names=["layer", context.dst_gdf.index.name or "node_id"],
-    )
+    dst_nodes.index = GeoDataProcessor.wrap_layer_index(dst_nodes.index, "dst")
     dst_nodes["node_type"] = "dst"
     dst_nodes["_original_index"] = context.dst_gdf.index
 

--- a/city2graph/utils.py
+++ b/city2graph/utils.py
@@ -6857,7 +6857,7 @@ def clip_graph(
 
     # Align clip geometry CRS to edges CRS when area is geospatial tabular input.
     if isinstance(area, (gpd.GeoDataFrame, gpd.GeoSeries)):
-        area_aligned = area.to_crs(edges.crs) if area.crs != edges.crs else area
+        area_aligned = GeoDataProcessor.harmonize_crs(area, edges.crs, warn=False)
         clip_geom = (
             area_aligned.geometry.union_all()
             if isinstance(area_aligned, gpd.GeoDataFrame) and len(area_aligned) > 1


### PR DESCRIPTION
## Description

This pull request consolidates duplicated CRS, centroid, validation, and graph-index logic into `GeoDataProcessor` in `base.py`, so that each spatial-validation concern has one canonical implementation. It is a behaviour-preserving refactor: no public API changes, no test modifications, and warning messages, categories, ordering, and stack-level attribution are all preserved byte-for-byte.

New `GeoDataProcessor` static methods:

- `harmonize_crs(source, target_crs, *, warn, stacklevel)` — reprojects a GeoDataFrame/GeoSeries to a target CRS when they differ, optionally emitting the existing `RuntimeWarning`. Replaces `morphology._ensure_crs_consistency`'s reprojection branch and the silent inline alignment in `utils.clip_graph`.
- `warn_crs_issues(gdf, *, missing_message, geographic_message, stacklevel)` — canonical missing-CRS / geographic-CRS checks with caller-supplied messages. Replaces `mobility._validate_crs` and the geographic-CRS branch of `morphology._ensure_crs_consistency`.
- `create_empty_edges_gdf(crs, from_col, to_col, extra_cols)` — moved verbatim from `morphology._create_empty_edges_gdf` so empty-edge schemas are constructed in one place.
- `wrap_layer_ids` / `wrap_layer_index` / `unwrap_layer_edge_index` — shared helpers for the `("src", id)` / `("dst", id)` namespacing in `proximity.py`, replacing three wrap sites (`_directed_graph`, `_directed_graph_gdf`) and the element-by-element unwrap in `bridge_nodes` with a single wrap/unwrap pair.

`compute_centroids` now explicitly re-stamps the input CRS on the result (previously done only in `mobility._compute_centroids`; a no-op for the existing callers in `utils.py`), letting mobility drop its duplicate.

Module-local duplicates removed: `mobility._validate_crs`, `mobility._compute_centroids`, `morphology._ensure_crs_consistency`, `morphology._create_empty_edges_gdf`.

Deliberately left in place: `proximity._group_nodes_empty_result` and `proximity._empty_contiguity_result`. Their output contracts differ from the shared empty-edges schema (heterogeneous node/edge dicts with a weight-typed MultiIndex, and a bespoke `nx.Graph` carrying `crs`/`contiguity`/`distance_metric` metadata respectively), so forcing them through the shared helper would change behaviour.

Verification beyond the test suite: warning attribution was spot-checked against `main` with `warnings.catch_warnings(record=True)` on a CRS-mismatched, geographic-CRS `place_to_movement_graph` call; the reported filename/lineno are identical before and after, since each removed helper frame is replaced by exactly one `GeoDataProcessor` frame with the same stack level.

## Related Issues

Fixes #197

## Checklist

- [x] I have read the [Contributing Guide](https://city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary. (No documentation changes needed: `GeoDataProcessor` is not part of the documented API surface and no public behaviour changed.)
- [x] I have added tests to cover my changes. (No new tests: behaviour is unchanged, and the coverage report confirms every new `base.py` helper line is exercised by existing public-API tests; the project convention is to test private helpers only through the public API.)
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
