### PR TITLE
Decompose oversized graph-building orchestrators into phase helpers

### DIFF
--- a/city2graph/mobility.py
+++ b/city2graph/mobility.py
@@ -133,6 +133,112 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
             is returned if ``directed=True``, otherwise a ``networkx.Graph``.
     """
     # --- Validation (Task 2) ------------------------------------------------
+    _validate_od_inputs(
+        od_data,
+        zones_gdf,
+        zone_id_col=zone_id_col,
+        matrix_type=matrix_type,
+        source_col=source_col,
+        target_col=target_col,
+        weight_cols=weight_cols,
+        threshold=threshold,
+        threshold_col=threshold_col,
+    )
+
+    # --- Conversion to canonical edgelist ----------------------------------
+    edge_df = _build_canonical_edgelist(
+        od_data,
+        zones_gdf,
+        zone_id_col=zone_id_col,
+        matrix_type=matrix_type,
+        source_col=source_col,
+        target_col=target_col,
+        weight_cols=weight_cols,
+        # For undirected mode, postpone thresholding until after symmetrization
+        threshold=threshold if directed else None,
+        threshold_col=threshold_col,
+        include_self_loops=include_self_loops,
+    )
+    # If undirected, symmetrize by merging reciprocal edges and summing weights
+    if not directed and not edge_df.empty:
+        edge_df = _symmetrize_undirected_edges(
+            edge_df,
+            matrix_type=matrix_type,
+            weight_cols=weight_cols,
+            threshold=threshold,
+        )
+
+    # --- Spatial assembly (Task 5) -----------------------------------------
+    nodes_gdf, edges_gdf = _assemble_od_frames(
+        edge_df,
+        zones_gdf,
+        zone_id_col=zone_id_col,
+        compute_edge_geometry=compute_edge_geometry,
+    )
+
+    # --- Output selection (Task 6) -----------------------------------------
+    if not as_nx:
+        # GeoDataFrame-first API: return (nodes, edges)
+        logger.info("Created graph with %d nodes and %d edges", len(nodes_gdf), len(edges_gdf))
+        return nodes_gdf, edges_gdf
+
+    G = gdf_to_nx(
+        nodes=nodes_gdf, edges=edges_gdf, keep_geom=compute_edge_geometry, directed=directed
+    )
+    logger.info(
+        "Created graph with %d nodes and %d edges", G.number_of_nodes(), G.number_of_edges()
+    )
+    return G
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+def _validate_od_inputs(
+    od_data: pd.DataFrame | np.ndarray,
+    zones_gdf: gpd.GeoDataFrame,
+    *,
+    zone_id_col: str | None,
+    matrix_type: Literal["edgelist", "adjacency"],
+    source_col: str,
+    target_col: str,
+    weight_cols: list[str] | None,
+    threshold: float | None,
+    threshold_col: str | None,
+) -> None:
+    """
+    Validate all inputs of :func:`od_matrix_to_graph`.
+
+    Runs the zone-frame checks, CRS warnings, threshold type check and the
+    ``matrix_type``-specific validation of ``od_data`` before any conversion
+    takes place.
+
+    Parameters
+    ----------
+    od_data : pandas.DataFrame | numpy.ndarray
+        OD data as an edge list or adjacency matrix.
+    zones_gdf : geopandas.GeoDataFrame
+        GeoDataFrame of zones with unique identifiers.
+    zone_id_col : str | None
+        Name of the zone ID column in ``zones_gdf``.
+    matrix_type : {'edgelist', 'adjacency'}
+        Declares how to interpret ``od_data``.
+    source_col : str
+        Column name for origins when using an edge list.
+    target_col : str
+        Column name for destinations when using an edge list.
+    weight_cols : list[str] | None
+        Edge list weight (flow) columns to preserve.
+    threshold : float | None
+        Minimum flow retained, applied to the canonical weight.
+    threshold_col : str | None
+        Column among ``weight_cols`` used for thresholding.
+
+    Returns
+    -------
+    None
+        This function validates input and raises on failure.
+    """
     _validate_zones_gdf(zones_gdf, zone_id_col)
     GeoDataProcessor.warn_crs_issues(
         zones_gdf,
@@ -172,10 +278,57 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
             threshold_col=threshold_col,
         )
 
-    # --- Conversion to canonical edgelist ----------------------------------
-    # For undirected mode, postpone thresholding until after symmetrization
-    post_sum_threshold = threshold if not directed else None
 
+def _build_canonical_edgelist(
+    od_data: pd.DataFrame | np.ndarray,
+    zones_gdf: gpd.GeoDataFrame,
+    *,
+    zone_id_col: str | None,
+    matrix_type: Literal["edgelist", "adjacency"],
+    source_col: str,
+    target_col: str,
+    weight_cols: list[str] | None,
+    threshold: float | None,
+    threshold_col: str | None,
+    include_self_loops: bool,
+) -> pd.DataFrame:
+    """
+    Convert validated OD data into a canonical directed edgelist.
+
+    Dispatches on ``matrix_type`` and the concrete ``od_data`` container
+    (edge list, adjacency DataFrame or adjacency ndarray), aligning zone
+    labels and normalising to canonical ``source``/``target``/``weight``
+    columns. Guarantees the canonical columns exist even for empty results.
+
+    Parameters
+    ----------
+    od_data : pandas.DataFrame | numpy.ndarray
+        OD data as an edge list or adjacency matrix.
+    zones_gdf : geopandas.GeoDataFrame
+        GeoDataFrame of zones with unique identifiers.
+    zone_id_col : str | None
+        Name of the zone ID column in ``zones_gdf``.
+    matrix_type : {'edgelist', 'adjacency'}
+        Declares how to interpret ``od_data``.
+    source_col : str
+        Column name for origins when using an edge list.
+    target_col : str
+        Column name for destinations when using an edge list.
+    weight_cols : list[str] | None
+        Edge list weight (flow) columns to preserve.
+    threshold : float | None
+        Minimum flow retained. Pass ``None`` to skip thresholding here
+        (undirected mode applies it after symmetrization instead).
+    threshold_col : str | None
+        Column among ``weight_cols`` used for thresholding.
+    include_self_loops : bool
+        Keep flows where origin == destination.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Edgelist with canonical ``source``, ``target`` and ``weight`` columns.
+    """
     if matrix_type == "edgelist":
         # Filter to zones and aggregate duplicates first
         aligned = _align_edgelist_zones(
@@ -191,8 +344,7 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
             source_col=source_col,
             target_col=target_col,
             weight_cols=weight_cols if weight_cols is not None else [],
-            # In undirected mode, thresholding is applied later
-            threshold=None if not directed else threshold,
+            threshold=threshold,
             threshold_col=threshold_col,
             include_self_loops=include_self_loops,
         )
@@ -206,8 +358,7 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
         edge_df = _adjacency_to_edgelist(
             adj,
             include_self_loops=include_self_loops,
-            # In undirected mode, thresholding is applied later
-            threshold=None if not directed else threshold,
+            threshold=threshold,
         )
     elif matrix_type == "adjacency" and isinstance(od_data, np.ndarray):
         zone_ids = _align_numpy_array_zones(
@@ -219,8 +370,7 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
             od_data,
             zone_ids,
             include_self_loops=include_self_loops,
-            # In undirected mode, thresholding is applied later
-            threshold=None if not directed else threshold,
+            threshold=threshold,
         )
 
     # Ensure canonical columns exist even if empty result
@@ -229,25 +379,86 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
             include_extra_weights=(matrix_type == "edgelist" and bool(weight_cols)),
             extra_weights=(weight_cols or []),
         )
+    return edge_df
 
-    # If undirected, symmetrize by merging reciprocal edges and summing weights
-    if not directed and not edge_df.empty:
-        # Sum canonical 'weight' and any provided additional weight columns
-        sum_cols = ["weight"]
-        if matrix_type == "edgelist" and weight_cols:
-            # Ensure we sum the explicitly requested weight columns as well
-            # (they are already present in edge_df)
-            for c in weight_cols:
-                if c not in sum_cols:
-                    sum_cols.append(c)
 
-        edge_df = _symmetrize_edges(edge_df, sum_cols=sum_cols)
+def _symmetrize_undirected_edges(
+    edge_df: pd.DataFrame,
+    *,
+    matrix_type: Literal["edgelist", "adjacency"],
+    weight_cols: list[str] | None,
+    threshold: float | None,
+) -> pd.DataFrame:
+    """
+    Merge reciprocal edges for undirected output and apply the threshold.
 
-        # Apply threshold after summation when requested
-        if post_sum_threshold is not None:
-            edge_df = edge_df.loc[_apply_threshold(edge_df["weight"], threshold=post_sum_threshold)]
+    Symmetrizes a non-empty canonical edgelist by summing the weights of
+    reciprocal edges (including any additional weight columns), then applies
+    the post-summation threshold when requested.
 
-    # --- Spatial assembly (Task 5) -----------------------------------------
+    Parameters
+    ----------
+    edge_df : pandas.DataFrame
+        Canonical directed edgelist with ``source``/``target``/``weight``.
+    matrix_type : {'edgelist', 'adjacency'}
+        Declares how the edgelist was built.
+    weight_cols : list[str] | None
+        Additional weight columns to sum for edgelist inputs.
+    threshold : float | None
+        Minimum summed weight retained (>=). ``None`` keeps all edges.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Symmetrized (and optionally thresholded) edgelist.
+    """
+    # Sum canonical 'weight' and any provided additional weight columns
+    sum_cols = ["weight"]
+    if matrix_type == "edgelist" and weight_cols:
+        # Ensure we sum the explicitly requested weight columns as well
+        # (they are already present in edge_df)
+        for c in weight_cols:
+            if c not in sum_cols:
+                sum_cols.append(c)
+
+    edge_df = _symmetrize_edges(edge_df, sum_cols=sum_cols)
+
+    # Apply threshold after summation when requested
+    if threshold is not None:
+        edge_df = edge_df.loc[_apply_threshold(edge_df["weight"], threshold=threshold)]
+    return edge_df
+
+
+def _assemble_od_frames(
+    edge_df: pd.DataFrame,
+    zones_gdf: gpd.GeoDataFrame,
+    *,
+    zone_id_col: str | None,
+    compute_edge_geometry: bool,
+) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
+    """
+    Assemble the spatial node and edge frames from a canonical edgelist.
+
+    Aligns the node index with the zone identifier, creates edge geometries
+    from zone centroids when requested, and converts the edge frame to a
+    (source, target) MultiIndex.
+
+    Parameters
+    ----------
+    edge_df : pandas.DataFrame
+        Canonical edgelist with ``source``/``target``/``weight`` columns.
+    zones_gdf : geopandas.GeoDataFrame
+        GeoDataFrame of zones with unique identifiers.
+    zone_id_col : str | None
+        Name of the zone ID column in ``zones_gdf``.
+    compute_edge_geometry : bool
+        Whether to build LineString geometries from zone centroids.
+
+    Returns
+    -------
+    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame]
+        The ``(nodes, edges)`` GeoDataFrames.
+    """
     # Nodes: set index aligned with zone identifier (column or original index)
     nodes_gdf = (
         zones_gdf.set_index(zone_id_col, drop=False).copy()
@@ -275,24 +486,9 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
         edges_gdf.index = mi
         # Ensure CRS preserved (GeoPandas keeps it on GeoDataFrame)
 
-    # --- Output selection (Task 6) -----------------------------------------
-    if not as_nx:
-        # GeoDataFrame-first API: return (nodes, edges)
-        logger.info("Created graph with %d nodes and %d edges", len(nodes_gdf), len(edges_gdf))
-        return nodes_gdf, edges_gdf
-
-    G = gdf_to_nx(
-        nodes=nodes_gdf, edges=edges_gdf, keep_geom=compute_edge_geometry, directed=directed
-    )
-    logger.info(
-        "Created graph with %d nodes and %d edges", G.number_of_nodes(), G.number_of_edges()
-    )
-    return G
+    return nodes_gdf, edges_gdf
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
 def _validate_zones_gdf(zones_gdf: gpd.GeoDataFrame, zone_id_col: str | None) -> None:
     """
     Validate the zones GeoDataFrame structure.

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -955,14 +955,87 @@ def place_to_place_graph(
     >>> nodes, edges = place_to_place_graph(tessellation_gdf, group_col='enclosure_id')
     """
     # Input validation
+    _validate_place_to_place_inputs(
+        place_gdf,
+        contiguity=contiguity,
+        group_col=group_col,
+        duplicate_edges=duplicate_edges,
+        as_nx=as_nx,
+    )
+
+    # Handle empty or insufficient data: return empty edges GeoDataFrame
+    if place_gdf.empty or len(place_gdf) < 2:
+        return _return_empty_place_edges(place_gdf, group_col, as_nx)
+
+    # Deduplicate based on place_id to avoid libpysal errors
+    # This handles cases where place_gdf has been joined with other data (e.g. buildings)
+    # resulting in multiple rows per place space. We only need unique place spaces for the graph.
+    gdf_unique = place_gdf.drop_duplicates(subset=[_PLACE_ID_COL])
+
+    # Set index to place_id so contiguity_graph returns edges with correct IDs
+    # We must ensure the index is unique for libpysal
+    gdf_indexed = gdf_unique.set_index(_PLACE_ID_COL)
+
+    _, edges_gdf = contiguity_graph(
+        gdf_indexed,
+        contiguity=contiguity,
+        as_nx=False,
+    )
+
+    if edges_gdf.empty:
+        return _return_empty_place_edges(place_gdf, group_col, as_nx)
+
+    # Reshape to from/to place-ID columns and apply the group filter
+    edges_gdf = _format_place_edges(edges_gdf, gdf_unique, group_col)
+
+    if as_nx:
+        return gdf_to_nx(nodes=gdf_unique, edges=edges_gdf)
+
+    if duplicate_edges:
+        edges_gdf = _symmetrize_edge_columns(edges_gdf, "from_place_id", "to_place_id")
+
+    return gdf_unique, edges_gdf
+
+
+def _validate_place_to_place_inputs(
+    place_gdf: gpd.GeoDataFrame,
+    *,
+    contiguity: str,
+    group_col: str | None,
+    duplicate_edges: bool,
+    as_nx: bool,
+) -> None:
+    """
+    Validate all inputs of :func:`place_to_place_graph`.
+
+    Checks the input GeoDataFrame, the output-mode flag combination, the
+    presence of the place-ID column, the contiguity type, and the group
+    column when one is requested.
+
+    Parameters
+    ----------
+    place_gdf : geopandas.GeoDataFrame
+        GeoDataFrame containing place polygons.
+    contiguity : str
+        Requested contiguity type; must be 'queen' or 'rook'.
+    group_col : str | None
+        Optional column used to group connections.
+    duplicate_edges : bool
+        Whether both edge directions were requested.
+    as_nx : bool
+        Whether NetworkX output was requested.
+
+    Returns
+    -------
+    None
+        This function validates input and raises on failure.
+    """
     _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_single_gdf_input(place_gdf, "place_gdf")
 
-    place_id_col = _PLACE_ID_COL
-
     # If not empty, require the ID column
-    if not place_gdf.empty and place_id_col not in place_gdf.columns:
-        msg = f"Expected ID column '{place_id_col}' not found in place_gdf."
+    if not place_gdf.empty and _PLACE_ID_COL not in place_gdf.columns:
+        msg = f"Expected ID column '{_PLACE_ID_COL}' not found in place_gdf."
         raise ValueError(msg)
 
     # Validate that the contiguity type is supported
@@ -975,28 +1048,33 @@ def place_to_place_graph(
         msg = f"group_col '{group_col}' not found in place_gdf columns"
         raise ValueError(msg)
 
-    # Handle empty or insufficient data: return empty edges GeoDataFrame
-    if place_gdf.empty or len(place_gdf) < 2:
-        return _return_empty_place_edges(place_gdf, group_col, as_nx)
 
-    # Deduplicate based on place_id to avoid libpysal errors
-    # This handles cases where place_gdf has been joined with other data (e.g. buildings)
-    # resulting in multiple rows per place space. We only need unique place spaces for the graph.
-    gdf_unique = place_gdf.drop_duplicates(subset=[place_id_col])
+def _format_place_edges(
+    edges_gdf: gpd.GeoDataFrame,
+    gdf_unique: gpd.GeoDataFrame,
+    group_col: str | None,
+) -> gpd.GeoDataFrame:
+    """
+    Reshape contiguity edges into the place-to-place output format.
 
-    # Set index to place_id so contiguity_graph returns edges with correct IDs
-    # We must ensure the index is unique for libpysal
-    gdf_indexed = gdf_unique.set_index(place_id_col)
+    Moves the (source, target) MultiIndex into ``from_place_id`` and
+    ``to_place_id`` columns, then either annotates and filters edges by the
+    requested group column or assigns the default group.
 
-    _, edges_gdf = contiguity_graph(
-        gdf_indexed,
-        contiguity=contiguity,
-        as_nx=False,
-    )
+    Parameters
+    ----------
+    edges_gdf : geopandas.GeoDataFrame
+        Contiguity edges indexed by (source, target) place IDs.
+    gdf_unique : geopandas.GeoDataFrame
+        Deduplicated places used to map place IDs to group values.
+    group_col : str | None
+        Optional column used to group connections.
 
-    if edges_gdf.empty:
-        return _return_empty_place_edges(place_gdf, group_col, as_nx)
-
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Edges with place-ID columns and group annotation.
+    """
     # contiguity_graph returns edges with MultiIndex (source, target) containing the index values
     # (which are now place_ids). We reset index to get them as columns.
     edges_gdf = edges_gdf.reset_index()
@@ -1010,7 +1088,7 @@ def place_to_place_graph(
     if group_col:
         # Create a mapping from place_id to group
         # Use gdf_unique to ensure unique index
-        id_to_group = gdf_unique.set_index(place_id_col)[group_col]
+        id_to_group = gdf_unique.set_index(_PLACE_ID_COL)[group_col]
 
         # Map group values to edges
         edges_gdf[group_col] = edges_gdf["from_place_id"].map(id_to_group)
@@ -1018,19 +1096,12 @@ def place_to_place_graph(
 
         # Filter edges where source and target are in the same group.
         # Copy keeps the returned frame free of a pandas 2.x _is_copy flag,
-        # since it leaves this public function.
+        # since it leaves the public function.
         edges_gdf = edges_gdf[edges_gdf[group_col] == to_group].copy()
 
     else:
         edges_gdf["group"] = 0
-
-    if as_nx:
-        return gdf_to_nx(nodes=gdf_unique, edges=edges_gdf)
-
-    if duplicate_edges:
-        edges_gdf = _symmetrize_edge_columns(edges_gdf, "from_place_id", "to_place_id")
-
-    return gdf_unique, edges_gdf
+    return edges_gdf
 
 
 # ============================================================================
@@ -1575,22 +1646,93 @@ def segments_to_graph(
     segments_clean = processor.validate_gdf(segments_gdf, ["LineString"])
 
     if segments_clean is None or segments_clean.empty:
-        empty_nodes = gpd.GeoDataFrame(columns=["geometry"], crs=segments_gdf.crs)
-        empty_nodes.index.name = "node_id"
-        empty_edges = gpd.GeoDataFrame(
-            columns=["geometry"],
-            crs=segments_gdf.crs,
-            index=pd.MultiIndex.from_arrays([[], []], names=["from_node_id", "to_node_id"]),
-        )
-        if as_nx:
-            return gdf_to_nx(nodes=empty_nodes, edges=empty_edges, multigraph=multigraph)
-        return empty_nodes, empty_edges
+        return _empty_segments_result(segments_gdf, multigraph=multigraph, as_nx=as_nx)
 
     # Extract coordinates
     start_coords = processor.extract_coordinates(segments_clean, start=True)
     end_coords = processor.extract_coordinates(segments_clean, start=False)
 
-    # Create unique nodes
+    # Create unique nodes indexed by node ID
+    nodes_gdf, coord_to_id = _build_segment_nodes(start_coords, end_coords, segments_clean.crs)
+
+    # Create edges with a (from_node_id, to_node_id[, edge_key]) MultiIndex
+    edges_gdf = _build_segment_edges(
+        segments_clean,
+        from_ids=start_coords.map(coord_to_id),
+        to_ids=end_coords.map(coord_to_id),
+        directed=directed,
+        multigraph=multigraph,
+    )
+
+    if as_nx:
+        return gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf, multigraph=multigraph)
+    return nodes_gdf, edges_gdf
+
+
+def _empty_segments_result(
+    segments_gdf: gpd.GeoDataFrame,
+    *,
+    multigraph: bool,
+    as_nx: bool,
+) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph | nx.MultiGraph:
+    """
+    Build the empty result for :func:`segments_to_graph`.
+
+    Creates empty node and edge GeoDataFrames with the expected index names
+    and the CRS of the input, converting to NetworkX when requested.
+
+    Parameters
+    ----------
+    segments_gdf : geopandas.GeoDataFrame
+        The original segments input, used only for its CRS.
+    multigraph : bool
+        Whether the NetworkX output should be a MultiGraph.
+    as_nx : bool
+        If True, return a NetworkX graph instead of GeoDataFrames.
+
+    Returns
+    -------
+    tuple[geopandas.GeoDataFrame, geopandas.GeoDataFrame] or networkx.Graph or networkx.MultiGraph
+        Empty ``(nodes, edges)`` GeoDataFrames or the equivalent NetworkX graph.
+    """
+    empty_nodes = gpd.GeoDataFrame(columns=["geometry"], crs=segments_gdf.crs)
+    empty_nodes.index.name = "node_id"
+    empty_edges = gpd.GeoDataFrame(
+        columns=["geometry"],
+        crs=segments_gdf.crs,
+        index=pd.MultiIndex.from_arrays([[], []], names=["from_node_id", "to_node_id"]),
+    )
+    if as_nx:
+        return gdf_to_nx(nodes=empty_nodes, edges=empty_edges, multigraph=multigraph)
+    return empty_nodes, empty_edges
+
+
+def _build_segment_nodes(
+    start_coords: pd.Series,
+    end_coords: pd.Series,
+    crs: object,
+) -> tuple[gpd.GeoDataFrame, dict[tuple[float, float], int]]:
+    """
+    Build the unique-node GeoDataFrame for :func:`segments_to_graph`.
+
+    Deduplicates the segment endpoint coordinates, assigns sequential node
+    IDs and materialises the nodes as a Point GeoDataFrame indexed by
+    ``node_id``.
+
+    Parameters
+    ----------
+    start_coords : pandas.Series
+        Segment start coordinates as (x, y) tuples.
+    end_coords : pandas.Series
+        Segment end coordinates as (x, y) tuples.
+    crs : object
+        CRS to assign to the nodes GeoDataFrame.
+
+    Returns
+    -------
+    tuple[geopandas.GeoDataFrame, dict[tuple[float, float], int]]
+        The nodes GeoDataFrame and the coordinate-to-node-ID mapping.
+    """
     all_coords = pd.concat([start_coords, end_coords]).drop_duplicates()
     coord_to_id = {coord: i for i, coord in enumerate(all_coords)}
 
@@ -1605,13 +1747,45 @@ def segments_to_graph(
             "node_id": range(len(all_coords)),
             "geometry": gpd.points_from_xy(x_coords, y_coords),
         },
-        crs=segments_clean.crs,
+        crs=crs,
     ).set_index("node_id", drop=True)
+    return nodes_gdf, coord_to_id
 
-    # Create edges with MultiIndex
-    from_ids = start_coords.map(coord_to_id)
-    to_ids = end_coords.map(coord_to_id)
 
+def _build_segment_edges(
+    segments_clean: gpd.GeoDataFrame,
+    *,
+    from_ids: pd.Series,
+    to_ids: pd.Series,
+    directed: bool,
+    multigraph: bool,
+) -> gpd.GeoDataFrame:
+    """
+    Build the edge GeoDataFrame for :func:`segments_to_graph`.
+
+    Optionally canonicalizes undirected edges to an unordered node-ID pair,
+    then assigns a ``(from_node_id, to_node_id)`` MultiIndex, extended with
+    an ``edge_key`` level for multigraphs. Rejects duplicate node pairs when
+    ``multigraph=False``.
+
+    Parameters
+    ----------
+    segments_clean : geopandas.GeoDataFrame
+        Validated LineString segments providing the edge rows.
+    from_ids : pandas.Series
+        Node IDs of the segment start points.
+    to_ids : pandas.Series
+        Node IDs of the segment end points.
+    directed : bool
+        Whether the edges keep their drawn orientation.
+    multigraph : bool
+        Whether duplicate node pairs are kept as parallel edges.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Edges indexed by the node-ID MultiIndex.
+    """
     if not directed:
         # Canonicalize each edge to an unordered (min, max) node-id order so
         # reverse-drawn duplicate segments share one unordered pair. The
@@ -1647,10 +1821,7 @@ def segments_to_graph(
             [from_ids, to_ids],
             names=["from_node_id", "to_node_id"],
         )
-
-    if as_nx:
-        return gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf, multigraph=multigraph)
-    return nodes_gdf, edges_gdf
+    return edges_gdf
 
 
 # ============================================================================

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -1725,7 +1725,6 @@ def bridge_nodes(
         msg = "proximity_method must be 'knn' or 'fixed_radius'"
         raise ValueError(msg)
 
-    edge_dict = {}
     method = proximity_method.lower()
     metric_name = str(kwargs.get("distance_metric", "euclidean"))
     net_gdf = kwargs.get("network_gdf")
@@ -1741,6 +1740,66 @@ def bridge_nodes(
     source_types = _normalize_layer_types(source_node_types, "source", node_order, node_set)
     target_types = _normalize_layer_types(target_node_types, "target", node_order, node_set)
 
+    edge_dict = _build_bridge_edges(
+        nodes_dict,
+        source_types,
+        target_types,
+        method=method,
+        param=param,
+        distance_metric=metric_name,
+        network_gdf=net_gdf,
+        network_weight=net_weight,
+    )
+
+    if as_nx:
+        return gdf_to_nx(nodes=nodes_dict, edges=edge_dict, multigraph=multigraph, directed=True)
+    return nodes_dict, edge_dict
+
+
+def _build_bridge_edges(
+    nodes_dict: dict[str, gpd.GeoDataFrame],
+    source_types: list[str],
+    target_types: list[str],
+    *,
+    method: str,
+    param: float,
+    distance_metric: str,
+    network_gdf: gpd.GeoDataFrame | None,
+    network_weight: str | None,
+) -> dict[tuple[str, str, str], gpd.GeoDataFrame]:
+    """
+    Build directed proximity edges for every ordered pair of node layers.
+
+    Iterates over the ordered (source, target) layer pairs, skipping
+    same-layer pairs, and computes the directed edges for each pair with the
+    requested proximity method, unwrapping the layer index back to the
+    original node IDs.
+
+    Parameters
+    ----------
+    nodes_dict : dict[str, geopandas.GeoDataFrame]
+        Mapping of node type to node GeoDataFrame.
+    source_types : list[str]
+        Ordered, validated source node types.
+    target_types : list[str]
+        Ordered, validated target node types.
+    method : str
+        ``"knn"`` or ``"fixed_radius"`` proximity strategy.
+    param : float
+        Method-specific parameter (``k`` or radius).
+    distance_metric : str
+        Metric name as understood by :class:`DistanceMetric`.
+    network_gdf : geopandas.GeoDataFrame | None
+        Supporting network data required for the ``network`` metric.
+    network_weight : str | None
+        Edge attribute used as weight for the ``network`` metric.
+
+    Returns
+    -------
+    dict[tuple[str, str, str], geopandas.GeoDataFrame]
+        Edge GeoDataFrames keyed by ``(source_type, 'is_nearby', target_type)``.
+    """
+    edge_dict = {}
     for src_type in source_types:
         for dst_type in target_types:
             if src_type == dst_type:
@@ -1752,12 +1811,12 @@ def bridge_nodes(
             _, edges_gdf = _directed_graph(
                 src_gdf=src_gdf,
                 dst_gdf=dst_gdf,
-                distance_metric=metric_name,
+                distance_metric=distance_metric,
                 method=method,
                 param=param,
                 as_nx=False,
-                network_gdf=net_gdf,
-                network_weight=net_weight,
+                network_gdf=network_gdf,
+                network_weight=network_weight,
                 return_nodes=False,
             )
 
@@ -1765,10 +1824,7 @@ def bridge_nodes(
             if not edges_gdf.empty:
                 edges_gdf.index = GeoDataProcessor.unwrap_layer_edge_index(edges_gdf.index)
             edge_dict[(src_type, "is_nearby", dst_type)] = edges_gdf
-
-    if as_nx:
-        return gdf_to_nx(nodes=nodes_dict, edges=edge_dict, multigraph=multigraph, directed=True)
-    return nodes_dict, edge_dict
+    return edge_dict
 
 
 def group_nodes(

--- a/city2graph/utils/spatial.py
+++ b/city2graph/utils/spatial.py
@@ -3208,7 +3208,6 @@ def plot_graph(  # noqa: PLR0913
             ax.figure.patch.set_facecolor(bgcolor)
 
     # GeoDataFrame-based plotting
-    is_hetero = isinstance(nodes, dict) or isinstance(edges, dict)
     if is_hetero:
         _plot_hetero_graph(nodes, edges, ax, **style_kwargs)
     else:


### PR DESCRIPTION
## Description

Decomposes the remaining oversized graph-building orchestrators so that each public function reads as a short, phase-by-phase pipeline (validation → transformation → assembly → output), with each phase in a focused private helper.

Changes per function:

- **`od_matrix_to_graph`** (`mobility.py`, ~155-line body): extracted `_validate_od_inputs` (zone/CRS/threshold/matrix-type checks), `_build_canonical_edgelist` (the three-way edgelist / adjacency-DataFrame / adjacency-ndarray conversion with the empty-frame guarantee), `_symmetrize_undirected_edges` (reciprocal-edge merging and post-sum thresholding), and `_assemble_od_frames` (node index alignment, edge geometries, MultiIndex). The public body is now ~40 lines of orchestration.
- **`segments_to_graph`** (`morphology.py`, ~82-line body): extracted `_empty_segments_result`, `_build_segment_nodes` (endpoint dedup and node-ID assignment), and `_build_segment_edges` (undirected canonicalisation and the multigraph edge-key vs duplicate-pair branch).
- **`place_to_place_graph`** (`morphology.py`, ~77-line body): extracted `_validate_place_to_place_inputs` and `_format_place_edges` (MultiIndex reshape, place-ID columns, group annotation/filtering).
- **`bridge_nodes`** (`proximity.py`, ~52-line body): extracted `_build_bridge_edges` (the ordered layer-pair loop over `_directed_graph` with index unwrapping).
- **`plot_graph`** (`utils/spatial.py`): already a thin dispatcher; only removed a duplicated `is_hetero` computation.

The other functions named in the issue (`morphological_graph`, `place_to_movement_graph`, `contiguity_graph`) are already decomposed by earlier refactors (e.g. cac00ba, 2e04f74).

## Related Issues

Closes #199

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary. *(No documentation changes needed: the public API is unchanged.)*
- [x] I have added tests to cover my changes. *(No new tests: this is a behaviour-preserving refactor; the extracted helpers are fully exercised through the existing public-API tests, and coverage of the touched modules is unchanged — `mobility.py` and `proximity.py` remain at 100 %.)*
- [x] All new and existing tests passed. *(860 passed.)*
- [x] Pre-commit checks passed locally.
