### PR TITLE
Align transportation graph conversion and strengthen mobility tests

### DIFF
--- a/city2graph/transportation.py
+++ b/city2graph/transportation.py
@@ -12,16 +12,20 @@ import json
 import logging
 import tempfile
 import zipfile
-from contextlib import suppress
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import duckdb
 import geopandas as gpd
-import networkx as nx
 import pandas as pd
 from shapely import wkt
+
+from .utils import gdf_to_nx
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -239,8 +243,10 @@ def _ensure_graph_sql_support(con: duckdb.DuckDBPyConnection) -> None:
             msg = "DuckDB spatial extension is required to build transport graph geometries."
             raise RuntimeError(msg) from error
 
-    # Usually raises duckdb.Error if the function already exists.
-    with suppress(duckdb.Error):
+    registered = con.execute(
+        "SELECT count(*) FROM duckdb_functions() WHERE function_name = 'time_to_seconds'"
+    ).fetchone()
+    if registered is None or not registered[0]:
         con.create_function(
             "time_to_seconds",
             _time_to_seconds,
@@ -1188,44 +1194,6 @@ def _build_travel_summary_nodes(con: duckdb.DuckDBPyConnection) -> gpd.GeoDataFr
     return nodes_gdf
 
 
-def _summary_graph_to_networkx(
-    nodes_gdf: gpd.GeoDataFrame,
-    edges_gdf: gpd.GeoDataFrame,
-    *,
-    directed: bool,
-) -> nx.DiGraph | nx.Graph:
-    """
-    Convert summary-graph GeoDataFrames into a NetworkX graph.
-
-    Node and edge attributes are copied row-wise so the NetworkX graph mirrors
-    the GeoDataFrame representation.
-
-    Parameters
-    ----------
-    nodes_gdf : gpd.GeoDataFrame
-        Summary graph nodes indexed by ``stop_id``.
-    edges_gdf : gpd.GeoDataFrame
-        Summary graph edges indexed by stop pairs.
-    directed : bool
-        Whether to create a directed or undirected graph.
-
-    Returns
-    -------
-    nx.DiGraph | nx.Graph
-        Graph populated with node and edge attributes.
-    """
-    graph = nx.DiGraph() if directed else nx.Graph()
-    graph.graph["crs"] = str(nodes_gdf.crs) if nodes_gdf.crs else None
-
-    for stop_id, row in nodes_gdf.iterrows():
-        graph.add_node(stop_id, **row.to_dict())
-
-    for (from_stop_id, to_stop_id), row in edges_gdf.iterrows():
-        graph.add_edge(from_stop_id, to_stop_id, **row.to_dict())
-
-    return graph
-
-
 def travel_summary_graph(
     con: duckdb.DuckDBPyConnection,
     start_time: str | None = None,
@@ -1286,7 +1254,12 @@ def travel_summary_graph(
     tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.DiGraph | nx.Graph
         ``(nodes_gdf, edges_gdf)`` when ``as_nx`` is ``False``; otherwise
         a ``nx.DiGraph`` (``directed=True``) or ``nx.Graph``
-        (``directed=False``) built from those GeoDataFrames.
+        (``directed=False``) built from those GeoDataFrames via
+        :func:`city2graph.utils.gdf_to_nx`, following its shared
+        conventions: integer node identifiers with the original
+        ``stop_id`` values stored in the ``_original_index`` node
+        attribute, node ``pos`` coordinates, and graph-level CRS and
+        index metadata.
     """
     tables = _list_tables(con)
     required = {"stop_times", "stops", "trips"}
@@ -1320,4 +1293,4 @@ def travel_summary_graph(
     if not as_nx:
         return nodes_gdf, edges_gdf
 
-    return _summary_graph_to_networkx(nodes_gdf, edges_gdf, directed=directed)
+    return gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf, directed=directed)

--- a/city2graph/utils/conversion.py
+++ b/city2graph/utils/conversion.py
@@ -275,11 +275,7 @@ class NxConverter(BaseGraphConverter):
             The validated nodes and edges GeoDataFrames.
         """
         nodes = self.processor.validate_gdf(nodes, allow_empty=True)
-        edges = self.processor.validate_gdf(
-            edges,
-            ["LineString", "MultiLineString"],
-            allow_empty=True,
-        )
+        edges = _validate_edge_frame(self.processor, edges, allow_empty=True)
         # mypy: ensure edges is GeoDataFrame
         if edges is None:
             msg = "Edges GeoDataFrame cannot be None"
@@ -529,6 +525,12 @@ class NxConverter(BaseGraphConverter):
         if edges_gdf.empty:
             return
 
+        # Without edge geometries, endpoints cannot be matched by coordinates;
+        # resolve them from the edge index against the original node index.
+        if _edges_lack_geometry(edges_gdf):
+            self._add_homogeneous_edges_by_index(graph, edges_gdf)
+            return
+
         # Create node mapping (either from existing nodes or from edge coordinates)
         if nodes_gdf is not None and not nodes_gdf.empty:
             coord_to_node = {
@@ -555,6 +557,60 @@ class NxConverter(BaseGraphConverter):
 
         # Filter valid edges
         valid_mask = u_nodes.notna() & v_nodes.notna()
+        valid_edges = edges_gdf[valid_mask]
+        valid_u = u_nodes[valid_mask]
+        valid_v = v_nodes[valid_mask]
+
+        self._create_edge_list(graph, valid_u, valid_v, valid_edges, self.keep_geom)
+
+    def _add_homogeneous_edges_by_index(
+        self,
+        graph: nx.Graph | nx.MultiGraph,
+        edges_gdf: gpd.GeoDataFrame,
+    ) -> None:
+        """
+        Add homogeneous edges by mapping the edge index to node identifiers.
+
+        Used when the edges GeoDataFrame carries no geometry (e.g. built with
+        ``compute_edge_geometry=False``), so endpoints cannot be matched by
+        coordinates. The first two levels of the edge index are matched
+        against the ``_original_index`` of the nodes already in the graph,
+        mirroring the heterogeneous conversion path.
+
+        Parameters
+        ----------
+        graph : networkx.Graph or networkx.MultiGraph
+            The NetworkX graph to which the edges will be added.
+        edges_gdf : geopandas.GeoDataFrame
+            The GeoDataFrame containing the edge data, indexed by a
+            ``(source, target)`` MultiIndex of node identifiers.
+        """
+        if not isinstance(edges_gdf.index, pd.MultiIndex) or edges_gdf.index.nlevels < 2:
+            logger.warning(
+                "Could not map %d edges without geometry: a (source, target) "
+                "MultiIndex is required",
+                len(edges_gdf),
+            )
+            return
+
+        node_lookup = {
+            node_data.get("_original_index"): node_id
+            for node_id, node_data in graph.nodes(data=True)
+        }
+        node_lookup.pop(None, None)
+
+        src_indices = edges_gdf.index.get_level_values(0)
+        dst_indices = edges_gdf.index.get_level_values(1)
+        u_nodes = pd.Series(src_indices, index=edges_gdf.index).map(node_lookup)
+        v_nodes = pd.Series(dst_indices, index=edges_gdf.index).map(node_lookup)
+
+        valid_mask = u_nodes.notna() & v_nodes.notna()
+        if not valid_mask.all():
+            logger.warning(
+                "Could not find nodes for %d edges without geometry",
+                int((~valid_mask).sum()),
+            )
+
         valid_edges = edges_gdf[valid_mask]
         valid_u = u_nodes[valid_mask]
         valid_v = v_nodes[valid_mask]
@@ -1427,6 +1483,68 @@ class NxConverter(BaseGraphConverter):
         )
 
 
+def _edges_lack_geometry(edges: gpd.GeoDataFrame | None) -> bool:
+    """
+    Check whether an edges GeoDataFrame carries no geometry at all.
+
+    Edge frames built without geometry (e.g. with
+    ``compute_edge_geometry=False``) hold ``None`` in every row of the
+    geometry column. Such frames must bypass geometry validation and have
+    their endpoints resolved from the edge index instead.
+
+    Parameters
+    ----------
+    edges : geopandas.GeoDataFrame or None
+        The edges GeoDataFrame to inspect.
+
+    Returns
+    -------
+    bool
+        True if ``edges`` is a non-empty GeoDataFrame whose geometry values
+        are all missing.
+    """
+    return (
+        isinstance(edges, gpd.GeoDataFrame)
+        and not edges.empty
+        and bool(edges.geometry.isna().all())
+    )
+
+
+def _validate_edge_frame(
+    processor: GeoDataProcessor,
+    edges: gpd.GeoDataFrame | None,
+    allow_empty: bool = True,
+) -> gpd.GeoDataFrame | None:
+    """
+    Validate a homogeneous edges GeoDataFrame, tolerating absent geometry.
+
+    Edges without any geometry (e.g. built with
+    ``compute_edge_geometry=False``) skip geometry validation, which would
+    drop every row; their endpoints are resolved from the edge index instead.
+
+    Parameters
+    ----------
+    processor : GeoDataProcessor
+        The processor performing the geometry validation.
+    edges : geopandas.GeoDataFrame or None
+        The edges GeoDataFrame to validate.
+    allow_empty : bool, default True
+        Whether to allow an empty GeoDataFrame.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame or None
+        The validated edges GeoDataFrame, or None if input was None.
+    """
+    if _edges_lack_geometry(edges):
+        return edges
+    return processor.validate_gdf(
+        edges,
+        ["LineString", "MultiLineString"],
+        allow_empty=allow_empty,
+    )
+
+
 def _normalize_index_name(name: object) -> str | None:
     """
     Normalize an index name to a string or None.
@@ -1986,11 +2104,7 @@ def validate_gdf(
             )
 
         if edges_gdf is not None:
-            validated_edges = processor.validate_gdf(
-                edges_gdf,
-                ["LineString", "MultiLineString"],
-                allow_empty=allow_empty,
-            )
+            validated_edges = _validate_edge_frame(processor, edges_gdf, allow_empty=allow_empty)
 
     # Ensure CRS consistency
     all_gdfs_to_check: list[gpd.GeoDataFrame] = []

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -11,6 +11,7 @@ from typing import cast
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pytest
 
 from city2graph.mobility import od_matrix_to_graph
 
@@ -700,3 +701,112 @@ class TestODMatrixToGraph:
         sums = {tuple(idx): (row["w1"], row["w2"], row["weight"]) for idx, row in edges.iterrows()}
         assert sums[("A", "B")] == (3, 30, 3)
         assert sums[("A", "C")] == (7, 70, 7)
+
+    def test_threshold_keeps_weights_equal_to_boundary(
+        self, od_zones_gdf: gpd.GeoDataFrame
+    ) -> None:
+        """Thresholding is inclusive: weights equal to the threshold survive."""
+        E = pd.DataFrame(
+            {
+                "source": ["A", "B"],
+                "target": ["B", "C"],
+                "flow": [2, 1],
+            }
+        )
+        _nodes, edges = od_matrix_to_graph(
+            E,
+            od_zones_gdf,
+            zone_id_col="zone_id",
+            matrix_type="edgelist",
+            weight_cols=["flow"],
+            threshold=2,
+        )
+        # weight == threshold kept, weight below dropped
+        assert list(edges.index) == [("A", "B")]
+        assert edges.iloc[0]["weight"] == 2
+
+    def test_edgelist_directed_self_loops_toggle(self, od_zones_gdf: gpd.GeoDataFrame) -> None:
+        """include_self_loops controls self-loop retention on the directed edgelist path."""
+        E = pd.DataFrame(
+            {
+                "source": ["A", "A"],
+                "target": ["A", "B"],
+                "flow": [3, 1],
+            }
+        )
+        _nodes, edges_default = od_matrix_to_graph(
+            E,
+            od_zones_gdf,
+            zone_id_col="zone_id",
+            matrix_type="edgelist",
+            weight_cols=["flow"],
+        )
+        assert ("A", "A") not in edges_default.index
+        assert ("A", "B") in edges_default.index
+
+        _nodes, edges_loops = od_matrix_to_graph(
+            E,
+            od_zones_gdf,
+            zone_id_col="zone_id",
+            matrix_type="edgelist",
+            weight_cols=["flow"],
+            include_self_loops=True,
+        )
+        assert ("A", "A") in edges_loops.index
+        assert edges_loops.loc[("A", "A"), "weight"] == 3
+
+    def test_as_nx_metadata_follows_shared_conventions(
+        self, od_zones_gdf: gpd.GeoDataFrame
+    ) -> None:
+        """as_nx output carries shared gdf_to_nx metadata and node conventions."""
+        A = np.array([[0, 2, 0], [0, 0, 1], [0, 0, 0]], dtype=float)
+        G = cast(
+            "nx.DiGraph",
+            od_matrix_to_graph(
+                A, od_zones_gdf, zone_id_col="zone_id", matrix_type="adjacency", as_nx=True
+            ),
+        )
+        assert str(G.graph["crs"]) == str(od_zones_gdf.crs)
+        assert G.graph["is_hetero"] is False
+        node_attrs = dict(G.nodes(data=True))
+        assert {attrs["_original_index"] for attrs in node_attrs.values()} == {"A", "B", "C"}
+        assert all("pos" in attrs for attrs in node_attrs.values())
+        for _u, _v, attrs in G.edges(data=True):
+            assert "weight" in attrs
+            assert "_original_edge_index" in attrs
+
+    def test_geographic_crs_emits_warning(self, od_zones_gdf: gpd.GeoDataFrame) -> None:
+        """Zones in a geographic CRS trigger the accuracy warning."""
+        E = pd.DataFrame({"source": ["A"], "target": ["B"], "flow": [1]})
+        with pytest.warns(UserWarning, match="Geographic CRS detected"):
+            od_matrix_to_graph(
+                E,
+                od_zones_gdf,
+                zone_id_col="zone_id",
+                matrix_type="edgelist",
+                weight_cols=["flow"],
+            )
+
+    def test_adjacency_ndarray_with_zone_id_none_uses_index(
+        self, od_zones_gdf: gpd.GeoDataFrame
+    ) -> None:
+        """NumPy adjacency with zone_id_col=None aligns rows to the zones index."""
+        zones = od_zones_gdf.set_index("zone_id")[["value", "geometry"]]
+        arr = np.array([[0, 5, 0], [0, 0, 2], [0, 0, 0]], dtype=float)
+        nodes, edges = od_matrix_to_graph(arr, zones, matrix_type="adjacency")
+        assert list(nodes.index) == ["A", "B", "C"]
+        assert list(edges.index) == [("A", "B"), ("B", "C")]
+        assert list(edges["weight"]) == [5.0, 2.0]
+
+    def test_empty_zones_gdf_raises(self, od_zones_gdf: gpd.GeoDataFrame) -> None:
+        """An empty zones GeoDataFrame leaves no overlapping zone IDs and raises."""
+        empty_zones = od_zones_gdf.iloc[0:0]
+        E = pd.DataFrame({"source": ["A"], "target": ["B"], "flow": [1]})
+        with pytest.raises(ValueError, match="No overlapping zone IDs"):
+            od_matrix_to_graph(
+                E,
+                empty_zones,
+                zone_id_col="zone_id",
+                matrix_type="edgelist",
+                weight_cols=["flow"],
+            )

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -104,6 +104,38 @@ class TestODMatrixToGraph:
         assert G.number_of_nodes() == 3
         assert G.number_of_edges() == 2
 
+    def test_networkx_output_without_edge_geometry(self, od_zones_gdf: gpd.GeoDataFrame) -> None:
+        """Edges survive NetworkX conversion when compute_edge_geometry=False."""
+        E = pd.DataFrame(
+            {
+                "source": ["A", "B"],
+                "target": ["B", "C"],
+                "flow": [5.0, 7.0],
+            }
+        )
+        G = cast(
+            "nx.DiGraph",
+            od_matrix_to_graph(
+                E,
+                od_zones_gdf,
+                zone_id_col="zone_id",
+                matrix_type="edgelist",
+                weight_cols=["flow"],
+                compute_edge_geometry=False,
+                as_nx=True,
+            ),
+        )
+        assert G.number_of_nodes() == 3
+        assert G.number_of_edges() == 2
+        # Endpoints map back to the zone ids and weights are preserved
+        weights = {
+            (G.nodes[u]["_original_index"], G.nodes[v]["_original_index"]): data["weight"]
+            for u, v, data in G.edges(data=True)
+        }
+        assert weights == {("A", "B"): 5.0, ("B", "C"): 7.0}
+        # No geometry attribute is stored on the edges
+        assert all("geometry" not in data for _, _, data in G.edges(data=True))
+
     def test_undirected_sums_reciprocals_edgelist(self, od_zones_gdf: gpd.GeoDataFrame) -> None:
         """Undirected mode sums reciprocal edges for edgelist input."""
         E = pd.DataFrame(

--- a/tests/test_transportation.py
+++ b/tests/test_transportation.py
@@ -49,6 +49,33 @@ def dict_to_con(d: dict[str, pd.DataFrame]) -> duckdb.DuckDBPyConnection:
     return con
 
 
+class _ShowTablesResult:
+    def fetchall(self) -> list[tuple[str]]:
+        return [("stop_times",), ("stops",), ("trips",)]
+
+
+class _FunctionCountResult:
+    def fetchone(self) -> tuple[int]:
+        return (0,)
+
+
+class FailingUdfConnection:
+    """Connection stub whose UDF registration fails after spatial support loads."""
+
+    def execute(self, query: str) -> _ShowTablesResult | _FunctionCountResult | None:
+        if query == "SHOW TABLES":
+            return _ShowTablesResult()
+        if query == "LOAD spatial;":
+            return None
+        if "duckdb_functions()" in query:
+            return _FunctionCountResult()
+        raise AssertionError(query)
+
+    def create_function(self, *_args: object, **_kwargs: object) -> None:
+        msg = "UDF registration failed"
+        raise duckdb.Error(msg)
+
+
 class TestTimeHelpers:
     def test_time_to_seconds_with_float(self) -> None:
         assert _time_to_seconds(3600.0) == 3600.0
@@ -639,3 +666,70 @@ class TestTravelSummaryGraph:
 
         with pytest.raises(ValueError, match="stops must contain either a geometry column"):
             travel_summary_graph(con)
+
+    def test_travel_summary_graph_as_nx_follows_shared_conventions(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+        graph = travel_summary_graph(con, as_nx=True)
+
+        assert isinstance(graph, nx.Graph)
+        assert str(graph.graph["crs"]) == "EPSG:4326"
+        assert graph.graph["is_hetero"] is False
+        assert all(isinstance(node_id, int) for node_id in graph.nodes)
+
+        node_attrs = dict(graph.nodes(data=True))
+        original_ids = {attrs["_original_index"] for attrs in node_attrs.values()}
+        assert original_ids == {"stop1", "stop2", "stop3"}
+        assert all("pos" in attrs for attrs in node_attrs.values())
+
+        assert graph.number_of_edges() > 0
+        for _u, _v, attrs in graph.edges(data=True):
+            assert attrs["travel_time_sec"] > 0
+            assert attrs["frequency"] > 0
+            assert "_original_edge_index" in attrs
+
+    def test_travel_summary_graph_as_nx_empty_edges(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        sample_gtfs_dict["stop_times"] = pd.DataFrame(
+            columns=["trip_id", "stop_id", "arrival_time", "departure_time", "stop_sequence"]
+        )
+        con = dict_to_con(sample_gtfs_dict)
+        graph = travel_summary_graph(con, as_nx=True)
+
+        assert isinstance(graph, nx.Graph)
+        assert graph.number_of_nodes() == 3
+        assert graph.number_of_edges() == 0
+
+    def test_travel_summary_graph_as_nx_time_filtered_directed(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+        graph = travel_summary_graph(
+            con,
+            start_time="08:00:00",
+            end_time="08:10:00",
+            as_nx=True,
+            directed=True,
+            use_frequencies=False,
+        )
+
+        assert isinstance(graph, nx.DiGraph)
+        assert graph.number_of_edges() == 2
+        for _u, _v, attrs in graph.edges(data=True):
+            assert attrs["travel_time_sec"] > 0
+            assert attrs["frequency"] > 0
+
+    def test_travel_summary_graph_instant_time_window(
+        self, sample_gtfs_dict: dict[str, pd.DataFrame]
+    ) -> None:
+        con = dict_to_con(sample_gtfs_dict)
+        nodes_gdf, edges_gdf = travel_summary_graph(con, start_time="08:00:00", end_time="08:00:00")
+
+        assert len(nodes_gdf) == 3
+        assert len(edges_gdf) == 0
+
+    def test_travel_summary_graph_surfaces_udf_registration_failures(self) -> None:
+        with pytest.raises(duckdb.Error, match="UDF registration failed"):
+            travel_summary_graph(cast("duckdb.DuckDBPyConnection", FailingUdfConnection()))

--- a/tests/utils/test_conversion.py
+++ b/tests/utils/test_conversion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import geopandas as gpd
@@ -253,6 +254,52 @@ class TestNxConversions(BaseConversionTest):
             assert isinstance(graph, nx.Graph)
             # Heterogeneous edges dict without nodes results in empty graph
             assert graph.number_of_edges() == 0
+
+    def test_geometryless_edges_mapped_by_index(
+        self,
+        sample_nodes_gdf: gpd.GeoDataFrame,
+        sample_edges_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Edges without geometry are mapped via the (source, target) MultiIndex."""
+        edges = sample_edges_gdf.set_geometry(
+            gpd.GeoSeries([None] * len(sample_edges_gdf), index=sample_edges_gdf.index),
+            crs=sample_edges_gdf.crs,
+        )
+        # An edge referencing an unknown node id cannot be mapped and is dropped
+        unknown = edges.iloc[[0]].copy()
+        unknown.index = pd.MultiIndex.from_tuples([(1, 99)], names=edges.index.names)
+        edges = pd.concat([edges, unknown])
+
+        with caplog.at_level(logging.WARNING, logger="city2graph.utils"):
+            graph = gdf_to_nx(nodes=sample_nodes_gdf, edges=edges, keep_geom=False)
+
+        assert graph.number_of_edges() == len(sample_edges_gdf)
+        original_edges = {
+            (graph.nodes[u]["_original_index"], graph.nodes[v]["_original_index"])
+            for u, v in graph.edges()
+        }
+        assert original_edges == set(sample_edges_gdf.index)
+        assert "Could not find nodes for 1 edges without geometry" in caplog.text
+
+    def test_geometryless_edges_without_multiindex_are_dropped(
+        self,
+        sample_nodes_gdf: gpd.GeoDataFrame,
+        sample_edges_gdf: gpd.GeoDataFrame,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Edges without geometry and without a (u, v) MultiIndex cannot be mapped."""
+        flat_edges = sample_edges_gdf.reset_index(drop=True)
+        edges = flat_edges.set_geometry(
+            gpd.GeoSeries([None] * len(flat_edges), index=flat_edges.index),
+            crs=flat_edges.crs,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="city2graph.utils"):
+            graph = gdf_to_nx(nodes=sample_nodes_gdf, edges=edges, keep_geom=False)
+
+        assert graph.number_of_edges() == 0
+        assert "MultiIndex is required" in caplog.text
 
     def test_nx_to_gdf_requires_nodes_or_edges(self, simple_nx_graph: nx.Graph) -> None:
         """Requesting neither nodes nor edges should raise."""


### PR DESCRIPTION
## Description

This pull request addresses the three quality and consistency gaps identified in #205:

1. **Shared NetworkX conversion for `travel_summary_graph(as_nx=True)`.** The transportation-specific `_summary_graph_to_networkx` converter is removed and the `as_nx=True` path now calls the shared `gdf_to_nx`, as mobility, morphology, and proximity already do. The NetworkX output therefore follows the library-wide conventions: integer node identifiers with original `stop_id` values preserved in the `_original_index` node attribute, node `pos` coordinates, `_original_edge_index` on edges, and full graph-level `GraphMetadata` (CRS object, `is_hetero`, index names, geometry columns), making the result round-trippable via `nx_to_gdf`. Note this changes the `as_nx=True` output conventions (previously stop-id node keys and a string-valued `crs` entry); the docstring is updated accordingly.

2. **Narrowed error handling in `_ensure_graph_sql_support`.** The blanket `with suppress(duckdb.Error)` around `create_function("time_to_seconds", ...)` is replaced by an existence pre-check against `duckdb_functions()`. Registration is skipped only when the UDF is already present, and any genuine registration failure now propagates immediately instead of surfacing later as a hard-to-diagnose SQL error.

3. **Strengthened tests.** `od_matrix_to_graph` gains coverage for the inclusive threshold boundary, self-loop toggling on the directed edgelist path, shared `gdf_to_nx` metadata on `as_nx` output, the geographic-CRS warning, NumPy adjacency alignment with `zone_id_col=None`, and empty `zones_gdf`. `travel_summary_graph` gains tests pinning the shared as_nx conventions, empty-edge as_nx output, a time-filtered directed as_nx combination without frequency expansion, an instant (equal start/end) time window, and the propagation of UDF registration failures.

4. **Fixed silent edge loss for geometryless edges in `gdf_to_nx`.** While adding the tests above, a latent defect surfaced: `od_matrix_to_graph(..., compute_edge_geometry=False, as_nx=True)` returned a graph with zero edges, because `gdf_to_nx` matches edge endpoints by geometry coordinates. Edge frames whose geometry column is entirely missing now bypass geometry validation and resolve endpoints from the `(source, target)` MultiIndex against node `_original_index` values, logging a warning for unmappable edges instead of dropping everything silently. Regression tests cover the mobility path and the converter directly.

## Related Issues

Fixes #205.

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
