### PR TITLE
Repair invalid buildings before tessellation

### DIFF
--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -19,7 +19,7 @@ Frame ownership and copying:
 Public input GeoDataFrames are never mutated. Caller-owned frames are copied at
 most once, at the public boundary: ``_prepare_morphology`` copies
 ``segments_gdf`` before assigning movement ids (and ``buildings_gdf`` only to
-flatten a MultiIndex), while ``segments_to_graph`` and
+repair invalid polygons or flatten a MultiIndex), while ``segments_to_graph`` and
 ``movement_to_movement_graph`` copy their input before writing to it. Frames
 created inside the pipeline (rename, filter, join, or concat products) are
 owned by the pipeline and may be mutated without further defensive copies.
@@ -627,9 +627,14 @@ def _prepare_morphology(  # noqa: PLR0913
         msg = "clipping_buffer must be greater than or equal to extent_buffer."
         raise ValueError(msg)
 
+    original_buildings = buildings_gdf
+    buildings_gdf = _repair_invalid_buildings(buildings_gdf)
+
     if isinstance(buildings_gdf.index, pd.MultiIndex):
-        # Copy guards the index write below on the caller's frame.
-        buildings_gdf = buildings_gdf.copy()
+        # Reuse the owned repair result when possible; otherwise copy before
+        # flattening so the caller's index remains unchanged.
+        if buildings_gdf is original_buildings:
+            buildings_gdf = buildings_gdf.copy()
         buildings_gdf.index = buildings_gdf.index.to_flat_index()
 
     # Ensure CRS consistency between buildings and segments
@@ -2218,6 +2223,45 @@ def _valid_polygon_gdf(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         valid_geom = valid_geom & out.geometry.geom_type.isin(["Polygon", "MultiPolygon"])
         out = out.loc[valid_geom]
     return out
+
+
+def _repair_invalid_buildings(buildings: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Repair invalid building polygons before any morphology computation.
+
+    A single self-intersecting footprint can make GEOS reject the complete
+    enclosed tessellation, causing every otherwise valid building in the unit
+    to degrade to a footprint fallback. Reuse the fallback path's polygon
+    validation here so the primary tessellation, reachability filters and
+    building joins all operate on the same repaired geometries.
+
+    Parameters
+    ----------
+    buildings : geopandas.GeoDataFrame
+        Caller-owned building footprints.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        The original frame when every footprint is usable, otherwise an owned
+        frame with invalid polygons repaired and irreparable rows removed.
+    """
+    unusable = buildings.geometry.isna() | buildings.geometry.is_empty
+    unusable |= ~buildings.geometry.is_valid
+    if not unusable.any():
+        return buildings
+
+    invalid_count = int(unusable.sum())
+    repaired = _valid_polygon_gdf(buildings)
+    dropped_count = len(buildings) - len(repaired)
+    repaired_count = invalid_count - dropped_count
+    logger.warning(
+        "Repaired %d invalid building geometries with a zero-width buffer; "
+        "dropped %d geometries that remained unusable.",
+        repaired_count,
+        dropped_count,
+    )
+    return repaired
 
 
 def _fallback_tessellation_without_enclosures(

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1787,6 +1787,54 @@ class TestIndividualGraphFunctions(TestMorphologyBase):
 class TestInputValidationAndErrors(TestMorphologyBase):
     """Comprehensive input validation and error handling tests."""
 
+    def test_invalid_building_is_repaired_before_enclosed_tessellation(
+        self,
+        sample_crs: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A malformed footprint must not degrade the whole unit to fallbacks."""
+        invalid = Polygon(
+            [(0, 0), (20, 0), (20, 20), (0, 20), (0, 0)],
+            holes=[[(8, -1), (12, -1), (12, 5), (8, 5), (8, -1)]],
+        )
+        buildings = gpd.GeoDataFrame(
+            {"building_name": ["invalid", "valid"]},
+            geometry=[
+                invalid,
+                Polygon([(30, 5), (40, 5), (40, 15), (30, 15), (30, 5)]),
+            ],
+            crs=sample_crs,
+        )
+        segments = gpd.GeoDataFrame(
+            geometry=[
+                LineString([(-10, -10), (60, -10)]),
+                LineString([(60, -10), (60, 40)]),
+                LineString([(60, 40), (-10, 40)]),
+                LineString([(-10, 40), (-10, -10)]),
+            ],
+            crs=sample_crs,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="city2graph.morphology"):
+            nodes, _ = morphological_graph(
+                buildings,
+                segments,
+                keep_buildings=True,
+                include_unenclosed_buildings=True,
+                tessellation_fallback=True,
+                tessellation_n_jobs=1,
+            )
+
+        places = nodes["place"]
+        place_ids = places["place_id"] if "place_id" in places else places.index.to_series()
+        assert not place_ids.astype(str).str.startswith("fallback_").any()
+        assert places.geometry.is_valid.all()
+        assert set(places["building_name"].dropna()) == {"invalid", "valid"}
+        assert not buildings.geometry.is_valid.iloc[0]
+        assert buildings.geometry.iloc[0].equals_exact(invalid, tolerance=0)
+        assert "Repaired 1 invalid building geometries" in caplog.text
+        assert "dropped 0 geometries" in caplog.text
+
     def test_geometry_type_validation(self, sample_crs: str) -> None:
         """Test geometry type validation for buildings and segments."""
         # Test invalid building geometry types


### PR DESCRIPTION
## Description

Repair invalid building footprints before morphology tessellation begins.

Previously, an invalid or empty building geometry could reach the enclosed tessellation unchanged. GEOS could then reject the entire tessellation unit, causing otherwise valid buildings to degrade to footprint fallback cells. This change reuses the existing polygon-validation path at the public morphology boundary so tessellation, reachability filtering, and building joins all operate on the same repaired geometries. It preserves caller-owned inputs, logs repaired and dropped geometry counts, and avoids an unnecessary copy when all footprints are already usable.

A regression test covers a self-intersecting building alongside a valid building. It verifies that both remain in the enclosed tessellation, outputs are valid, no fallback IDs are introduced, the input frame is unchanged, and repair statistics are logged.

## Related Issues

None.

## Checklist

- [x] I have read the [Contributing Guide](https.city2graph.net/contributing.html).
- [x] I have updated the documentation, if necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Pre-commit checks passed locally.
