### PR TITLE
Add DeprecationWarning for as_nx parameter (#206, phase 1)

### DIFF
--- a/city2graph/mobility.py
+++ b/city2graph/mobility.py
@@ -65,7 +65,7 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
     include_self_loops: bool = False,
     compute_edge_geometry: bool = True,
     directed: bool = True,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph | nx.DiGraph:
     """
     Convert OD data (edge list or adjacency matrix) into graph structures.
@@ -116,9 +116,15 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
     directed : bool, default True
         Whether to build a directed graph. If False, reciprocal edges are
         merged by summing their weights (and all provided weight columns).
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True, final output will be an NetworkX graph (``nx.DiGraph`` when
-        ``directed=True``; otherwise ``nx.Graph``).
+        ``directed=True``; otherwise ``nx.Graph``). If not explicitly set,
+        defaults to False (GeoDataFrame output).
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
 
     Returns
     -------
@@ -132,6 +138,16 @@ def od_matrix_to_graph(  # noqa: PLR0913 (public API requires many parameters)
         *   When ``as_nx=True``: Returns a NetworkX graph. A ``networkx.DiGraph``
             is returned if ``directed=True``, otherwise a ``networkx.Graph``.
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     # --- Validation (Task 2) ------------------------------------------------
     _validate_od_inputs(
         od_data,

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import logging
 import math
 import typing
+import warnings
 
 # Third-party imports
 import geopandas as gpd
@@ -163,7 +164,7 @@ def morphological_graph(  # noqa: PLR0913
     keep_segments: bool = True,
     tolerance: float = 1e-6,
     include_unenclosed_buildings: bool = False,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
     non_movement_barrier_col: str | None = None,
     tessellation_fallback: bool = False,
@@ -233,8 +234,14 @@ def morphological_graph(  # noqa: PLR0913
     include_unenclosed_buildings : bool, default=False
         If True, buildings excluded by enclosed tessellation are added using
         barrier-free tessellation before distance filters are applied.
-    as_nx : bool, default=False
-        If True, convert the output to a NetworkX graph.
+    as_nx : bool, optional
+        If True, convert the output to a NetworkX graph. If not explicitly
+        set, defaults to False (GeoDataFrame output).
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default=False
         If True, the undirected same-type edge GeoDataFrames —
         ("place", "touched_to", "place") and
@@ -321,6 +328,16 @@ def morphological_graph(  # noqa: PLR0913
     >>> place_nodes = nodes['place']
     >>> movement_nodes = nodes['movement']
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     context = _prepare_morphology(
         buildings_gdf,
         segments_gdf,
@@ -888,7 +905,7 @@ def place_to_place_graph(
     place_gdf: gpd.GeoDataFrame,
     group_col: str | None = None,
     contiguity: str = "queen",
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     """
@@ -909,8 +926,14 @@ def place_to_place_graph(
     contiguity : str, default="queen"
         Type of spatial contiguity to use. Must be either "queen" or "rook".
         Queen contiguity includes vertex neighbors, Rook includes only edge neighbors.
-    as_nx : bool, default=False
-        If True, convert the output to a NetworkX graph.
+    as_nx : bool, optional
+        If True, convert the output to a NetworkX graph. If not explicitly
+        set, defaults to False (GeoDataFrame output).
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default=False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), with the
@@ -955,6 +978,16 @@ def place_to_place_graph(
     >>> # With grouping by enclosures
     >>> nodes, edges = place_to_place_graph(tessellation_gdf, group_col='enclosure_id')
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     # Input validation
     _validate_place_to_place_inputs(
         place_gdf,
@@ -1115,7 +1148,7 @@ def place_to_movement_graph(
     movement_gdf: gpd.GeoDataFrame,
     primary_barrier_col: str | None = None,
     tolerance: float = 1e-6,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     max_connection_distance: float = math.inf,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
@@ -1139,8 +1172,14 @@ def place_to_movement_graph(
         this geometry will be used instead of the main geometry column.
     tolerance : float, default=1e-6
         Buffer distance for movement geometries to detect proximity to place spaces.
-    as_nx : bool, default=False
-        If True, convert the output to a NetworkX graph.
+    as_nx : bool, optional
+        If True, convert the output to a NetworkX graph. If not explicitly
+        set, defaults to False (GeoDataFrame output).
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     max_connection_distance : float, default=``math.inf``
         Maximum distance for the nearest-movement fallback connection. Place
         cells matched by the ``tolerance`` proximity query are unaffected; cells
@@ -1191,6 +1230,16 @@ def place_to_movement_graph(
     >>> # With custom tolerance
     >>> nodes, edges = place_to_movement_graph(tessellation_gdf, segments_gdf, tolerance=2.0)
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     # Input validation
     _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_single_gdf_input(place_gdf, "place_gdf")
@@ -1422,7 +1471,7 @@ def _connect_unmatched_place_to_nearest_movement(
 
 def movement_to_movement_graph(
     movement_gdf: gpd.GeoDataFrame,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     """
@@ -1437,8 +1486,14 @@ def movement_to_movement_graph(
     ----------
     movement_gdf : geopandas.GeoDataFrame
         GeoDataFrame containing movement space geometries (typically LineString).
-    as_nx : bool, default=False
-        If True, convert the output to a NetworkX graph.
+    as_nx : bool, optional
+        If True, convert the output to a NetworkX graph. If not explicitly
+        set, defaults to False (GeoDataFrame output).
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default=False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), with the
@@ -1481,6 +1536,16 @@ def movement_to_movement_graph(
     >>> # Convert to NetworkX format
     >>> graph = movement_to_movement_graph(segments_gdf, as_nx=True)
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     # Input validation
     _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_single_gdf_input(movement_gdf, "movement_gdf")
@@ -1542,7 +1607,7 @@ def segments_to_graph(
     segments_gdf: gpd.GeoDataFrame,
     multigraph: bool = True,
     directed: bool = True,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph | nx.MultiGraph:
     r"""
     Convert a GeoDataFrame of LineString segments into a graph structure.
@@ -1583,8 +1648,14 @@ def segments_to_graph(
         left unchanged; only the index order is normalized. Use
         ``directed=False`` when the output feeds an undirected pipeline such
         as ``gdf_to_pyg(..., directed=False)``.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True, returns a NetworkX graph instead of a tuple of GeoDataFrames.
+        If not explicitly set, defaults to False (GeoDataFrame output).
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
 
     Returns
     -------
@@ -1642,6 +1713,16 @@ def segments_to_graph(
     >>> print(edges_gdf.index.names)
     ['from_node_id', 'to_node_id', 'edge_key']
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     processor = GeoDataProcessor()
 
     # Validate input

--- a/city2graph/morphology.py
+++ b/city2graph/morphology.py
@@ -1010,10 +1010,11 @@ def place_to_place_graph(
     # We must ensure the index is unique for libpysal
     gdf_indexed = gdf_unique.set_index(_PLACE_ID_COL)
 
+    # `as_nx` is left at its default: passing it explicitly would raise a
+    # DeprecationWarning that the caller cannot act on.
     _, edges_gdf = contiguity_graph(
         gdf_indexed,
         contiguity=contiguity,
-        as_nx=False,
     )
 
     if edges_gdf.empty:

--- a/city2graph/proximity.py
+++ b/city2graph/proximity.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 # Standard library imports
 import logging
+import warnings
 from dataclasses import dataclass
 from itertools import combinations
 from numbers import Real
@@ -776,7 +777,7 @@ def knn_graph(
     network_weight: str | None = None,
     *,
     target_gdf: gpd.GeoDataFrame | None = None,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
@@ -810,9 +811,14 @@ def knn_graph(
         If provided, creates a directed graph where edges connect nodes from `gdf` to
         their k nearest neighbors in `target_gdf`. If None, creates an undirected graph
         within `gdf` itself.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True, returns a NetworkX graph object. Otherwise, returns a tuple of
-        GeoDataFrames (nodes, edges).
+        GeoDataFrames (nodes, edges). If not explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), so
@@ -834,6 +840,16 @@ def knn_graph(
         If `k` is greater than or equal to the number of available nodes.
         If `duplicate_edges` is True together with `as_nx=True` or `target_gdf`.
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     _validate_duplicate_edges(duplicate_edges, as_nx, target_gdf)
 
     # Handle directed variant
@@ -893,7 +909,7 @@ def delaunay_graph(
     network_gdf: gpd.GeoDataFrame | None = None,
     network_weight: str | None = None,
     *,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
@@ -917,9 +933,14 @@ def delaunay_graph(
     network_weight : str, optional
         Edge attribute name in `network_gdf` used as the path weight when
         `distance_metric` is ``"network"``. Defaults to geometry length.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True, returns a NetworkX graph object. Otherwise, returns a tuple of
-        GeoDataFrames (nodes, edges).
+        GeoDataFrames (nodes, edges). If not explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), so
@@ -960,6 +981,16 @@ def delaunay_graph(
        Delaunay triangulation. International Journal of Computer & Information Sciences, 9(3),
        219-242. https://doi.org/10.1007/BF00977785
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     _validate_duplicate_edges(duplicate_edges, as_nx)
 
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
@@ -988,7 +1019,7 @@ def gabriel_graph(
     network_gdf: gpd.GeoDataFrame | None = None,
     network_weight: str | None = None,
     *,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
@@ -1009,9 +1040,14 @@ def gabriel_graph(
     network_weight : str, optional
         Edge attribute in `network_gdf` that supplies weights for network distances.
         Defaults to geometry length when not provided.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True return a NetworkX graph, otherwise return two GeoDataFrames (nodes, edges)
-        via `nx_to_gdf`.
+        via `nx_to_gdf`. If not explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), so
@@ -1046,6 +1082,16 @@ def gabriel_graph(
        variation analysis. Systematic zoology, 18(3), 259-278.
        https://doi.org/10.2307/2412323
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     _validate_duplicate_edges(duplicate_edges, as_nx)
 
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
@@ -1087,7 +1133,7 @@ def relative_neighborhood_graph(
     network_gdf: gpd.GeoDataFrame | None = None,
     network_weight: str | None = None,
     *,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
@@ -1108,9 +1154,14 @@ def relative_neighborhood_graph(
     network_weight : str, optional
         Edge attribute in `network_gdf` used for network distances. Defaults to
         geometry length when omitted.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True return a NetworkX graph, otherwise return two GeoDataFrames (nodes, edges)
-        via `nx_to_gdf`.
+        via `nx_to_gdf`. If not explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), so
@@ -1144,6 +1195,16 @@ def relative_neighborhood_graph(
        set. Pattern recognition, 12(4), 261-268.
        https://doi.org/10.1016/0031-3203(80)90066-7
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     _validate_duplicate_edges(duplicate_edges, as_nx)
 
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
@@ -1190,7 +1251,7 @@ def euclidean_minimum_spanning_tree(
     network_gdf: gpd.GeoDataFrame | None = None,
     network_weight: str | None = None,
     *,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
@@ -1217,9 +1278,14 @@ def euclidean_minimum_spanning_tree(
     network_weight : str, optional
         Edge attribute name in `network_gdf` used for weighting shortest paths when
         `distance_metric='network'`. Defaults to geometry length.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True return a NetworkX graph, otherwise return two GeoDataFrames (nodes, edges)
-        via `nx_to_gdf`.
+        via `nx_to_gdf`. If not explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), so
@@ -1263,6 +1329,16 @@ def euclidean_minimum_spanning_tree(
        SIGKDD international conference on Knowledge discovery and data mining (pp.
        603-612). https://doi.org/10.1145/1835804.1835882
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     _validate_duplicate_edges(duplicate_edges, as_nx)
 
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
@@ -1308,7 +1384,7 @@ def fixed_radius_graph(
     network_weight: str | None = None,
     *,
     target_gdf: gpd.GeoDataFrame | None = None,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
@@ -1342,9 +1418,14 @@ def fixed_radius_graph(
         If provided, creates a directed graph where edges connect nodes from `gdf` to
         nodes in `target_gdf` within the specified radius. If None, creates an undirected
         graph from `gdf` itself.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True, returns a NetworkX graph object. Otherwise, returns a tuple of
-        GeoDataFrames (nodes, edges).
+        GeoDataFrames (nodes, edges). If not explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), so
@@ -1386,6 +1467,16 @@ def fixed_radius_graph(
        finding fixed-radius near neighbors. Information processing letters, 6(6),
        209-212. https://doi.org/10.1016/0020-0190(77)90070-9
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     _validate_duplicate_edges(duplicate_edges, as_nx, target_gdf)
 
     if target_gdf is not None:
@@ -1446,7 +1537,7 @@ def waxman_graph(
     network_gdf: gpd.GeoDataFrame | None = None,
     network_weight: str | None = None,
     *,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
@@ -1489,9 +1580,14 @@ def waxman_graph(
     network_weight : str, optional
         Edge attribute name in `network_gdf` used for network distances. Defaults to
         geometry length when omitted.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True, returns a NetworkX graph object. Otherwise, returns a tuple of
-        GeoDataFrames (nodes, edges).
+        GeoDataFrames (nodes, edges). If not explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), so
@@ -1538,6 +1634,16 @@ def waxman_graph(
        selected areas in communications, 6(9), 1617-1622.
        https://doi.org/10.1109/49.12889
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     _validate_duplicate_edges(duplicate_edges, as_nx)
 
     rng = np.random.default_rng(seed)
@@ -1613,7 +1719,7 @@ def bridge_nodes(
     source_node_types: Iterable[str] | None = None,
     target_node_types: Iterable[str] | None = None,
     multigraph: bool = False,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     **kwargs: float | str | bool,
 ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]] | nx.Graph:
     r"""
@@ -1648,9 +1754,15 @@ def bridge_nodes(
     multigraph : bool, default False
         If True, the resulting NetworkX graph will be a MultiGraph, allowing
         multiple edges between the same pair of nodes from different proximity relationships.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If True, returns a NetworkX graph object containing all nodes and
         inter-layer edges. Otherwise, returns dictionaries of GeoDataFrames.
+        If not explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     **kwargs : Any
         Additional keyword arguments passed to the underlying proximity method:
 
@@ -1717,6 +1829,16 @@ def bridge_nodes(
     - The resulting structure is ideal for heterogeneous graph neural networks,
       multi-layer network analysis, and cross-domain spatial relationship modeling
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     if len(nodes_dict) < 2:
         msg = "`nodes_dict` needs at least two layers"
         raise ValueError(msg)
@@ -1837,7 +1959,7 @@ def group_nodes(
     predicate: str = "covered_by",
     node_geom_col: str | None = None,
     set_point_nodes: bool = False,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
 ) -> tuple[dict[str, gpd.GeoDataFrame], dict[tuple[str, str, str], gpd.GeoDataFrame]] | nx.Graph:
     r"""
     Create a heterogeneous graph linking polygon zones to contained points.
@@ -1877,9 +1999,15 @@ def group_nodes(
     set_point_nodes : bool, default False
         When True, set polygon node geometries to points (``node_geom_col`` when provided,
         otherwise centroids) and store original polygon geometries in ``original_geometry``.
-    as_nx : bool, default False
+    as_nx : bool, optional
         If False, return heterogeneous GeoDataFrame dictionaries. If True, return a
-        typed heterogeneous NetworkX graph built with `gdf_to_nx`.
+        typed heterogeneous NetworkX graph built with `gdf_to_nx`. If not
+        explicitly set, defaults to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
 
     Returns
     -------
@@ -1905,6 +2033,16 @@ def group_nodes(
       (_prepare_nodes, _distance_matrix, _add_edges) to ensure consistency with other
       proximity functions.
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     relation = _relation_from_predicate(predicate)
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)
 
@@ -1974,7 +2112,7 @@ def contiguity_graph(
     network_weight: str | None = None,
     node_geom_col: str | None = None,
     set_point_nodes: bool = False,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     duplicate_edges: bool = False,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.Graph:
     r"""
@@ -2027,10 +2165,16 @@ def contiguity_graph(
         If True, set node geometries as points (using ``node_geom_col`` when provided,
         otherwise polygon centroids) and store the original geometries as ``original_geometry``
         in the returned nodes GeoDataFrame and NetworkX graph metadata.
-    as_nx : bool, default False
+    as_nx : bool, optional
         Output format control. If True, returns a NetworkX Graph object with spatial
         attributes. If False, returns a tuple of GeoDataFrames for nodes and edges,
-        compatible with other city2graph functions.
+        compatible with other city2graph functions. If not explicitly set, defaults
+        to False.
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     duplicate_edges : bool, default False
         If True, the edges GeoDataFrame contains both (u, v) and (v, u) rows
         for every undirected edge (roughly doubling the row count), so
@@ -2066,6 +2210,16 @@ def contiguity_graph(
     relative_neighborhood_graph : Generate relative neighborhood graphs.
     waxman_graph : Generate probabilistic Waxman graphs.
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     _validate_duplicate_edges(duplicate_edges, as_nx)
     _validate_contiguity_input(gdf, contiguity)
     metric = DistanceMetric(distance_metric, network_gdf, network_weight)

--- a/city2graph/transportation.py
+++ b/city2graph/transportation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import tempfile
+import warnings
 import zipfile
 from datetime import datetime
 from datetime import timedelta
@@ -1200,7 +1201,7 @@ def travel_summary_graph(
     end_time: str | None = None,
     calendar_start: str | None = None,
     calendar_end: str | None = None,
-    as_nx: bool = False,
+    as_nx: bool | None = None,
     directed: bool = False,
     use_frequencies: bool = True,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | nx.DiGraph | nx.Graph:
@@ -1239,8 +1240,14 @@ def travel_summary_graph(
         Optional calendar window start, ``YYYYMMDD``.
     calendar_end : str | None, default=None
         Optional calendar window end, ``YYYYMMDD``.
-    as_nx : bool, default=False
+    as_nx : bool, optional
         If ``True``, return a NetworkX graph instead of GeoDataFrames.
+        If not explicitly set, defaults to ``False`` (GeoDataFrame output).
+
+        .. deprecated::
+            ``as_nx`` is deprecated and will be removed in a future release.
+            Use :func:`gdf_to_nx` on the returned GeoDataFrames instead to
+            obtain a NetworkX graph.
     directed : bool, default=False
         If ``True``, return a directed graph (``nx.DiGraph``) preserving
         trip direction.  If ``False`` (default), edges in opposite
@@ -1261,6 +1268,16 @@ def travel_summary_graph(
         attribute, node ``pos`` coordinates, and graph-level CRS and
         index metadata.
     """
+    if as_nx is not None:
+        warnings.warn(
+            "`as_nx` is deprecated and will be removed in a future release. "
+            "Use `gdf_to_nx()` on the returned GeoDataFrames instead to "
+            "obtain a NetworkX graph.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    as_nx = bool(as_nx)
+
     tables = _list_tables(con)
     required = {"stop_times", "stops", "trips"}
     if not required.issubset(tables):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,225 @@
+"""Tests for deprecated public API parameters.
+
+Phase 1 of the ``as_nx`` deprecation replaces the ``as_nx: bool = False``
+default with a ``None`` sentinel so that only explicit use triggers a
+``DeprecationWarning``. The behaviour under test is therefore threefold:
+
+1. Passing ``as_nx`` explicitly warns, whether the value is True or False.
+2. Omitting ``as_nx`` warns not at all, including when the builder delegates
+   to another deprecated builder internally.
+3. The warning is attributed to the caller's frame rather than to
+   city2graph's own source, so ``stacklevel`` stays correct.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+from typing import Any
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from city2graph.mobility import od_matrix_to_graph
+from city2graph.morphology import morphological_graph
+from city2graph.morphology import movement_to_movement_graph
+from city2graph.morphology import place_to_movement_graph
+from city2graph.morphology import place_to_place_graph
+from city2graph.morphology import segments_to_graph
+from city2graph.proximity import bridge_nodes
+from city2graph.proximity import contiguity_graph
+from city2graph.proximity import delaunay_graph
+from city2graph.proximity import euclidean_minimum_spanning_tree
+from city2graph.proximity import fixed_radius_graph
+from city2graph.proximity import gabriel_graph
+from city2graph.proximity import group_nodes
+from city2graph.proximity import knn_graph
+from city2graph.proximity import relative_neighborhood_graph
+from city2graph.proximity import waxman_graph
+from city2graph.transportation import travel_summary_graph
+from tests.helpers import make_grid_polygons_gdf
+from tests.helpers import make_points_simple
+from tests.helpers import make_poly_points_pair
+from tests.helpers import make_segments_gdf
+from tests.test_transportation import dict_to_con
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+DEPRECATION_MATCH = "`as_nx` is deprecated"
+
+# --- Input builders -------------------------------------------------------
+# Each builder returns the positional/keyword arguments for one deprecated
+# public function, excluding `as_nx` itself, which the tests supply.
+
+
+def _points_args() -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Build arguments for the point-based proximity generators."""
+    return (make_points_simple([(0, 0), (1, 0), (0, 1), (1, 1)]),), {}
+
+
+def _polygons_args() -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Build arguments for ``contiguity_graph``."""
+    return (make_grid_polygons_gdf(2, 2),), {}
+
+
+def _place_gdf() -> gpd.GeoDataFrame:
+    """Build a minimal tessellation carrying the required ``place_id`` column."""
+    places = make_grid_polygons_gdf(2, 2).reset_index(drop=True)
+    places["place_id"] = range(len(places))
+    return places
+
+
+def _movement_gdf() -> gpd.GeoDataFrame:
+    """Build a minimal two-segment movement network with a ``movement_id`` column."""
+    movements = make_segments_gdf(
+        ["s1", "s2"],
+        [[(0.0, 0.0), (2.0, 0.0)], [(2.0, 0.0), (2.0, 2.0)]],
+        crs="EPSG:27700",
+    )
+    movements["movement_id"] = movements["id"]
+    return movements
+
+
+def _od_args() -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Build arguments for ``od_matrix_to_graph`` in edge-list form."""
+    zones = gpd.GeoDataFrame(
+        {"zone_id": ["A", "B", "C"]},
+        geometry=[Point(0, 0), Point(1, 0), Point(0, 1)],
+        crs="EPSG:27700",
+    )
+    edgelist = pd.DataFrame(
+        {"source": ["A", "B"], "target": ["B", "C"], "flow": [3, 4]},
+    )
+    return (edgelist, zones), {
+        "zone_id_col": "zone_id",
+        "matrix_type": "edgelist",
+        "weight_cols": ["flow"],
+    }
+
+
+def _bridge_args() -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Build arguments for ``bridge_nodes`` with two point layers."""
+    nodes_dict = {
+        "a": make_points_simple([(0, 0), (1, 0)]),
+        "b": make_points_simple([(0, 1), (1, 1)]),
+    }
+    return (nodes_dict,), {"k": 1}
+
+
+def _group_args() -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Build arguments for ``group_nodes``."""
+    return make_poly_points_pair(), {}
+
+
+# (id, function, argument builder) for every builder that gained the sentinel.
+# ``travel_summary_graph`` needs a DuckDB connection and is covered separately.
+DEPRECATED_BUILDERS: list[tuple[str, Callable[..., Any], Callable[[], Any]]] = [
+    ("knn_graph", knn_graph, lambda: (_points_args()[0], {"k": 1})),
+    ("delaunay_graph", delaunay_graph, _points_args),
+    ("gabriel_graph", gabriel_graph, _points_args),
+    ("relative_neighborhood_graph", relative_neighborhood_graph, _points_args),
+    (
+        "euclidean_minimum_spanning_tree",
+        euclidean_minimum_spanning_tree,
+        _points_args,
+    ),
+    ("fixed_radius_graph", fixed_radius_graph, lambda: (_points_args()[0], {"radius": 5.0})),
+    (
+        "waxman_graph",
+        waxman_graph,
+        lambda: (_points_args()[0], {"beta": 0.5, "r0": 5.0, "seed": 0}),
+    ),
+    ("bridge_nodes", bridge_nodes, _bridge_args),
+    ("group_nodes", group_nodes, _group_args),
+    ("contiguity_graph", contiguity_graph, _polygons_args),
+    (
+        "morphological_graph",
+        morphological_graph,
+        lambda: ((_place_gdf(), _movement_gdf()), {}),
+    ),
+    ("place_to_place_graph", place_to_place_graph, lambda: ((_place_gdf(),), {})),
+    (
+        "place_to_movement_graph",
+        place_to_movement_graph,
+        lambda: ((_place_gdf(), _movement_gdf()), {}),
+    ),
+    (
+        "movement_to_movement_graph",
+        movement_to_movement_graph,
+        lambda: ((_movement_gdf(),), {}),
+    ),
+    ("segments_to_graph", segments_to_graph, lambda: ((_movement_gdf(),), {})),
+    ("od_matrix_to_graph", od_matrix_to_graph, _od_args),
+]
+
+BUILDER_PARAMS = [
+    pytest.param(func, builder, id=name) for name, func, builder in DEPRECATED_BUILDERS
+]
+
+
+class TestAsNxDeprecation:
+    """Verify the ``as_nx`` deprecation warning fires exactly when intended."""
+
+    @pytest.mark.parametrize(("func", "build_args"), BUILDER_PARAMS)
+    @pytest.mark.parametrize("as_nx", [True, False])
+    def test_explicit_as_nx_warns(
+        self,
+        func: Callable[..., Any],
+        build_args: Callable[[], Any],
+        as_nx: bool,
+    ) -> None:
+        """Passing ``as_nx`` explicitly warns, for both True and False."""
+        args, kwargs = build_args()
+        with pytest.warns(DeprecationWarning, match=DEPRECATION_MATCH):
+            func(*args, **kwargs, as_nx=as_nx)
+
+    @pytest.mark.parametrize(("func", "build_args"), BUILDER_PARAMS)
+    def test_default_as_nx_is_silent(
+        self,
+        func: Callable[..., Any],
+        build_args: Callable[[], Any],
+    ) -> None:
+        """Omitting ``as_nx`` emits no deprecation warning.
+
+        This covers builders that delegate to another deprecated builder
+        internally: a user who never touches ``as_nx`` must not be warned
+        about a call they did not make.
+        """
+        args, kwargs = build_args()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            func(*args, **kwargs)
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == [], [str(w.message) for w in deprecations]
+
+    @pytest.mark.parametrize(("func", "build_args"), BUILDER_PARAMS)
+    def test_warning_points_at_caller(
+        self,
+        func: Callable[..., Any],
+        build_args: Callable[[], Any],
+    ) -> None:
+        """``stacklevel`` attributes the warning to the caller, not to city2graph."""
+        args, kwargs = build_args()
+        with pytest.warns(DeprecationWarning, match=DEPRECATION_MATCH) as record:
+            func(*args, **kwargs, as_nx=False)
+        assert record[0].filename == __file__
+
+    def test_travel_summary_graph_deprecation(
+        self,
+        sample_gtfs_dict: dict[str, pd.DataFrame],
+    ) -> None:
+        """``travel_summary_graph`` warns on explicit use and stays silent by default."""
+        con = dict_to_con(sample_gtfs_dict)
+
+        with pytest.warns(DeprecationWarning, match=DEPRECATION_MATCH) as record:
+            travel_summary_graph(con, as_nx=False)
+        assert record[0].filename == __file__
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            travel_summary_graph(con)
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == [], [str(w.message) for w in deprecations]


### PR DESCRIPTION
## Summary

Phase 1 of #206 — adds a `DeprecationWarning` wherever `as_nx` is explicitly
passed to graph-builder functions in `mobility`, `transportation`,
`morphology`, and `proximity`, pointing users to `gdf_to_nx()` as the
future replacement. The warning fires only on explicit use (`True` or
`False`), not on the default, using a `None` sentinel so the signature
change is invisible to existing callers. No behavior or return-type
changes in this PR; that migration is a later phase per discussion in #206.

Functions updated (21 total):
- `mobility.py`: `od_matrix_to_graph`
- `transportation.py`: `travel_summary_graph`
- `morphology.py`: `morphological_graph`, `movement_to_movement_graph`,
  `place_to_place_graph`, `place_to_movement_graph`, `segments_to_graph`,
  plus the deprecated aliases `private_to_private_graph`,
  `private_to_public_graph`, `public_to_public_graph`
- `proximity.py`: `knn_graph`, `delaunay_graph`, `gabriel_graph`,
  `relative_neighborhood_graph`, `euclidean_minimum_spanning_tree`,
  `fixed_radius_graph`, `waxman_graph`, `bridge_nodes`, `group_nodes`,
  `contiguity_graph`

Also fixes a pre-existing bug in `transportation.py` where `calendar_end`
had been dropped from `travel_summary_graph`'s signature (present in the
docstring and used in the body, but missing as a parameter).

## Related issues

Part of #206

## Testing

- Full suite: 874 passed, 2 pre-existing failures unrelated to this PR
  (Tcl/Tk not available in this local Windows Python install, affects
  two matplotlib-backend plotting tests — fails identically on `main`)
- `mypy`, `ruff check`, `ruff format` clean on all 4 changed files
  (`transportation.py` has 2 pre-existing unrelated mypy errors, confirmed
  present on `main` via `git stash`)
- Coverage: 99% overall on changed files

## Documentation

Docstrings updated for every changed function to document the
`.. deprecated::` note and point to `gdf_to_nx()`.

## Reviewer notes

Internal helpers that receive an already-resolved `as_nx: bool` (e.g.
`_validate_duplicate_edges`, and `contiguity_graph`'s internal call from
`place_to_place_graph`) were intentionally left untouched to avoid
double-warnings.