### PR TITLE
load_gtfs: parse the GTFS CSV dialect explicitly instead of auto-detecting it

### DIFF
--- a/city2graph/transportation.py
+++ b/city2graph/transportation.py
@@ -548,7 +548,14 @@ def load_gtfs(path: str | Path) -> duckdb.DuckDBPyConnection:
                     zf.extract(name, tmp_dir)
                     table_name = name.rsplit("/", 1)[-1].replace(".txt", "")
                     file_path = str(Path(tmp_dir) / name)
-                    con.read_csv(file_path, all_varchar=True, auto_detect=True).create(table_name)
+                    con.read_csv(
+                        file_path,
+                        all_varchar=True,
+                        header=True,
+                        delimiter=",",
+                        strict_mode=False,
+                        null_padding=True,
+                    ).create(table_name)
     except (OSError, zipfile.BadZipFile, duckdb.Error):
         logger.exception("Failed to read GTFS archive at %s", path)
         return con

--- a/tests/test_load_gtfs_ragged.py
+++ b/tests/test_load_gtfs_ragged.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from city2graph.transportation import load_gtfs
+
+_STOP_TIMES = (
+    "trip_id,arrival_time,departure_time,stop_id,stop_sequence,"
+    "stop_headsign,pickup_type,drop_off_time,shape_dist_traveled\n"
+    "T1,6:00:00,6:00:00,S1,1\n"
+    "T1,6:10:00,6:10:00,S2,2\n"
+    "T2,7:00:00,7:00:00,S1,1,Airport,0,7:00:00,0\n"
+    "T2,7:15:00,7:15:00,S2,2,Airport,0,7:15:00,1200\n"
+)
+_STOPS = "stop_id,stop_name,stop_lat,stop_lon\nS1,First,36.9,-116.7\nS2,Second,36.9,-116.8\n"
+
+
+def test_load_gtfs_parses_rows_with_omitted_optional_fields(tmp_path: Path) -> None:
+    feed = tmp_path / "ragged.zip"
+    with zipfile.ZipFile(feed, "w") as z:
+        z.writestr("stop_times.txt", _STOP_TIMES)
+        z.writestr("stops.txt", _STOPS)
+
+    con = load_gtfs(str(feed))
+    cols = [r[0] for r in con.execute("DESCRIBE stop_times").fetchall()]
+
+    assert len(cols) == 9, f"stop_times mis-parsed into {len(cols)} column(s): {cols[0][:60]!r}"
+    assert "stop_sequence" in cols
+    assert con.execute("SELECT count(*) FROM stop_times").fetchone()[0] == 4


### PR DESCRIPTION
## Summary
`load_gtfs` reads each GTFS file with `con.read_csv(..., auto_detect=True)`. On feeds where some rows omit trailing optional fields — permitted by the GTFS specification — recent DuckDB releases cannot infer a dialect and load the whole file into a single VARCHAR column. Every later reference to a real column (`stop_id`, `stop_sequence`) then raises a `BinderException`, so `get_od_pairs` and `travel_summary_graph` fail on such feeds.

## Reproduction
The reference Google `sample-feed.zip` triggers it. Its `stop_times.txt` holds 15 rows with all nine columns and 13 rows with only five, because the optional `stop_headsign`, `pickup_type`, `drop_off_time` and `shape_dist_traveled` fields are omitted. On DuckDB 1.5.5, `DESCRIBE stop_times` returns a single column whose name is the entire comma-joined header, and `travel_summary_graph(con, ...)` raises `BinderException: Referenced column "stop_sequence" not found`.

## Root cause
DuckDB's CSV sniffer tightened across the 1.x series. Given rows whose field counts differ from the header, it no longer settles on a delimiter and falls back to a single-column read. GTFS does not need sniffing: the format fixes the dialect (comma-delimited, one header row, optional fields omittable), so detecting it is unnecessary and, on ragged feeds, wrong.

## Fix
Parse the GTFS dialect explicitly and tolerate omitted optional fields. `null_padding` fills them with NULL; `strict_mode=False` accepts the short rows.

## Why the suite missed it
The `load_gtfs` fixtures use uniform, fully-populated rows, so auto-detection succeeds on them, and `test_load_gtfs_basic` asserts only that the expected tables exist, not that their columns split. The `get_od_pairs` and `travel_summary_graph` tests build their connection from in-memory frames via `dict_to_con`, bypassing the CSV path.

## Tests
Adds a regression test that builds a feed with rows omitting optional fields and asserts `stop_times` parses into its nine columns. It fails on `main` and passes with the fix. The existing `tests/test_transportation.py` suite continues to pass.
