### PR TITLE
Cut edge types before the isochrone reachability search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 
+## 1.0.1 (2026-08-24)
+
+### Fixed
+- Fixed `create_isochrone()` applying `cut_edge_types` after the reachability search instead of before it. The cut edges were still traversed, so nodes reachable only through them remained inside the isochrone and only the cut edge geometries were dropped from the resulting polygon; with the hull-based methods, which build the polygon from node coordinates alone, the parameter had no effect at all. The listed edge types are now removed before the shortest-path computation, so `cut_edge_types=[t]` produces the same isochrone as never supplying `t` in `edges`. Results obtained with `cut_edge_types` on earlier versions will change: cutting a transit edge type now yields the area reachable without transit rather than the transit-assisted area with the transit lines erased.
+- Fixed `cut_edge_types` removing the wrong edge on multigraphs. Parallel edges between the same node pair were collected as `(u, v)` pairs, and NetworkX removes an arbitrary parallel edge for such a pair, so a walking edge could be removed in place of the transit edge running alongside it. Parallel edges are now matched by key.
+
+### Documentation
+- Documented that `cut_edge_types` removes edges before the reachability search, and that nodes reachable only through those edges therefore fall outside the isochrone.
+- Removed `cut_edge_types` from the walk-plus-transit isochrone cell of the GTFS example notebook. The cell computes a multimodal isochrone but cut the transit edge type, which had no effect on its `concave_hull_knn` output before this release and would now remove the transit reach that the section exists to show.
+- Updated release metadata for `v1.0.1`.
+
+
 ## 1.0.0 (2026-07-31)
 
 First stable release. The public API is now considered settled and will follow

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/c2g-dev/city2graph"
 url: "https://city2graph.net"
 license: BSD-3-Clause
-version: 1.0.0
-date-released: "2026-07-31"
+version: 1.0.1
+date-released: "2026-08-24"
 identifiers:
   - type: doi
     value: "https://doi.org/10.1016/j.compenvurbsys.2026.102492"

--- a/city2graph/utils/spatial.py
+++ b/city2graph/utils/spatial.py
@@ -198,8 +198,10 @@ def create_isochrone(
         The edge attribute to use for distance calculation (e.g., 'length',
         'travel_time'). If None, the function will use the default edge attribute.
     cut_edge_types : list[tuple[str, str, str]] | None, default None
-        List of edge types to remove from the graph before processing (e.g.,
-        [("bus_stop", "is_next_to", "bus_stop")]).
+        List of edge types to remove from the graph before the reachability
+        search (e.g., [("bus_stop", "is_next_to", "bus_stop")]). Because the
+        edges are removed first, they cannot be traversed at all, so nodes that
+        are only reachable through them fall outside the isochrone.
     method : str, default "concave_hull_knn"
         The method to generate the isochrone polygon. Options are:
 
@@ -264,6 +266,10 @@ def create_isochrone(
     nx_graph = _prepare_isochrone_graph(graph, nodes, edges, edge_attr)
     crs = nx_graph.graph.get("crs")
 
+    # Cut edge types before traversal so they cannot be used to reach further nodes
+    if cut_edge_types:
+        nx_graph = _filter_edges_by_type(nx_graph, cut_edge_types)
+
     distances = _compute_center_node_distances(
         nx_graph,
         center_point=center_point,
@@ -275,9 +281,6 @@ def create_isochrone(
         rows: list[dict[str, float | Polygon | MultiPolygon | GeometryCollection]] = []
         for layer_threshold in thresholds:
             reachable = _build_reachable_subgraph(nx_graph, distances, layer_threshold)
-            if cut_edge_types:
-                reachable = _filter_edges_by_type(reachable, cut_edge_types)
-
             geometry = _build_isochrone_geometry(reachable, method, crs, **kwargs)
             rows.append(
                 {
@@ -289,11 +292,6 @@ def create_isochrone(
         return gpd.GeoDataFrame(rows, geometry="geometry", crs=crs)
 
     reachable = _build_reachable_subgraph(nx_graph, distances, thresholds[0])
-
-    # Filter Edge Types if requested
-    if cut_edge_types:
-        reachable = _filter_edges_by_type(reachable, cut_edge_types)
-
     final_geom = _build_isochrone_geometry(reachable, method, crs, **kwargs)
 
     if final_geom is None:
@@ -561,7 +559,8 @@ def _filter_edges_by_type(
     Remove edges of specified types from the graph.
 
     Iterates through the graph edges and removes those that match any of the
-    specified types in `cut_edge_types`.
+    specified types in `cut_edge_types`. For multigraphs, parallel edges are
+    matched individually so that only the edges of a cut type are removed.
 
     Parameters
     ----------
@@ -576,11 +575,19 @@ def _filter_edges_by_type(
         The graph with specified edges removed.
     """
     graph = graph.copy()
-    edges_to_remove = [
-        (u, v)
-        for u, v, d in graph.edges(data=True)
-        if (d.get("full_edge_type") or d.get("edge_type")) in cut_edge_types
-    ]
+    edges_to_remove: list[tuple[Any, ...]]
+    if graph.is_multigraph():
+        edges_to_remove = [
+            (u, v, key)
+            for u, v, key, d in graph.edges(keys=True, data=True)
+            if (d.get("full_edge_type") or d.get("edge_type")) in cut_edge_types
+        ]
+    else:
+        edges_to_remove = [
+            (u, v)
+            for u, v, d in graph.edges(data=True)
+            if (d.get("full_edge_type") or d.get("edge_type")) in cut_edge_types
+        ]
     if edges_to_remove:
         graph.remove_edges_from(edges_to_remove)
     return graph

--- a/docs/examples/gtfs.ipynb
+++ b/docs/examples/gtfs.ipynb
@@ -2704,7 +2704,6 @@
     "    center_point=center_point,\n",
     "    threshold=multimodal_threshold_seconds,\n",
     "    edge_attr=\"travel_time_sec\",\n",
-    "    cut_edge_types=[(\"bus_station\", \"is_next_to\", \"bus_station\")],  # Only cut walking edges for multimodal isochrone\n",
     "    method=\"concave_hull_knn\",\n",
     "    k=50\n",
     " )\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "city2graph"
-version = "1.0.0"
+version = "1.0.1"
 description = "A Python library for Geospatial Graph Neural Networks and GeoAI for Urban Analytics with PyTorch Geometric. Convert geospatial data to graphs for spatiotemporal analysis, urban mobility studies, and more."
 authors = [
     {name = "Yuta Sato", email = "y.sato@liverpool.ac.uk"}

--- a/tests/utils/test_spatial.py
+++ b/tests/utils/test_spatial.py
@@ -1568,8 +1568,8 @@ class TestGraphAnalysis(BaseGraphTest):
         assert not iso_cut.empty
         assert iso_cut.geometry.iloc[0].area < iso_full.geometry.iloc[0].area
 
-    def test_isochrone_disconnected_components(self, sample_crs: str) -> None:
-        """Test that cutting edges results in multiple polygons if graph becomes disconnected."""
+    def test_isochrone_cut_edges_are_not_traversed(self, sample_crs: str) -> None:
+        """Cut edges must be removed before traversal, not just dropped from the geometry."""
         # Create two clusters connected by a single edge
         # Cluster 1
         c1_nodes = [Point(0, 0), Point(1, 0), Point(0, 1)]
@@ -1609,8 +1609,7 @@ class TestGraphAnalysis(BaseGraphTest):
 
         graph = gdf_to_nx(nodes=nodes_gdf, edges=edges_gdf)
 
-        # Generate isochrone with cutting "transit"
-        # Distance 20 is enough to reach cluster 2
+        # Distance 20 is enough to reach cluster 2, but only via the transit edge
         iso = utils.create_isochrone(
             graph,
             center_point=Point(0, 0),
@@ -1620,11 +1619,119 @@ class TestGraphAnalysis(BaseGraphTest):
             cut_edge_types=[("transit", "transit", "transit")],
         )
 
-        # Should be MultiPolygon (or at least disjoint)
+        # Cluster 2 is only reachable through the cut edge, so it must be excluded
         geom = iso.geometry.iloc[0]
-        assert geom.geom_type == "MultiPolygon"
-        # Area should be small (approx 2 small triangles), not covering the gap
-        assert geom.area < 100.0
+        assert geom.geom_type == "Polygon"
+        assert geom.covers(Point(0, 0))
+        assert not geom.intersects(Point(100, 100))
+        assert geom.area == pytest.approx(0.5)
+
+        # Without cutting, the transit edge is traversable and cluster 2 is reached
+        iso_full = utils.create_isochrone(
+            graph,
+            center_point=Point(0, 0),
+            threshold=20,
+            edge_attr="length",
+            method="convex_hull",
+        )
+        assert iso_full.geometry.iloc[0].intersects(Point(100, 100))
+
+    def test_isochrone_cut_edge_types_matches_omitting_edge_type(self, sample_crs: str) -> None:
+        """Cutting an edge type must equal never supplying that edge type at all."""
+        # A straight walking chain plus a fast link that shortcuts from end to end
+        xs = [0, 100, 200]
+        street = gpd.GeoDataFrame(
+            {"geometry": [Point(x, 0) for x in xs]},
+            index=pd.Index([f"s{i}" for i in range(len(xs))], name="node_id"),
+            crs=sample_crs,
+        )
+        stop = gpd.GeoDataFrame(
+            {"geometry": [Point(0, 5), Point(200, 5)]},
+            index=pd.Index(["b0", "b1"], name="node_id"),
+            crs=sample_crs,
+        )
+        walk = (
+            gpd.GeoDataFrame(
+                {
+                    "length": [100.0, 100.0],
+                    "geometry": [
+                        LineString([(0, 0), (100, 0)]),
+                        LineString([(100, 0), (200, 0)]),
+                    ],
+                },
+                crs=sample_crs,
+            )
+            .assign(u=["s0", "s1"], v=["s1", "s2"])
+            .set_index(["u", "v"])
+        )
+        transit = (
+            gpd.GeoDataFrame(
+                {"length": [1.0], "geometry": [LineString([(0, 5), (200, 5)])]},
+                crs=sample_crs,
+            )
+            .assign(u=["b0"], v=["b1"])
+            .set_index(["u", "v"])
+        )
+        access = (
+            gpd.GeoDataFrame(
+                {
+                    "length": [1.0, 1.0],
+                    "geometry": [
+                        LineString([(0, 0), (0, 5)]),
+                        LineString([(200, 0), (200, 5)]),
+                    ],
+                },
+                crs=sample_crs,
+            )
+            .assign(u=["s0", "s2"], v=["b0", "b1"])
+            .set_index(["u", "v"])
+        )
+
+        transit_type = ("stop", "is_next_to", "stop")
+        nodes = {"street": street, "stop": stop}
+        edges = {
+            ("street", "connects_to", "street"): walk,
+            transit_type: transit,
+            ("street", "is_nearby", "stop"): access,
+        }
+        common = {
+            "center_point": Point(0, 0),
+            "threshold": 150.0,
+            "edge_attr": "length",
+            "method": "convex_hull",
+        }
+
+        cut = utils.create_isochrone(
+            gdf_to_nx(nodes=nodes, edges=edges),
+            cut_edge_types=[transit_type],
+            **common,
+        )
+        omitted = utils.create_isochrone(
+            nodes=nodes,
+            edges={k: v for k, v in edges.items() if k != transit_type},
+            **common,
+        )
+        everything = utils.create_isochrone(gdf_to_nx(nodes=nodes, edges=edges), **common)
+
+        assert cut.geometry.iloc[0].bounds[2] == pytest.approx(omitted.geometry.iloc[0].bounds[2])
+        assert cut.geometry.iloc[0].area == pytest.approx(omitted.geometry.iloc[0].area)
+        assert everything.geometry.iloc[0].area > cut.geometry.iloc[0].area
+
+    def test_isochrone_cut_edge_types_multigraph_keeps_parallel_edges(
+        self, sample_crs: str
+    ) -> None:
+        """Only the parallel edge of a cut type is removed in a multigraph."""
+        graph = nx.MultiGraph()
+        graph.graph["crs"] = sample_crs
+        graph.add_node(1, pos=(0.0, 0.0))
+        graph.add_node(2, pos=(10.0, 0.0))
+        graph.add_edge(1, 2, key=0, full_edge_type=("transit", "transit", "transit"), length=1.0)
+        graph.add_edge(1, 2, key=1, full_edge_type=("street", "street", "street"), length=5.0)
+
+        filtered = spatial_utils._filter_edges_by_type(graph, [("transit", "transit", "transit")])
+
+        remaining = [d.get("full_edge_type") for _, _, d in filtered.edges(data=True)]
+        assert remaining == [("street", "street", "street")]
 
     def test_isochrone_center_gdf(self, sample_nx_graph: nx.Graph) -> None:
         """Test isochrone creation with GeoDataFrame as center_point."""

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "city2graph"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary

`create_isochrone()` applied `cut_edge_types` **after** the reachability search rather than before it. `_compute_center_node_distances()` and `_build_reachable_subgraph()` ran on the full graph, and `_filter_edges_by_type()` was applied only to the resulting subgraph, so the cut edges were still traversed and were merely removed from the geometry that got drawn. Nodes reachable only through a cut edge stayed inside the isochrone. For the hull-based methods, which build the polygon from node coordinates alone, the parameter had no effect whatsoever. The docstring already described the intended behaviour: "edge types to remove from the graph before processing".

The filtering now runs once on the prepared graph before the distance computation, covering both the scalar and the layered threshold paths, so `cut_edge_types=[t]` gives the same isochrone as never supplying `t` in `edges`.

This PR also fixes a second defect in `_filter_edges_by_type()`: parallel edges were collected as `(u, v)` pairs, and NetworkX removes an arbitrary parallel edge for such a pair, so on a multigraph a walking edge could be removed in place of the transit edge running alongside it. Parallel edges are now matched by key.

Reproduction, on a straight walking chain from x=0 to x=600 (4.8 km/h, so 75 s per 100 m) with two stops joined by one 30-second transit edge, 120-second threshold from x=0:

| call | area | max x reached |
| --- | --- | --- |
| everything | 3000 | 600 |
| `cut_edge_types=[transit]` (before) | 500 | 600 |
| `cut_edge_types=[transit]` (after) | 250 | 100 |
| transit omitted from `edges` | 250 | 100 |

Cutting the transit type now agrees exactly with never supplying it.

**Behaviour change.** Isochrones computed with `cut_edge_types` on 1.0.0 and earlier will change: cutting a transit edge type now yields the area reachable without transit, rather than the transit-assisted area with the transit lines erased. This is released as `1.0.1`, with `pyproject.toml`, `CITATION.cff`, and the CHANGELOG updated accordingly.

## Related issues

Not applicable.

## Testing

- `uv run --group dev --extra cpu pytest -q` — 940 passed.
- `uv run --group dev --extra cpu pre-commit run --all-files` — clean.

`test_isochrone_disconnected_components` asserted a `MultiPolygon`, which was the bug itself: cluster 2 was reached through the cut transit edge and only that edge's geometry was dropped. It is replaced by `test_isochrone_cut_edges_are_not_traversed`, which asserts cluster 2 is excluded when the type is cut and reached when it is not. Two tests are added: `test_isochrone_cut_edge_types_matches_omitting_edge_type` (the equivalence above) and `test_isochrone_cut_edge_types_multigraph_keeps_parallel_edges`. All three fail against the pre-fix source and pass after it.

## Documentation

- `cut_edge_types` in the `create_isochrone()` docstring now states that removal precedes the reachability search and that nodes reachable only through those edges fall outside the isochrone.
- Removed `cut_edge_types` from the walk-plus-transit isochrone cell of `docs/examples/gtfs.ipynb`. That cell computes a multimodal isochrone but cut the transit edge type. The parameter had no effect on its `concave_hull_knn` output before this change and would now remove the transit reach the section exists to demonstrate. The stored outputs remain correct, because `concave_hull_knn` builds its hull from node coordinates only.
- CHANGELOG entries under a new `1.0.1` section.

## Reviewer notes

Worth a second opinion on the release framing: this is a bug fix, so it is filed as a patch, but it does change the output of existing `cut_edge_types` calls. If that warrants a minor bump instead, the version metadata is the only thing to adjust.
